### PR TITLE
Fixed extraction folder for nircmd

### DIFF
--- a/nircmd.json
+++ b/nircmd.json
@@ -2,6 +2,6 @@
 	"homepage": "http://www.nirsoft.net/utils/nircmd.html",
 	"version": "2.75",
 	"url": "http://www.nirsoft.net/utils/nircmd.zip",
-	"extract_dir": "nircmd",
+	"extract_dir": ".",
 	"bin": "nircmdc.exe"
 }


### PR DESCRIPTION
I had to change the extraction folder to `.` to make nircmd install. Possibly vendor changed the layout of the ZIP archive?

    C:\Users\frank\AppData\Local\scoop\cache> unzip -l nircmd#2.75#http_www.nirsoft.net_utils_nircmd.zip
    Archive:  nircmd#2.75#http_www.nirsoft.net_utils_nircmd.zip
    Length      Date    Time    Name
    ---------  ---------- -----   ----
    44032  11.08.2013 15:41   nircmd.exe
    43520  11.08.2013 15:40   nircmdc.exe
    45977  11.08.2013 15:43   NirCmd.chm
    ---------                     -------
    133529                     3 files