### PR TITLE
Fix rust-nightly urls

### DIFF
--- a/rust-nightly.json
+++ b/rust-nightly.json
@@ -4,10 +4,10 @@
     "license": "MIT/Apache 2.0",
     "architecture": {
       "64bit": {
-        "url": "https://static.rust-lang.org/dist/rust-nightly-x86_64-w64-mingw32.exe"
+        "url": "https://static.rust-lang.org/dist/rust-nightly-x86_64-pc-windows-gnu.exe"
       },
       "32bit": {
-        "url": "https://static.rust-lang.org/dist/rust-nightly-i686-w64-mingw32.exe"
+        "url": "https://static.rust-lang.org/dist/rust-nightly-i686-pc-windows-gnu.exe"
       }
     },
     "innosetup": true,


### PR DESCRIPTION
Urls were 404ing as the filenames were changed.