### PR TITLE
Add notepad2-mod

### DIFF
--- a/notepad2-mod.json
+++ b/notepad2-mod.json
@@ -1,0 +1,22 @@
+{
+	"homepage": "https://github.com/XhmikosR/notepad2-mod",
+	"license": "BSD",
+	"version": "4.2.25",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/XhmikosR/notepad2-mod/releases/download/4.2.25.985/Notepad2-mod.4.2.25.985_x64.zip",
+			"hash": "sha256:b20c1510f4551c082baf5330e0d019df2475d41a08b92f925012832bf985a0dd"
+		},
+		"32bit": {
+			"url": "https://github.com/XhmikosR/notepad2-mod/releases/download/4.2.25.985/Notepad2-mod.4.2.25.985_x86.zip",
+			"hash": "sha256:f62b3dd534619df339e8c267d84f7dafacb0471bb423e807972cf7ced05c1acc"
+		}
+	},
+	"bin": [
+		"Notepad2.exe"
+	],
+	"shortcuts": [
+		[ "Notepad2.exe", "Notepad2-mod" ]
+	],
+	"checkver": "Current Release: Version ([0-9\\.]+)"
+}


### PR DESCRIPTION
**notepad2-mod** is an improved version of **notepad2** (already included into Extras Bucket).

It provides additional features such as code-folding and improved syntax highlighting, I personally prefer using it to the regular notepad2.

https://github.com/XhmikosR/notepad2-mod#notepad2-mod