### PR TITLE
Add Microsoft's FCIV (File Checksum Integrity Verifier)

### DIFF
--- a/fciv.json
+++ b/fciv.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://support.microsoft.com/en-us/kb/841290",
+    "version": "2.05",
+    "url": "http://download.microsoft.com/download/c/f/4/cf454ae0-a4bb-4123-8333-a1b6737712f7/Windows-KB841290-x86-ENU.exe",
+    "hash": "md5:58dc4df814685a165f58037499c89e76",
+    "installer": {
+        "args": [
+            "/Q",
+            "/T:$dir",
+            "/C"
+        ]
+    },
+    "bin": [
+        "fciv.exe"
+    ]
+}


### PR DESCRIPTION
 FCIV can compute MD5 or SHA-1 cryptographic hash values for specified files.