### PR TITLE
Add cross compiler for ARM targets

### DIFF
--- a/gcc-arm-none-eabi.json
+++ b/gcc-arm-none-eabi.json
@@ -1,0 +1,9 @@
+{
+  "homepage": "https://developer.arm.com/open-source/gnu-toolchain/gnu-rm",
+  "license": "GPL3",
+  "version": "6-2016q4",
+  "url": "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/6-2016q4/gcc-arm-none-eabi-6_2-2016q4-20161216-win32.zip",
+  "hash": "2984c4a6db7f51bb19be1027aa13f1fdf46367d6b36b77ea727329a29f1b78f4",
+  "env_add_path": "bin"
+}
+


### PR DESCRIPTION
From https://developer.arm.com/open-source/gnu-toolchain/gnu-rm:

"These toolchains are based on Free Software Foundation's (FSF) GNU
Open source tools and newlib.

​The toolchains support ARM Cortex-M0, Cortex-M0+, Cortex-M3, Cortex-M4, Cortex-M7, Cortex-R4, Cortex-R5, Cortex-R7, Cortex-R8 processors and ARMv8-M Baseline and Mainline architectures."