### PR TITLE
Fixed hash for whois.exe

### DIFF
--- a/whois.json
+++ b/whois.json
@@ -6,7 +6,7 @@
         "https://download.sysinternals.com/files/WhoIs.zip"
     ],
     "hash": [
-        "d3cad212334569993da468631a9ba2c02f23addda4f3b38b8f2c96a54ff556a3"
+        "4110c9d1068131c17a3f42155724873e21883d1dd3aece5e0e744a855f3a1d11"
     ],
     "bin": "whois.exe"
 }


### PR DESCRIPTION
Previous hash for the zip download was wrong.