### PR TITLE
Update Notepad++

### DIFF
--- a/notepadplusplus.json
+++ b/notepadplusplus.json
@@ -4,5 +4,6 @@
 	"license": "GPL",
 	"hash": "F6E39295CE4EE256939DA327DAD4651248A0C7BECBC3AE8558C179D2F1FCD760",
 	"url": "http://download.tuxfamily.org/notepadplus/archive/6.6.9/npp.6.6.9.bin.zip",
+	"checkver": "Current Version:.*?<span>(.*?)</span>",
 	"bin": "notepad++.exe"
 }

--- a/notepadplusplus.json
+++ b/notepadplusplus.json
@@ -1,9 +1,9 @@
 {
 	"homepage": "http://notepad-plus-plus.org",
-	"version": "6.6.9",
+	"version": "6.9.2",
 	"license": "GPL",
-	"hash": "F6E39295CE4EE256939DA327DAD4651248A0C7BECBC3AE8558C179D2F1FCD760",
-	"url": "http://download.tuxfamily.org/notepadplus/archive/6.6.9/npp.6.6.9.bin.zip",
+	"hash": "473e2bfe766e0e0b26ef2f20d0c462084fd19b9d16f68b3744d52c8e931fc102",
+	"url": "https://notepad-plus-plus.org/repository/6.x/6.9.2/npp.6.9.2.bin.zip",
 	"checkver": "Current Version:.*?<span>(.*?)</span>",
 	"bin": "notepad++.exe",
 	"shortcuts": [

--- a/notepadplusplus.json
+++ b/notepadplusplus.json
@@ -5,5 +5,8 @@
 	"hash": "F6E39295CE4EE256939DA327DAD4651248A0C7BECBC3AE8558C179D2F1FCD760",
 	"url": "http://download.tuxfamily.org/notepadplus/archive/6.6.9/npp.6.6.9.bin.zip",
 	"checkver": "Current Version:.*?<span>(.*?)</span>",
-	"bin": "notepad++.exe"
+	"bin": "notepad++.exe",
+	"shortcuts": [
+		[ "notepad++.exe", "Notepad++" ]
+	]
 }


### PR DESCRIPTION
I updated Notepad++ to the latest version (6.9.2) and also enabled it for `checkver.ps1`.

I also added a shortcut for it, tell me if I should remove it.