### PR TITLE
Add sublime text editor

### DIFF
--- a/sublime-text.json
+++ b/sublime-text.json
@@ -11,5 +11,6 @@
 			"hash": "382a1fb1c19869e2a6f8501fb4d03552252edaf2fb7917f8bd99bba8b9d32a90"
 		}
 	},
-	"bin": "subl.exe"
+	"bin": "subl.exe",
+	"notes": "This is a beta version of Sublime Text 3. For more information please see http://www.sublimetext.com/3"
 }

--- a/sublime-text.json
+++ b/sublime-text.json
@@ -1,0 +1,15 @@
+{
+	"homepage": "http://www.sublimetext.com/3",
+	"version": "b3083",
+	"architecture": {
+		"64bit": {
+			"url": "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203083%20x64.zip",
+			"hash": "7b1665efcb64933530347244c99482e878a70bc90c59fe5ff0d0ec9862d5ed26"
+		},
+		"32bit": {
+			"url": "http://c758482.r82.cf2.rackcdn.com/Sublime%20Text%20Build%203083.zip",
+			"hash": "382a1fb1c19869e2a6f8501fb4d03552252edaf2fb7917f8bd99bba8b9d32a90"
+		}
+	},
+	"bin": "subl.exe"
+}


### PR DESCRIPTION
Been thinking of adding Sublime Text 3 to scoop for a while. It isn't exactly open source, however this bucket is meant for non open source apps. The beta as far as I am aware is free, but if you have a license you can enter it in which disables *free version* notifications that pop-up every time you save.

The app installs fine, but I wouldn't recommend using it through scoop if you already have it installed on your system. It is the portable version which has some implications. Your data (packages, etc) will be stored in the sublime-text folder and everytime that scoop is updated, your packages will be removed with the old version. I don't know whether it is possible to change this to using AppData. Perhaps later it can magically extract the non-portable executable and use that instead of the portable zip version.

Another issue that I havn't tested but I assume will occur is file association. I have nearly every text based file assoiciated with sublime text so that when I open that file it will open with sublime text. I assume if sublime is installed with scoop this may not work properly anymore. If it does work, then when it is updated it may break the association due to the movement of directory (or maybe not if it is referenced to the shim).

Anyway, thoughts? I probably won't use it unless some of these issues are resolved, but others might want to try it out, maybe they will have solutions? Would be nice to have in scoop. :smile: 


