### PR TITLE
add dartium

### DIFF
--- a/dartium.dart
+++ b/dartium.dart
@@ -1,0 +1,12 @@
+{
+    "version": "1.10.0",
+    "license": "BSD",
+    "homepage": "https://www.dartlang.org/",
+    "extract_dir": "dartium-win-full-stable-45396.0",
+    "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/45396/dartium/dartium-windows-ia32-release.zip",
+    "hash": "ea067e333c2659896a5ca07f86668d17cf963d6a1e5f554dc4fb8769e1d03282",
+    "checkver": {
+        "url": "http://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION",
+        "re": "\\s*\"version\"\\s*:\\s*(\\d+\\.\\d+\\.\\d+.*)"
+    }
+}


### PR DESCRIPTION
Dartium is a build of Chrome with a built-in Dart VM. Useful for development.