### PR TITLE
UAC-free Sourcetree installer

### DIFF
--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -1,0 +1,4 @@
+param($dir, $installer)
+
+$installer.exe /extract
+msiexec /a $installer2.msi /qb TARGETDIR="$dir"

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -1,4 +1,10 @@
-param($dir, $installer)
+param($dir, $fname, $installer, $inst)
 
-$installer.exe /extract
-msiexec /a $installer2.msi /qb TARGETDIR="$dir"
+echo $fname
+echo $installer
+$unpack = Start-Process ".\$inst.exe" -Wait -ea Stop -PassThru -arg "/extract"
+if($unpack.ExitCode -eq 0)
+{
+    mkdir "$pwd\app"
+    iex "msiexec /a $inst.msi /qb TARGETDIR=$pwd\app"
+}

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -1,10 +1,10 @@
-param($dir, $fname, $installer, $inst)
+param($dir, $sourcetreeIns)
 
-echo $fname
-echo $installer
-$unpack = Start-Process ".\$inst.exe" -Wait -ea Stop -PassThru -arg "/extract"
+echo $dir
+echo $sourcetreeIns
+# Unpack the installer to expose the MSI
+$unpack = Start-Process "$dir\$sourcetreeIns.exe" -Wait -ea Stop -PassThru -arg "/extract"
 if($unpack.ExitCode -eq 0)
 {
-    mkdir "$pwd\app"
-    iex "msiexec /a $inst.msi /qb TARGETDIR=$pwd\app"
+    iex "msiexec /a $sourcetreeIns.msi /qb TARGETDIR=$dir"
 }

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -13,6 +13,6 @@ if($unpack.ExitCode -eq 0)
     $install = Start-Process msiexec -Wait -ea stop -PassThru -arg "/a $dir\$sourcetreeIns.msi /qb TARGETDIR=$dir\app"
     if($install.ExitCode -ne 0)
     {
-        Write-Host "Installer failed."
+        Write-Error "Installer failed."
     }
 }

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -1,11 +1,14 @@
 param($dir, $sourcetreeIns)
 
-echo $dir
-echo $sourcetreeIns
+# This script follows the some steps described here to make the app portable:
+# 
+# https://github.com/cosmomill/SourceTreePortable
+#
 # Unpack the installer to expose the MSI
 $unpack = Start-Process "$dir\$sourcetreeIns.exe" -Wait -ea Stop -PassThru -arg "/extract"
 if($unpack.ExitCode -eq 0)
 {
+    # The extracted MSI doesn't seem to like being installed in $dir, so we put it in subditectory
     mkdir $dir\app
     $install = Start-Process msiexec -Wait -ea stop -PassThru -arg "/a $dir\$sourcetreeIns.msi /qb TARGETDIR=$dir\app"
     if($install.ExitCode -ne 0)

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -6,5 +6,10 @@ echo $sourcetreeIns
 $unpack = Start-Process "$dir\$sourcetreeIns.exe" -Wait -ea Stop -PassThru -arg "/extract"
 if($unpack.ExitCode -eq 0)
 {
-    iex "msiexec /a $sourcetreeIns.msi /qb TARGETDIR=$dir"
+    mkdir $dir\app
+    $install = Start-Process msiexec -Wait -ea stop -PassThru -arg "/a $sourcetreeIns.msi /qb TARGETDIR=$dir\app"
+    if($install.ExitCode -ne 0)
+    {
+        Write-Host "Installer failed."
+    }
 }

--- a/scripts/sourcetree.ps1
+++ b/scripts/sourcetree.ps1
@@ -7,7 +7,7 @@ $unpack = Start-Process "$dir\$sourcetreeIns.exe" -Wait -ea Stop -PassThru -arg 
 if($unpack.ExitCode -eq 0)
 {
     mkdir $dir\app
-    $install = Start-Process msiexec -Wait -ea stop -PassThru -arg "/a $sourcetreeIns.msi /qb TARGETDIR=$dir\app"
+    $install = Start-Process msiexec -Wait -ea stop -PassThru -arg "/a $dir\$sourcetreeIns.msi /qb TARGETDIR=$dir\app"
     if($install.ExitCode -ne 0)
     {
         Write-Host "Installer failed."

--- a/sourcetree.json
+++ b/sourcetree.json
@@ -3,15 +3,15 @@
     "version": "1.7.0.32509",
     "url": [
             "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.7.0.32509.exe",
-            ""
+            "https://raw.githubusercontent.com/damnhandy/scoop-extras/master/scripts/sourcetree.ps1"
     ],
     "hash": [
             "43fed24136c83d1d0fee64a7c44949cc76a8b749cd44a2ff04691c4418869c68",
-            ""
+            "96e191d44a8a62b93bf459c668863c4c1c19f042e3954d01daf4087a3c3e3313"
     ],
     "installer": {
         "file": "sourcetree.ps1",
-        "args" : [ "$dir", "SourceTreeSetup_1.7.0.32509.exe" ]
+        "args" : [ "$dir", "$fname", "$installer", "SourceTreeSetup_1.7.0.32509" ]
     },
     "bin": [
         [ "sourcetree.exe", "sourcetree" ],

--- a/sourcetree.json
+++ b/sourcetree.json
@@ -7,7 +7,7 @@
     ],
     "hash": [
             "43fed24136c83d1d0fee64a7c44949cc76a8b749cd44a2ff04691c4418869c68",
-            "3dcad033679149e3848e5fdca5abdb7d5f2b5681c3241adc586ab53ab026f262"
+            "97f47ed65669e8b3a649221e828975edc8cf6ec2d0c04b18b53aa7d1f73a3755"
     ],
     "installer": {
         "file": "sourcetree.ps1",

--- a/sourcetree.json
+++ b/sourcetree.json
@@ -1,10 +1,17 @@
 {
     "homepage": "https://www.sourcetreeapp.com/",
     "version": "1.7.0.32509",
-    "url":"https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.7.0.32509.exe",
-    "hash":"43fed24136c83d1d0fee64a7c44949cc76a8b749cd44a2ff04691c4418869c68",
+    "url": [
+            "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.7.0.32509.exe",
+            ""
+    ],
+    "hash": [
+            "43fed24136c83d1d0fee64a7c44949cc76a8b749cd44a2ff04691c4418869c68",
+            ""
+    ],
     "installer": {
-        "args": ["APPDIR=\"$dir\"","/qb"]
+        "file": "sourcetree.ps1",
+        "args" : [ "$dir", "SourceTreeSetup_1.7.0.32509.exe" ]
     },
     "bin": [
         [ "sourcetree.exe", "sourcetree" ],

--- a/sourcetree.json
+++ b/sourcetree.json
@@ -3,18 +3,18 @@
     "version": "1.7.0.32509",
     "url": [
             "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.7.0.32509.exe",
-            "https://raw.githubusercontent.com/damnhandy/scoop-extras/master/scripts/sourcetree.ps1"
+            "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sourcetree.ps1"
     ],
     "hash": [
             "43fed24136c83d1d0fee64a7c44949cc76a8b749cd44a2ff04691c4418869c68",
-            "96e191d44a8a62b93bf459c668863c4c1c19f042e3954d01daf4087a3c3e3313"
+            "3dcad033679149e3848e5fdca5abdb7d5f2b5681c3241adc586ab53ab026f262"
     ],
     "installer": {
         "file": "sourcetree.ps1",
-        "args" : [ "$dir", "$fname", "$installer", "SourceTreeSetup_1.7.0.32509" ]
+        "args" : [ "$dir", "SourceTreeSetup_1.7.0.32509" ]
     },
     "bin": [
-        [ "sourcetree.exe", "sourcetree" ],
-        [ "stree_gri.exe", "stree_gri" ]
+        [ "app\\sourcetree.exe", "sourcetree" ],
+        [ "app\\stree_gri.exe", "stree_gri" ]
     ]
 }


### PR DESCRIPTION
I've run into a few issues with SourceTree needing admin rights in order to be installed. I took a gander at this repository:

   https://github.com/cosmomill/SourceTreePortable

And attempted to refactor it into a PowerShell script. My PowerShell is weak, but the user is not promoted with a UAC prompt. Is there a better way to this>