### PR TITLE
update gvim to version 80-069

### DIFF
--- a/gvim.json
+++ b/gvim.json
@@ -1,14 +1,14 @@
 {
 	"url": "http://www.vim.org",
 	"license": "http://vimdoc.sourceforge.net/htmldoc/uganda.html#license",
-	"version": "8.0",
+	"version": "8.0-069",
 	"url": [
-		"http://ftp.vim.org/pub/vim/pc/gvim80.zip",
-		"http://ftp.vim.org/pub/vim/pc/vim80rt.zip"
+		"http://ftp.vim.org/pub/vim/pc/gvim80-069.zip",
+		"http://ftp.vim.org/pub/vim/pc/vim80-069rt.zip"
 	],
 	"hash": [
-		"3F87F034DEDBD76BFF334ECB208B9B98BDCBBBDEFBB6351E677C3997001AEBF5",
-		"33B84CDAE8526216CCB80BC83253903FCA7885D4B60B217A3CC303844517DC66"
+		"65B7148BF95ECB1DE9602FA24DEFAD09DF3B128C24AC38688A7FEF6D5E8170F8",
+		"482B3AEF45C3731B205D7C5FE59E0CCA7542AAE9B447F46B4792B89F2F79E01E"
 	],
 	"extract_dir": [ "vim\\vim80", "vim\\vim80" ],
 	"bin": "gvim.exe",


### PR DESCRIPTION
This updates the `gvim` manifest to refer to the latest build of VIM 8.0, as per the https://groups.yahoo.com/neo/groups/vimannounce/conversations/messages/244

Note: The files at the URLs that the manifest originally used (ending `gvim80.zip`, and `vim80rt.zip`) have also been updated with the same content, so either way the hash value is out of date and needs updating :)