### PR TITLE
Update ngrok to stable

### DIFF
--- a/ngrok.json
+++ b/ngrok.json
@@ -1,15 +1,15 @@
 {
 	"homepage": "https://ngrok.com/",
-	"version": "2.0.19",
+	"version": "2.0.24",
 	"license": "Apache 2.0",
 	"architecture": {
 		"64bit": {
-			"url": "https://dl.ngrok.com/ngrok_2.0.19_windows_amd64.zip",
-			"hash": "247e294a1958b1f632b8feb88c6f8e2f2ed599e0ed4260cffcb0fa30b9c4dc2d"
+			"url": "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip",
+			"hash": "7ba017d849d6411b0e8e56e967c0ab188a55f21de8f8cfa3c4358fc995187f15"
 		},
 		"32bit": {
-			"url": "https://dl.ngrok.com/ngrok_2.0.19_windows_386.zip",
-			"hash": "640de49301de165aec308b984883d8a38ddac60b79cea040e1da91ba2a9ea48c"
+			"url": "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-386.zip",
+			"hash": "5e7e4a14dc3b7beb1cbceea5dedf0c4bbcfabf79b71dfd075fe967d78df2dc6d"
 		}
 	},
 	"bin": "ngrok.exe"


### PR DESCRIPTION
The download link always points to the latest stable version (today it's 2.1.14).