### PR TITLE
Upgrade ELS to 1.4.4

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://www.elasticsearch.org",
-	"version": "1.4.0",
+	"version": "1.4.4",
 	"depends": "openjdk",
-	"url": "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.0.zip",
-	"hash": "sha1:ffba14b85e4f03f9fbcfb86dc65c4a83390514d1",
-	"extract_dir": "elasticsearch-1.4.0",
+	"url": "https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.4.4.zip",
+	"hash": "sha1:52f40875c7bf5b93252017ce2cd0f779ca2c51fd",
+	"extract_dir": "elasticsearch-1.4.4",
 	"bin": [["bin\\elasticsearch.bat"],["bin\\service.bat", "elssrv", ""]]
 }


### PR DESCRIPTION
Kibana 4 need ELS 1.4.4 or later, so time for an upgrade.