### PR TITLE
Add xmllint

### DIFF
--- a/xmllint.json
+++ b/xmllint.json
@@ -1,17 +1,36 @@
 {
 	"homepage": "http://xmlsoft.org/",
 	"version": "2.9.3",
-	"url": [
-		"ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86.7z",
-		"ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86.7z",
-		"ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86.7z",
-		"ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86.7z"
-		],
-	"hash": [
-		"8e8483c3314f9ab44422873a41b0b1048c5a89682d977538e1a16b7114801135",
-		"67e986d9da6af91ee3665b28c323a94cb344451b6fc3ba725b7c975bdef16960",
-		"19ec3a9087632fe3a75b885c5c3a8e4f58e7edb31e9ea905651e5ce2fdf86cd0",
-		"e50f54d82bbb8c413e3337bdccf8d795f69affd17a813a0b44cedd899af8fc62"
-		],
+	"license": "MIT",
+	"architecture": {
+		"64bit": {
+			"url": [
+				"ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86_64.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86_64.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86_64.7z"
+			],
+			"hash": [
+				"789ff211527bdeb80003b39b67c57742c23286db33c1b3d1622f52fc67612f60", 
+				"727eac03f7b65b167aa975b5b83f89cabc6654a4031ae3810a59b5d9901627f8", 
+				"b3645b70813b78eb17a7989fd4316a1f53ea8e0991fbcf34e201f9ea71f44d6c", 
+				"2a0112800cdd0e0c699552fb751701102bdeb509f12c800bb0a4cb4c58f40cc5"
+			]
+		},
+		"32bit": {
+			"url": [
+				"ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86.7z", 
+				"ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86.7z"
+			],
+			"hash": [
+				"8e8483c3314f9ab44422873a41b0b1048c5a89682d977538e1a16b7114801135", 
+				"67e986d9da6af91ee3665b28c323a94cb344451b6fc3ba725b7c975bdef16960", 
+				"19ec3a9087632fe3a75b885c5c3a8e4f58e7edb31e9ea905651e5ce2fdf86cd0", 
+				"e50f54d82bbb8c413e3337bdccf8d795f69affd17a813a0b44cedd899af8fc62"
+			]
+		}
+	},
 	"bin": "bin\\xmllint.exe"
 }

--- a/xmllint.json
+++ b/xmllint.json
@@ -1,0 +1,17 @@
+{
+	"homepage": "http://xmlsoft.org/",
+	"version": "2.9.3",
+	"url": [
+		"ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86.7z",
+		"ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86.7z",
+		"ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86.7z",
+		"ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86.7z"
+		],
+	"hash": [
+		"8e8483c3314f9ab44422873a41b0b1048c5a89682d977538e1a16b7114801135",
+		"67e986d9da6af91ee3665b28c323a94cb344451b6fc3ba725b7c975bdef16960",
+		"19ec3a9087632fe3a75b885c5c3a8e4f58e7edb31e9ea905651e5ce2fdf86cd0",
+		"e50f54d82bbb8c413e3337bdccf8d795f69affd17a813a0b44cedd899af8fc62"
+		],
+	"bin": "bin\\xmllint.exe"
+}


### PR DESCRIPTION
Hey there, here is a PR for [xmllint](http://xmlsoft.org/xmllint.html) 

Each of the 7z files that the manifest calls out have a bunch of extra supporting folders in them that aren't needed for xmllint.exe to run properly (`lib/`, `share/`, `include/`, etc). The only stuff that needs to be part of this are the dlls in the `bin/` folder in each 7z archive. 

I tried to exclude the unneeded stuff in the manifest via the `extract_dir` element but I couldn't get it to work. So as it is now, when you install you'll get all 23mb of stuff that's in these 7z's as opposed to the ~8 that's actually needed. 