### PR TITLE
Use official Emacs dependencies -> enables eww, image display etc

### DIFF
--- a/emacs.json
+++ b/emacs.json
@@ -6,21 +6,21 @@
         "64bit": {
             "url": [
                 "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.1-2-x86_64-w64-mingw32.zip",
-                "ftp://ftp.gnutls.org/gcrypt/gnutls/w32/gnutls-3.4.9-w64.zip"
+                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25-x86_64-deps.zip"
             ],
             "hash": [
                 "5c2e1ef2bfca8aa516297471f16fa79ff98c7386a7db181a08044a6a9811267d",
-                "7f5a2ac916fc967aeab65cf90a229f1f827782cfef08aa42d0db7e1ee5d0d7d4"
+                "d928e6caaeb5267f978dad0a54c90b0ea6f31ad384f43d8a6bb54c67d2b2f184"
             ]
         },
         "32bit": {
             "url": [
                 "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.1-2-i686-w64-mingw32.zip",
-                "ftp://ftp.gnutls.org/gcrypt/gnutls/w32/gnutls-3.4.9-w32.zip"
+                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25-i686-deps.zip"
             ],
             "hash": [
                 "471f94bf64553f8f048019ed16559fa1f102e39262a1fde88bcf627d320f7266",
-                "1811f0eee506939b07b50c65077542650041a89a89e385f6fc6cb6d084ceb8dc"
+                "37daea32cc054ae6b709c015704bdf7b7459c63b1be27cdd590d2807e50b236a"
             ]
         }
     },


### PR DESCRIPTION
The Emacs project proposes a bundle of dependencies to install alongside emacs.  Using these instead of the gnutls zip file originally in the app manifest enables more functionality, e.g.


- eww (a web browser in Emacs) because libxml2 can now be found
- inline image display because the image libraries can now be found
- probably others

Note that the same binaries as those contained in the gnutls zip are also included, so that dependency/download was dropped.