### PR TITLE
Update VS Code to 1.5.1

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -11,7 +11,7 @@
         [ "code.exe", "Visual Studio Code" ]
     ],
     "checkver": {
-        "url": "https://code.visualstudio.com/Updates",
-        "re": "<h1>(\\d+\\.\\d+\\.\\d+).*?</h1>"
+        "url": "https://github.com/Microsoft/vscode/releases",
+        "re": "<span class=\"tag-name\">(\\d+\\.\\d+\\.\\d+)</span>"
     }
 }

--- a/vscode.json
+++ b/vscode.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://code.visualstudio.com/",
-    "version": "1.3.1",
+    "version": "1.5.1",
     "license": "https://code.visualstudio.com/License/",
-    "url": "https://az764295.vo.msecnd.net/stable/e6b4afa53e9c0f54edef1673de9001e9f0f547ae/VSCode-win32-stable.zip",
-    "hash": "4e6f8346b0d121a8a3b302cb33b94e5a29bda0ac6fe826b737512023a51bc69b",
+    "url": "https://az764295.vo.msecnd.net/stable/07d663dc1bd848161edf4cd4ce30cce410d3d877/VSCode-win32-stable.zip",
+    "hash": "4bf68caec938fc2f8d3a4b74b4c39e83f3b5e87ea9cda8881ae4b6a16820fc06",
     "bin": [
         "code.exe"
     ],


### PR DESCRIPTION
I think we need a better strategy for detecting available updates for VS Code, because the current one isn't working. Maybe we could check their GitHub releases page?