### PR TITLE
Update Notepad++ to 7.0

### DIFF
--- a/notepadplusplus.json
+++ b/notepadplusplus.json
@@ -1,9 +1,17 @@
 {
 	"homepage": "http://notepad-plus-plus.org",
-	"version": "6.9.2",
+	"version": "7.0",
 	"license": "GPL",
-	"hash": "473e2bfe766e0e0b26ef2f20d0c462084fd19b9d16f68b3744d52c8e931fc102",
-	"url": "https://notepad-plus-plus.org/repository/6.x/6.9.2/npp.6.9.2.bin.zip",
+	"architecture": {
+		"64Bit": {
+			"url": "https://notepad-plus-plus.org/repository/7.x/7.0/npp.7.bin.x64.7z",
+			"hash": "sha1:f354424c907380bf937f7043288706af5fd6ea1e"
+		},
+		"32Bit": {
+			"url": "https://notepad-plus-plus.org/repository/7.x/7.0/npp.7.bin.7z",
+			"hash": "sha1:c9c1da0cdf9cef6a6b4f3bea6bc4281c9d7810eb"
+		}
+	},
 	"checkver": "Current Version:.*?<span>(.*?)</span>",
 	"bin": "notepad++.exe",
 	"shortcuts": [


### PR DESCRIPTION
Notepad++ now has a x64 version.

I simply copied the SHA1 hashes from the download page, as I'm too lazy to download the files myself. Ping me if I should change them to SHA256.