### PR TITLE
Update sysinternals URL to have correct case.

### DIFF
--- a/sysinternals.json
+++ b/sysinternals.json
@@ -2,7 +2,7 @@
 	"homepage": "http://technet.microsoft.com/en-us/sysinternals/bb842062",
 	"license": "http://technet.microsoft.com/sysinternals/bb469936",
 	"version": "0.2016.01.04",
-	"url": "https://download.sysinternals.com/files/sysinternalssuite.zip",
+	"url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
 	"bin": [
 		"accesschk.exe",
 		"AccessEnum.exe",


### PR DESCRIPTION
Currently `scoop install sysinternals` returns the following error output

```
PS>scoop install sysinternals
installing sysinternals (0.2016.01.04)
downloading https://download.sysinternals.com/files/sysinternalssuite.zip...The remote server returned an error: (404) Not Found.
```

It appears that the letter-casing in the URL being lower case causes this. After modifying this line locally to the following casing scoop can successfully download the sysinternals suite.