### PR TITLE
upgrade tomcat to 8.5.5

### DIFF
--- a/tomcat.json
+++ b/tomcat.json
@@ -1,17 +1,17 @@
 {
 	"homepage": "https://tomcat.apache.org/",
-	"version": "8.0.2.6",
+	"version": "8.5.5",
 	"architecture": {
 		"64bit": {
-			"url": "http://apache.uberglobalmirror.com/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-windows-x64.zip",
-			"hash": "md5:97866aaad7f7314e025a73dcd4c6181e"
+			"url": "http://apache.uberglobalmirror.com/tomcat/tomcat-8/v8.5.5/bin/apache-tomcat-8.5.5-windows-x64.zip",
+			"hash": "md5:36e2584f2ed63d424cfaee705f042932"
 		},
 		"32bit": {
-			"url": "http://apache.uberglobalmirror.com/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-windows-x86.zip",
-			"hash": "md5:d0bed652e47a80fbf546b5bab2b97a06"
+			"url": "http://apache.uberglobalmirror.com/tomcat/tomcat-8/v8.5.5/bin/apache-tomcat-8.5.5-windows-x86.zip",
+			"hash": "md5:92787c657637dfcdba0fcd5365391355"
 		}
 	},
-	"extract_dir": "apache-tomcat-8.0.26",
+	"extract_dir": "apache-tomcat-8.5.5",
 	"bin": "bin\\catalina.bat",
 	"env_set": { 
 		"CATALINA_HOME": "$dir",


### PR DESCRIPTION
I have upgraded tomcat as old version looks like broken:

```
λ scoop install tomcat
installing tomcat (8.0.2.6)
downloading http://apache.uberglobalmirror.com/tomcat/tomcat-8/v8.0.26/bin/apache-tomcat-8.0.26-windows-x64.zip...The remote server returned an error: (404) Not Found.
```