### PR TITLE
Update vlc.json

### DIFF
--- a/vlc.json
+++ b/vlc.json
@@ -1,17 +1,17 @@
 {
 	"homepage": "http://www.videolan.org/",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"license": "GPL",
 	"architecture": {
 		"64bit": {
-			"url": "http://get.videolan.org/vlc/2.2.0/win64/vlc-2.2.0-win64.zip",
-			"hash": "f5065077680a2d3b0ff3f3dcd830ecc7e314101e9af7be18485d26a80c610401"
+			"url": "http://get.videolan.org/vlc/2.2.1/win64/vlc-2.2.1-win64.zip",
+			"hash": "78c7240487593e9b8e93b3271480245443355df88a615ce2dac5d52d7fd1b119"
 		},
 		"32bit": {
-			"url": "http://get.videolan.org/vlc/2.2.0/win32/vlc-2.2.0-win32.zip",
-			"hash": "485716446c37d29d3d9299fe37d7e1a28923c82f3df25356bd8f107d59917603"
+			"url": "http://get.videolan.org/vlc/2.2.1/win32/vlc-2.2.1-win32.zip",
+			"hash": "501e3aafd46c2aadd6822a2764e00159ef06fdf98ae56f90dec049e61be1bd67"
 		}
 	},
-	"extract_dir": "vlc-2.2.0",
+	"extract_dir": "vlc-2.2.1",
 	"bin": "vlc.exe"
 }


### PR DESCRIPTION
Updated from 2.2.0 to 2.2.1. I used the SHA 256 hash values for `hash` property.