### PR TITLE
webstorm 11.0.3

### DIFF
--- a/webstorm
+++ b/webstorm
@@ -1,7 +1,0 @@
-{
-  "version": "11.0.3",
-  "url": "https://download.jetbrains.com/webstorm/WebStorm-11.0.3.exe",
-  "hash": "678888c8e4cce921a88bcdb16db4bdc784196983b3147e854a759102ad14b037",
-  "installer": { "args": ["/S", "/D=$dir"] },
-  "uninstaller": { "file" : "bin\\Uninstall.exe", "args" : ["/S"] }
-}

--- a/webstorm
+++ b/webstorm
@@ -1,0 +1,7 @@
+{
+  "version": "11.0.3",
+  "url": "https://download.jetbrains.com/webstorm/WebStorm-11.0.3.exe",
+  "hash": "678888c8e4cce921a88bcdb16db4bdc784196983b3147e854a759102ad14b037",
+  "installer": { "args": ["/S", "/D=$dir"] },
+  "uninstaller": { "file" : "bin\\Uninstall.exe", "args" : ["/S"] }
+}

--- a/webstorm.json
+++ b/webstorm.json
@@ -1,5 +1,6 @@
 {
   "version": "11.0.3",
+  "homepage": "http://www.jetbrains.com/webstorm/",
   "url": "https://download.jetbrains.com/webstorm/WebStorm-11.0.3.exe#/dl.7z",
   "hash": "678888c8e4cce921a88bcdb16db4bdc784196983b3147e854a759102ad14b037",
   "bin": "bin\\WebStorm.exe"

--- a/webstorm.json
+++ b/webstorm.json
@@ -1,0 +1,6 @@
+{
+  "version": "11.0.3",
+  "url": "https://download.jetbrains.com/webstorm/WebStorm-11.0.3.exe#/dl.7z",
+  "hash": "678888c8e4cce921a88bcdb16db4bdc784196983b3147e854a759102ad14b037",
+  "bin": "bin\\WebStorm.exe"
+}


### PR DESCRIPTION
I have 2 open points before merging my pull-request
- how to tag a proprietary license in the manifest
- the uninstallation gives following error:
```couldn't remove ~\appdata\local\scoop\apps\webstorm\11.0.3: it may be in use```
I don't know if the root cause is scoop or not