### PR TITLE
Update git-preview to 2.3.7.windows.1

### DIFF
--- a/git-preview.json
+++ b/git-preview.json
@@ -1,15 +1,15 @@
 {
 	"homepage": "https://git-for-windows.github.io/",
 	"license": "GPL2",
-	"version": "2.3.5.8-dev-preview",
+	"version": "2.3.7.windows.1",
 	"architecture": {
 		"64bit": {
-			"url": "https://github.com/git-for-windows/git/releases/download/v2.3.5.windows.8/PortableGit-2.3.5.8-dev-preview-64-bit.7z.exe#/dl1.7z",
-			"hash": "850bca6a507c3d2114748c5527471c1bb7ccf209337ce7e0199e465c6c7badd3"
+			"url": "https://github.com/git-for-windows/git/releases/download/v2.3.7.windows.1/PortableGit-2.3.7.1-dev-preview-64-bit.7z.exe#/dl.7z",
+			"hash": "4a797863678611dea94ec65bc9f11b5ff561063e496083c74847619d94c5e128"
 		},
 		"32bit": {
-			"url": "https://github.com/git-for-windows/git/releases/download/v2.3.5.windows.8/PortableGit-2.3.5.8-dev-preview-32-bit.7z.exe#/dl1.7z",
-			"hash": "64a2f5e1f067565ed8c5c936965205fba151a78038f54cfc0afb8d462d99d8fe"
+			"url": "https://github.com/git-for-windows/git/releases/download/v2.3.7.windows.1/PortableGit-2.3.7.1-dev-preview-32-bit.7z.exe#/dl.7z",
+			"hash": "cfd8ae35e2a39bc6d509e6f14e411d0c7f15ccf6c1aa03ffbaba41da36ea890a"
 		}
 	},
 	"bin": [ "cmd\\git.exe", "cmd\\gitk.exe", "cmd\\git-gui.exe" ],


### PR DESCRIPTION
I opted to use the version name from `git version` instead of the filename. 