### PR TITLE
Update Oracle JDK to 1.8.0-u121

### DIFF
--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -1,25 +1,21 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "1.8.0-u74",
+    "version": "1.8.0-u121",
     "architecture": {
         "64bit": {
             "url": [
-                "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-windows-x64.exe#/dl.7z",
-                "https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+                "http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-windows-x64.exe"
             ],
             "hash": [
-                "a02623388258681c0e474d1b6598499ec1eb2bd5e4a32631e165f559d7b2389c",
-                "f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+                "3e39f87441841a152cd327e95d09755fbe4b443316dac94a0494d68910b0994e"
             ]
         },
         "32bit": {
             "url": [
-                "http://download.oracle.com/otn-pub/java/jdk/8u74-b02/jdk-8u74-windows-i586.exe#/dl.7z",
-                "https://raw.github.com/lukesampson/scoop-extras/master/scripts/oraclejdk.ps1"
+                "http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-windows-i586.exe"
             ],
             "hash": [
-                "8ae01bd2d1c6e947cd47dec0a0b33560a67649b6a3044f4effd7b652394c7163",
-                "f24bec9b3f4e096a301e4c9089ab977f8d251c9af9ad2dd885d002257b108f4d"
+                "b57abcfbcdd42d15626775fb214811328f614a9a9e623d4904bbfd6bb2aac79f"
             ]
         }
     },
@@ -27,9 +23,8 @@
         "oraclelicense": "accept-securebackup-cookie"
     },
     "installer": {
-        "_comment": "oraclejdk unpacks .pack into .jar files",
-        "file": "oraclejdk.ps1",
-        "args": [ "$dir" ]
+        "args": [ "/s", "ADDLOCAL=\"ToolsFeature,SourceFeature\"", "INSTALLDIR=$dir" ],
+        "keep": "true"
     },
     "env_add_path": "bin",
     "env_set": {


### PR DESCRIPTION
Hi

first of all thanks for this great tool! We use this to automatically setup the dev machines. I managed to update to the newest Oracle Java version and use the silent installer shipped within the executable. The only issue is that there is a UAC popup and I don't think we are able to accept that in any way.

As I am only a former Windows user I do not have the knowledge on how to install it without any UAC (or somehow extract it etc.). In the updated manifest the `oraclejdk.ps1` script is not used anymore to install the JDK as this was not working anymore.

If there is someone else who is able to fix it please go ahead. You can use this pull request as a base. Or @lukesampson you can accept it if the UAC is not an issue.

The rest is working properly, so you have Java installed without the public JRE.

Cheers,

Guy