### PR TITLE
Update cpu-z to latest version

### DIFF
--- a/cpu-z.json
+++ b/cpu-z.json
@@ -1,6 +1,6 @@
 {
 	"homepage": "http://www.cpuid.com/softwares/cpu-z.html",
-	"url": "ftp://ftp.cpuid.com/cpu-z/cpu-z_1.71-en.zip",
+	"url": "ftp://ftp.cpuid.com/cpu-z/cpu-z_1.72-en.zip",
 	"version": "1.71",
 	"hash": "aeefcd73354c1bd0425ecfba0d7bca8245398a30be42c1f2e9dad68649a12b38",
 	"bin": [ [ "cpuz_x32.exe", "cpu-z" ], [ "cpuz_x32.exe", "cpu-z-32" ], [ "cpuz_x64.exe", "cpu-z-64" ] ]


### PR DESCRIPTION
New version of cpu-z is out and old link was broken.