### PR TITLE
Add Ragel 6.9

### DIFF
--- a/ragel.json
+++ b/ragel.json
@@ -1,0 +1,10 @@
+{
+    "homepage": "https://github.com/eloraiby/ragel-windows",
+    "version": "6.9",
+    "license": "GPL",
+    "url": "https://github.com/eloraiby/ragel-windows/raw/2e947e9c04e1cb98e99816b3ab4ab2a42926e8ff/ragel.exe",
+    "hash": "2d5b0703006b7d7530a055c6bbbbedc9de777a3ecd99b121afe9f01423d51f1a",
+    "bin": [
+        "ragel.exe"
+    ]
+}


### PR DESCRIPTION
Ragel compiles executable finite state machines from regular languages.
Read more at http://www.colm.net/open-source/ragel/

This is a pre-built binary from https://github.com/eloraiby/ragel-windows