### PR TITLE
upgrade sourcetree to 1.10.20.1

### DIFF
--- a/sourcetree.json
+++ b/sourcetree.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://www.sourcetreeapp.com/",
-    "version": "1.9.10.0",
+    "version": "1.10.20.1",
     "url": [
-            "https://downloads.atlassian.com/software/sourcetree/windows/SourceTreeSetup_1.9.10.0.exe",
+            "https://downloads.atlassian.com/software/sourcetree/windows/ga/SourceTreeSetup-1.10.20.1.exe",
             "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sourcetree.ps1"
     ],
     "hash": [
-            "0D4BB9F9F6835F0DCDD46CD0DAE38F1958BDE09EBF41B7555E7115FFCADFF837",
+            "49203A8657CE2B1F26141F6981464B3DD91045700FAEC1FD2733252AB05EA4DB",
             "97f47ed65669e8b3a649221e828975edc8cf6ec2d0c04b18b53aa7d1f73a3755"
     ],
     "installer": {
         "file": "sourcetree.ps1",
-        "args" : [ "$dir", "SourceTreeSetup_1.9.10.0" ]
+        "args" : [ "$dir", "SourceTreeSetup-1.10.20.1" ]
     },
     "bin": [
         [ "app\\sourcetree.exe", "sourcetree" ]


### PR DESCRIPTION
I came across some issues with this upgrade. 

I believe the script `https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sourcetree.ps1` needs to be updated, but have no idea what to update. Please assist?

At the moment the installation just hangs at the step `Checking hash of sourcetree.ps1... ok.`