### PR TITLE
RapidEE update. Switched version to build number.

### DIFF
--- a/RapidEE.json
+++ b/RapidEE.json
@@ -1,19 +1,30 @@
 {
-    "version":  "9.1",
+    "version":  "932",
     "license":  "https://www.rapidee.com/en/license",
 	"architecture": {
 		"64bit": {
 			"url": "https://www.rapidee.com/download/RapidEEx64.zip",
-			"hash": "86171f05c1b73503c17eae87c11654c5e3943525b6622f4298b16ea3c535087d"
+			"hash": "c1190f995f92bf0a9eaa39dc63e910c3d7c2110d4cc4890175945ea9e60e2117"
 		},
 		"32bit": {
 			"url": "https://www.rapidee.com/download/RapidEE.zip",
-			"hash": "eab5649d1956167fe5634a6356e6bc859800f528487faef10d0b80c463a5e9eb"
+			"hash": "5d54102d4bc351924337e2fce76457c87d3c78e4c96664c8cda5ef66c3d09a6c"
 		}
 	},
     "homepage":  "https://www.rapidee.com/en/about",
     "bin":  "rapidee.exe",
 		"shortcuts": [
 		[ "rapidee.exe", "RapidEE" ]
-	]
+	],
+	"checkver": "[0-9\\.]+ build (\\d+)",
+	"autoupdate": {
+		"architecture": {
+			"64bit": {
+				"url": "https://www.rapidee.com/download/RapidEEx64.zip"
+			},
+			"32bit": {
+				"url": "https://www.rapidee.com/download/RapidEE.zip"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Added `checkver` and `autoupdate`.

I couldn't figure out another way to make checkver + autoupdate happy, using build number seemed best compromise.