### PR TITLE
Adds SpeedCrunch and HTML tidy to extras bucket

### DIFF
--- a/speedcrunch.json
+++ b/speedcrunch.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://speedcrunch.org/",
+    "version": "0.12",
+    "url": "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-0.12-win32.zip",
+    "hash": "024362bccd7908b508192cd90c2f6a716b5aa4fa5c7ff2aea9a1bf49d6580175",
+    "extract_dir": "SpeedCrunch-0.12-win32",
+    "bin": "speedcrunch.exe",
+    "shortcuts": [
+        [
+            "speedcrunch.exe",
+            "SpeedCrunch"
+        ]
+    ],
+    "checkver": {
+        "url": "http://speedcrunch.org/download.html",
+        "re": "<h1>Version\\s+([^<]+)<\\/h1>"
+    },
+    "autoupdate": {
+        "extract_dir": "SpeedCrunch-$version-win32",
+        "url": "https://bitbucket.org/heldercorreia/speedcrunch/downloads/SpeedCrunch-$version-win32.zip"
+    }
+}

--- a/tidy.json
+++ b/tidy.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "http://www.html-tidy.org/",
+    "version": "5.2.0",
+    "architecture": {
+        "64bit": {
+            "url": "http://binaries.html-tidy.org/binaries/tidy-5.2.0/tidy-5.2.0-win64.zip",
+            "hash": "dd9fd814cc44bc2ffa9b9e547b1a6cbb42b6be7b9358542d3ee7f6e10b676423",
+            "extract_dir": "tidy-5.2.0-win64"
+        },
+        "32bit": {
+            "url": "http://binaries.html-tidy.org/binaries/tidy-5.2.0/tidy-5.2.0-win32.zip",
+            "hash": "94d653498b4f93b14f12a55ca06154e19c540c9b276e5d163f1cf84fa078f97a",
+            "extract_dir": "tidy-5.2.0-win32"
+        }
+    },
+    "bin": [
+        "bin/tidy.exe"
+    ],
+    "checkver": {
+        "url": "http://binaries.html-tidy.org/",
+        "re": "HTML Tidy version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "extract_dir": "tidy-$version",
+        "architecture": {
+            "64bit": {
+                "url": "http://binaries.html-tidy.org/binaries/tidy-$version/tidy-$version-win64.zip"
+            },
+            "32bit": {
+                "url": "http://binaries.html-tidy.org/binaries/tidy-$version/tidy-$version-win32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Merge only if you also merge my other pull request here (or get rid of the URL check as suggested by rrelmy):

https://github.com/lukesampson/scoop/pull/1333

as SpeedCrunch is hosted on bitbucket.

If you would rather not do that I can move HTML tidy onto a different branch and open a PR for that alone.