### PR TITLE
Update pandoc

### DIFF
--- a/pandoc.json
+++ b/pandoc.json
@@ -1,10 +1,9 @@
 {
 	"homepage": "http://johnmacfarlane.net/pandoc/",
-	"version": "1.12.2.1",
+	"version": "1.13.2",
 	"license": "GPL",
 	"depends": "latex",
-	"url": "https://pandoc.googlecode.com/files/pandoc-1.12.2.1.msi",
-	"hash": "sha1:d4cb0849e78dc1d75f77c5bfc6f0fe1e15055588",
+	"url": "https://github.com/jgm/pandoc/releases/download/1.13.2/pandoc-1.13.2-windows.msi",
 	"extract_dir": "Pandoc",
 	"bin": "pandoc.exe"
 }

--- a/pandoc.json
+++ b/pandoc.json
@@ -3,8 +3,8 @@
 	"version": "1.13.2",
 	"license": "GPL",
 	"depends": "latex",
-	"hash": "4047ae56658b6a3b1cea2ab0c2469687cb2c89715dc136812ae33cde930ce32d",
 	"url": "https://github.com/jgm/pandoc/releases/download/1.13.2/pandoc-1.13.2-windows.msi",
+	"hash": "4047ae56658b6a3b1cea2ab0c2469687cb2c89715dc136812ae33cde930ce32d",
 	"extract_dir": "Pandoc",
 	"bin": "pandoc.exe"
 }

--- a/pandoc.json
+++ b/pandoc.json
@@ -3,6 +3,7 @@
 	"version": "1.13.2",
 	"license": "GPL",
 	"depends": "latex",
+	"hash": "4047ae56658b6a3b1cea2ab0c2469687cb2c89715dc136812ae33cde930ce32d",
 	"url": "https://github.com/jgm/pandoc/releases/download/1.13.2/pandoc-1.13.2-windows.msi",
 	"extract_dir": "Pandoc",
 	"bin": "pandoc.exe"


### PR DESCRIPTION
I couldn't find the hash for this release, so I had to remove the hash field. According to the docs, it is optional.