### PR TITLE
upgraded sourcetree to 1.9.10.0

### DIFF
--- a/sourcetree.json
+++ b/sourcetree.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://www.sourcetreeapp.com/",
-    "version": "1.9.6.1",
+    "version": "1.9.10.0",
     "url": [
-            "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.9.6.1.exe",
+            "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.9.10.0.exe",
             "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sourcetree.ps1"
     ],
     "hash": [
-            "DC1632A35BE2F52D979F78F35A8294B801B675029FA119206E9804FFFA912918",
+            "0D4BB9F9F6835F0DCDD46CD0DAE38F1958BDE09EBF41B7555E7115FFCADFF837",
             "97f47ed65669e8b3a649221e828975edc8cf6ec2d0c04b18b53aa7d1f73a3755"
     ],
     "installer": {
         "file": "sourcetree.ps1",
-        "args" : [ "$dir", "SourceTreeSetup_1.9.6.1" ]
+        "args" : [ "$dir", "SourceTreeSetup_1.9.10.0" ]
     },
     "bin": [
         [ "app\\sourcetree.exe", "sourcetree" ]


### PR DESCRIPTION
Note, with 1.9.10.0 the first time running will prompt you with setup wizard. I don't think this is avoidable since it ask for your Atlassian Id (as part of Atlassian's SSO consolidation of all bitbucket Ids into Atlassian Id).