### PR TITLE
Fix vscode (1.2.0)

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -2,8 +2,8 @@
     "homepage": "https://code.visualstudio.com/",
     "version": "1.2.0",
     "license": "https://code.visualstudio.com/License/",
-    "url": "https://az764295.vo.msecnd.net/stable/def9e32467ad6e4f48787d38caf190acbfee5880/VSCode-win32-stable.zip",
-    "hash": "179626a489b9fa174dd41ccb883b4d0a6edea6c6b7ceaeb9dd21a83ed73d2417",
+    "url": "https://az764295.vo.msecnd.net/stable/809e7b30e928e0c430141b3e6abf1f63aaf55589/VSCode-win32-stable.zip",
+    "hash": "6aa28889eef2505cd743eca48e0d7c7e339b32c2dc071eb8736f9e62fb7bde4b",
     "bin": [
         "code.exe"
     ],


### PR DESCRIPTION
Incorrect URL was being used for the 1.2.0 zip.