### PR TITLE
Version bumps for Atom and OracleJDK

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://atom.io/",
-    "version": "1.4.3",
+    "version": "1.5.3",
     "license": "MIT",
-    "url": "https://github.com/atom/atom/releases/download/v1.4.3/atom-windows.zip",
-    "hash": "fee93ff13f2359133aad2b5e70aea965858e51acc4faf339da7d26ac80bbbda4",
+    "url": "https://github.com/atom/atom/releases/download/v1.5.3/atom-windows.zip",
+    "hash": "e3b7b889e81378c07d85d3406a748a30a00759f59ca1d7cf7697771bffac8d8a",
     "extract_dir": "Atom",
     "bin": [
         "atom.exe",

--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -1,24 +1,24 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "1.8.0-u72",
+    "version": "1.8.0-u74",
     "architecture": {
         "64bit": {
             "url": [
-                "http://download.oracle.com/otn-pub/java/jdk/8u72-b15/jdk-8u72-windows-x64.exe#/dl.7z",
+                "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-windows-x64.exe#/dl.7z",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
             ],
             "hash": [
-                "b32eeff6b4300d85c044d48287e99f750fdabe8a91f1cda81b890780bc92eaba",
+                "a02623388258681c0e474d1b6598499ec1eb2bd5e4a32631e165f559d7b2389c",
                 "f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
             ]
         },
         "32bit": {
             "url": [
-                "http://download.oracle.com/otn-pub/java/jdk/8u72-b15/jdk-8u72-windows-i586.exe#/dl.7z",
+                "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-windows-i586.exe#/dl.7z",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
             ],
             "hash": [
-                "d0e044b5582060defaf6c0cac7a0c614b181cdb886f5cb54ff8d6bf8a5df4aaf",
+                "8ae01bd2d1c6e947cd47dec0a0b33560a67649b6a3044f4effd7b652394c7163",
                 "f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
             ]
         }


### PR DESCRIPTION
Updated Atom to `1.5.3` and Oracle JDK 8 to `1.8.0_u74`