### PR TITLE
Fixed git-flow not installing

### DIFF
--- a/git-flow.json
+++ b/git-flow.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "latest",
   "homepage": "https://github.com/nvie/gitflow",
   "url": "https://raw.githubusercontent.com/nvie/gitflow/develop/contrib/gitflow-installer.sh",
@@ -10,7 +10,7 @@
     iex \"
       busybox mkdir -p $dir\\bin;
       git clone $env:REPO_HOME --recursive $env:REPO_NAME; 
-      sh $dir\\gitflow-installer.sh;
+	  sed -e '69d' -e 's/install -v -m [0-9]*/cp/g' $dir\\gitflow-installer.sh | sh;
       cp $env:REPO_NAME\\shFlags\\src\\shflags $dir\\bin\\gitflow-shFlags;
     \" | Out-Null
 


### PR DESCRIPTION
I recently had to reinstall git-flow and it wasn't working. 

They migrated their installer to use the linux only `install` command. I've simply replaced it with cp. 