### PR TITLE
Remove ninja buildsystem

### DIFF
--- a/ninja.json
+++ b/ninja.json
@@ -1,9 +1,0 @@
-{
-	"homepage": "http://martine.github.com/ninja",
-	"version": "1.4.0",
-	"license": "Apache 2.0",
-	"depends": "visualc",
-	"url": "https://github.com/martine/ninja/releases/download/v1.4.0/ninja-win.zip",
-	"hash": "8843d24040387e24f8dc459f192dc77d2bb7c388ce08c7093a6820a4f43c7368",
-	"bin": "ninja.exe"
-}


### PR DESCRIPTION
The ninja buildsystem meets all the requirements in order be placed into the main bucket, so a pull request has been made to add the ninja buildsystem to the main bucket and this request removes ninja  from the extras bucket.