### PR TITLE
update to latest stable conemu

### DIFF
--- a/conemu.json
+++ b/conemu.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://conemu.github.io/",
-    "version": "150408",
+    "version": "150813g",
     "license": "BSD 3-clause",
-    "url": "http://sourceforge.net/projects/conemu/files/Alpha/ConEmuPack.150408.7z",
-    "hash": "3af90e99e02118b03412170ec9b155c1574647e80343b135c5568851c55f19d7",
+    "url": "https://github.com/Maximus5/ConEmu/releases/download/v15.08.13g/ConEmuPack.150813g.7z",
+    "hash": "12d83ca3120fdb6619bd3166b727082c83eef45850bf8ca5b19e04f779fca39b",
     "bin": [
         "ConEmu.exe",
         "ConEmu64.exe"


### PR DESCRIPTION
Moves to the latest (stable) version of ConEmu: 150813g, also using the GitHub download site, since the main site (powered by fosshub, doesn't have an accessible download URL).