### PR TITLE
Version updates and added shortcuts

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -1,12 +1,15 @@
 {
     "homepage": "https://atom.io/",
-    "version": "1.4.0",
+    "version": "1.4.3",
     "license": "MIT",
-    "url": "https://github.com/atom/atom/releases/download/v1.4.0/atom-windows.zip",
-    "hash": "8C644D6E31B927C714E783FD3A577396AE719B72668BA8070E5F817EAD1F5AE6",
+    "url": "https://github.com/atom/atom/releases/download/v1.4.3/atom-windows.zip",
+    "hash": "fee93ff13f2359133aad2b5e70aea965858e51acc4faf339da7d26ac80bbbda4",
     "extract_dir": "Atom",
     "bin": [
         "atom.exe",
         "\\resources\\app\\apm\\bin\\apm.cmd"
-    ]
+    ],
+    "shortcuts" : [
+        [ "atom.exe" , "Atom"]
+    ] 
 }

--- a/eclipse-ee.json
+++ b/eclipse-ee.json
@@ -1,0 +1,19 @@
+{
+	"homepage": "http://www.eclipse.org",
+	"version": "4.5.1",
+	"architecture": {
+		"64bit": {
+			"url": "http://www.gtlib.gatech.edu/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32-x86_64.zip",
+			"hash": "md5:2917778fd8604cd2ba58453c6cb7a6bc"
+		},
+		"32bit": {
+			"url": "http://www.gtlib.gatech.edu/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32.zip",
+			"hash": "md5:fd0e5ceebc2a5b40274cb6146e78a4c3"
+		}
+	},
+	"extract_dir": "eclipse",
+	"bin": "eclipse.exe",
+    "shortcuts" : [
+        [ "eclipse.exe" , "Eclipse Mars JavaEE"]
+    ] 
+}

--- a/eclipse.json
+++ b/eclipse.json
@@ -12,5 +12,8 @@
 		}
 	},
 	"extract_dir": "eclipse",
-	"bin": "eclipse.exe"
+	"bin": "eclipse.exe",
+    "shortcuts" : [
+        [ "eclipse.exe" , "Eclipse Mars"]
+    ] 
 }

--- a/sourcetree.json
+++ b/sourcetree.json
@@ -16,5 +16,8 @@
     "bin": [
         [ "app\\sourcetree.exe", "sourcetree" ],
         [ "app\\stree_gri.exe", "stree_gri" ]
-    ]
+    ],
+    "shortcuts" : [
+        [ "app\\sourcetree.exe" , "Atlassian SourceTree"]
+    ] 
 }


### PR DESCRIPTION
Added shortcuts to:
- Atom
- SourceTree
- Eclipse and Eclipse for JavaEE

Bumped Atom from 1.4.0 to 1.4.3. 

Added Eclipse for JavaEE as an option in addition to Eclipse classic.