### PR TITLE
Git for Windows 2.3.5 - SSH Fix

### DIFF
--- a/git-preview.json
+++ b/git-preview.json
@@ -12,7 +12,20 @@
 			"hash": "64a2f5e1f067565ed8c5c936965205fba151a78038f54cfc0afb8d462d99d8fe"
 		}
 	},
-	"bin": [ "cmd\\git.exe", "cmd\\gitk.exe", "cmd\\git-gui.exe" ],
+	"bin": [
+		"cmd\\git.exe",
+		"cmd\\gitk.exe",
+		"cmd\\git-gui.exe",
+		"usr\\bin\\scp.exe",
+		"usr\\bin\\sftp.exe",
+		"usr\\bin\\slogin.exe",
+		"usr\\bin\\ssh-add.exe",
+		"usr\\bin\\ssh-agent.exe",
+		"usr\\bin\\sshd.exe",
+		"usr\\bin\\ssh-keygen.exe",
+		"usr\\bin\\ssh-keyscan.exe",
+		"usr\\bin\\ssh.exe"
+	],
 	"post_install": [
 		"git config --global credential.helper wincred"
 	]


### PR DESCRIPTION
This fixes an issue with the openssh version of ssh-agent where you need to enter credentials every time you connect over ssh.

I'm not sure if this is something we really want to do or not.  If you want to go back to the openssh version, you can just `scoop reset openssh`