### PR TITLE
All Eclipse Packaging projects plus SDK and platform

### DIFF
--- a/eclipse-android.json
+++ b/eclipse-android.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:454682b9bc3358fdbd36ac7efd0f87b343a19475fab167f8a67a3d7c2c8cc31a79960d7c0cca42d9ef33bab95a624f49083eefb86e046d859e0dacdabfde2fd8"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:9768d32efae1e59f01609115afa14d25ede869290aa1be0b439fb8302f3d35a34cc8241634b96dbc838a3d92940f489b56964a64e64533371a7e9d870c780d5c"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for Android Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.android=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.android.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-automotive.json
+++ b/eclipse-automotive.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.5.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip?version=4.5.1&architecture=64bit",
+            "hash": "sha512:0bafeca66dca870f8d89e8864c10f7ab648734548d805bb57994e1a34076950ad1ebc7998b4ffef81fa6f5821e98b486615aabb3dabc44313d3b749b58939691"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip?version=4.5.1&architecture=32bit",
+            "hash": "sha512:3467bf3b83b538473e8b2092d26c6bd5c38c0f63be7c84db9b147c53219f3e1d5f07e4411fc38d89da18c22891d7d2a0eef4ec1852ba78d5f825cd512f39961e"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Automotive Software Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.automotive=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.automotive.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-committers.json
+++ b/eclipse-committers.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:24dc08dd398ae66586502116e13ad7b71c93c5d900904962e27ff7745ffb235e2199e85dfa928e274dee3c93c45cf94e9c017cbb1bf64332c9d8698f8d81cb8e"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:65b8fdc296f9e9d2467035a2e5973954071049418402b714659f66cbb11670377182e01a628ffd83e94f0497ad77f580d85705fc9f5aa10cc45f1a0a0eadeb26"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Eclipse Committers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.committers=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.committers.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-cpp.json
+++ b/eclipse-cpp.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:a6566f36e65b1e960a0f7c726e6d90228c0e6d7523d9bb7c3a54cbe21458d82efc4cb5e8f8ea4491399ed1c97cde9b1b5fc481cce1081e30d28d3f5e387e6354"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:d686ffd06cc3b4f3f715d08fca030cdd61b2ebebbd357b23c5fb64b21110ff97db73869bf69517405706458a7324a7221fa274ddec671679458af781704d0ff1"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for C and C++ Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.cpp=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.cpp.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-dsl.json
+++ b/eclipse-dsl.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:a4a51a8d02117362e72bb1dbba9d7c7af09b428da6381f986dff1e9f560f54af188126ed61626dba12ec8e3cb936ee34a36d18040aaa6a76736d4ce3a749a81d"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:ae0b577d762d31741b50477c48a7032432e62877cb1dd44fb0630bafb72555012ced357aab34dd03bab4bcbab99dba3a27edea4e7ee9694dd222c5d92ad2bd8d"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Java and DSL Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.dsl=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.dsl.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-ee.json
+++ b/eclipse-ee.json
@@ -1,19 +1,48 @@
 {
-	"homepage": "http://www.eclipse.org",
-	"version": "4.5.1",
-	"architecture": {
-		"64bit": {
-			"url": "http://www.gtlib.gatech.edu/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32-x86_64.zip",
-			"hash": "md5:2917778fd8604cd2ba58453c6cb7a6bc"
-		},
-		"32bit": {
-			"url": "http://www.gtlib.gatech.edu/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-jee-mars-1-win32.zip",
-			"hash": "md5:fd0e5ceebc2a5b40274cb6146e78a4c3"
-		}
-	},
-	"extract_dir": "eclipse",
-	"bin": "eclipse.exe",
-    "shortcuts" : [
-        [ "eclipse.exe" , "Eclipse Mars JavaEE"]
-    ] 
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:460bd51ff71f1fff3b286e48b511615e2a946f2465ce435140562ac36a82a6ea1cf75a69027a5ce228014bfbda8a3c7be1ff4217e1d5e0c0e955fcf85ab807eb"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:236a83b4f9dc1560ff13507509ef23ded57c93d6b07c20f7afb48a84b28d101c5bc50f6fe4191648254b22acecb593f3ca1727746901bf48ad784bdd2de12c8f"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Java EE Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.jee=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.jee.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
 }

--- a/eclipse-javascript.json
+++ b/eclipse-javascript.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:254b4eea4bfda756f50680a6b1dc079e83831d1efafc60e779f9f074a2b0293c30db0813803cd174551f5e9101e29177940e274cd79312e56a3e135d301ac2c2"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:43445a0c141ea67da2362bed7b3d0510403264959bafb775ac089aee792e2a7ca197b78052d9f39f5b5510711fa85024f0b29a9de386b5ee519d94444310d86d"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for JavaScript and Web Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.javascript=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.javascript.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-modeling.json
+++ b/eclipse-modeling.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:05fe980578689e2b07bf77b4bc8ec48a62658300bd149279342e63ea93e94069ed72114995212e5b86cd48af038cff3dde182b6d879376c024a6965e090a3a34"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:9ed3f524d01814622ea3483c8ce45ae55506d4bd131fe07e18bd6a74f0cd0066019a2b47ac0e2271a2e282cb2dd0b7eb2149d97af1b8e5a8393caaf19c49b463"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse Modeling Tools"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.modeling=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.modeling.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-parallel.json
+++ b/eclipse-parallel.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:bd12761063839e19cdb5d651a44a1801cdd2c8940574c2e9139c880469ccaf7491a86cff4fa7a57c48b8553d9bdc96d69c77ab9713bd1b222e9642f37f1c94a2"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:0407b82f8ddce12887035884d9359d8f738fcc8c629a8faed54f6aa76b7e70995f4eb50becbbaf6429290a5d1a78715538b3306183f22bf5d5fa9960abb6ef25"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for Parallel Application Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.parallel=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.parallel.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-php.json
+++ b/eclipse-php.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:63b9257ee0070f58d25cacfc6e523506284dbc6a7df57480b8c19f45f07b5c4d7c5b8d390a936f6cc3b151f7c7dc34c093d7f882782d9a189345a70237fb74cc"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:c95c75beced1e19b0235b3894cd0f79513fe23416097c734a76b9555df136ce70e62da99e40883c1fa986a6b6ca7399b3203e8538a9f08458e17e3830fcb2a09"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for PHP Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.php=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.php.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-platform.json
+++ b/eclipse-platform.json
@@ -1,0 +1,49 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:6010868399e073a49b948c49e9f6c6250db58bf3684f489953b7fb67c34f7d52f0bb50ffa10d199dab7e362f2e52836a0dedbbdd0c994ebe7f2ac5ab787af7cc"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:503707a49d6a47f24b640692fc4b0fd810116af95e86d34f972af434dcf8fb4eeb158af2f0b41cc48bffd65326dd73397df3cc435b067a50c4ad97b306e5c287"
+        }
+    },
+    "extract_dir": "eclipse",
+    "bin": "eclipsec.exe",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse Platform"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "org.eclipse.platform=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/org.eclipse.platform.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-rcp.json
+++ b/eclipse-rcp.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:98a3c0181a14d4ba2383231a698c835ebe9af50fffddce0aa25a80da77127e13a9d4dff6a1e0f7df19ad3ae418606ff76c683132b0aeb6ce3f43ffb2ce1ba91e"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:fb856d4c99a6d208dec94c31dd1bf3176e5092e1cceb3146e6c708a9460ce89ec162d8409c8c53b74ab5687caac158c748665cafd4ba80cfe57c267e1ca94447"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for RCP and RAP Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.rcp=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.rcp.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-reporting.json
+++ b/eclipse-reporting.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:af8138a8bb506ee49359701d7ba13de1dadc9b69bf31ccd623ba8baef498aac789b4622abc98ab951926587c30fb34dffb077622c746f5bf370b68bab9f41933"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:d3488e8bf2e3cfdd4f5e4e9a488aa18d6f78cfbf3734933f353bb2fe29256a3a444e6a500059bb8601b23b031a0725968fe6b77f103759eb774242699156d66d"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Java and Report Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.reporting=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.reporting.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-scout.json
+++ b/eclipse-scout.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:ece3d3ec3a77fe04389d2415de40b05724a28dc6f821071375555e6d52ee566e9581ed9f2e8733030076f8624cdb0807b7ed3e3777dc4b91ccd5944355eec284"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:4b7c9403a2f89b7c0ee461e90f5851a7391c6dcfc57e82656d17c78e6950b6254da2c29a628a4134b591fc1339d0c83237c5556c8808818dceb74e074463389f"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for Scout Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.scout=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.scout.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-sdk.json
+++ b/eclipse-sdk.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:08b138abd6df922973aeb655f1d4f8c8d275ea329c429255cb26780cb2bc9def3e515d50ec6e460ba6034649e9dfc77d33e6df9a77188182032129f4a31e469a"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:14e938cbe0df0b336c345c8b620ad8e3650348ca1810bab1416d487f39e0ae84d4e38671b84b549b1ce738dbe8227d0432ba89b63578d65b6858c1493ff4baa5"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse SDK"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "org.eclipse.sdk=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/org.eclipse.sdk.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-testing.json
+++ b/eclipse-testing.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:7d6ad37acf19d1cb43da0fc1ce27044400b67515fa8db1c23319b136fac033269489f256a6caaf7d5c43e2033ae821debd2d55b214042764b9ce0cb6c8145e90"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:6b2bbcf3d3fa5e2d5d721e9b8e29344fe8dc52cc682d5e15c92580e279aed2039199db9ae79e8e2e0c6438398b8fc4f42a1fc4a82efde4a917f5685ac379a3e8"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for Testers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.testing=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.testing.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse.json
+++ b/eclipse.json
@@ -1,19 +1,48 @@
 {
-	"homepage": "http://www.eclipse.org",
-	"version": "4.5.1",
-	"architecture": {
-		"64bit": {
-			"url": "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-java-mars-1-win32-x86_64.zip",
-			"hash": "md5:ae739e6653eff6753499fe6409ec8952"
-		},
-		"32bit": {
-			"url": "http://ftp.osuosl.org/pub/eclipse/technology/epp/downloads/release/mars/1/eclipse-java-mars-1-win32.zip",
-			"hash": "md5:c5158b238fab0a87e9c271d077a815f5"
-		}
-	},
-	"extract_dir": "eclipse",
-	"bin": "eclipse.exe",
-    "shortcuts" : [
-        [ "eclipse.exe" , "Eclipse Mars"]
-    ] 
+    "homepage": "https://www.eclipse.org",
+    "license": "https://www.eclipse.org/legal/epl-v10.html",
+    "version": "4.6.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip?version=4.6.3&architecture=64bit",
+            "hash": "sha512:d1c6111bad30b5aeb6253fe2fbac636b6b35abb5b554455ed3a89061331cd30812420b0516151ef813b9cf89b7b498e707964ced6d5354c8b754d4258eead668"
+        },
+        "32bit": {
+            "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip?version=4.6.3&architecture=32bit",
+            "hash": "sha512:3c16cf5154d5d5750066720aa0aaa486244892ea8a680d5b5a46cb770e7d7b3efb4c8ad39e59fd698aed8866aa5dd96140975e833783a352f76a7b575f170d7d"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse IDE for Java Developers"
+        ]
+    ],
+    "checkver": {
+        "url": "https://version-to-train.azurewebsites.net/versions.txt",
+        "re": "epp.package.java=([\\d.]+[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip?version=$version&architecture=64bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip.sha512?version=$version&architecture=64bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            },
+            "32bit": {
+                "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip?version=$version&architecture=32bit",
+                "hash": {
+                    "mode": "extract",
+                    "type": "sha512",
+                    "url": "https://version-to-train.azurewebsites.net/epp.package.java.zip.sha512?version=$version&architecture=32bit",
+                    "find": "([a-zA-Z0-9]{128})"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
A rather big commit with all Eclipse projects added.

The Eclipse project uses “release trains” for its packaging project, and since the Europa release (3.3), the packaging project is named after the train, replacing all version numbers. For the main Eclipse project, a drop structure is used, with build id in its path. There are a couple of sources of information needed to do the mapping:

1.	The Oomph product map (http://git.eclipse.org/c/oomph/org.eclipse.oomph.git/plain/setups/org.eclipse.products.setup)
2.	The Simultaneous Release Schedule (https://wiki.eclipse.org/Simultaneous_Release)
3.	The Eclipse Project’s archived releases (http://archive.eclipse.org/eclipse/downloads/)
4.	The Eclipse Packaging Project’s archived releases (https://wiki.eclipse.org/Older_Versions_Of_Eclipse)

To make this work with the new functionality introduced with [#1332](https://github.com/lukesampson/scoop/pull/1332) I had to create a translator that now is running on Azure. It maps the actual version to the correct download link, no matter if it’s a named release or a drop, and then redirects to the Eclipse mirroring network to fetch the files.

The main reason for all of this is that scoop is missing a regex replace feature with callbacks configurable in the manifest, which would need to be evaluated both when `checkver.ps1` is run, and when installing older versions with `scoop install <whatever>@<older version>`. If this is something that in the scope of scoop, I would gladly help to create such a feature, though PowerShell skills are not currently on my resume.

If the new Eclipse manifests are somewhat too complicated for scoop extras, I can put them in a different bucket, but I do think the Eclipse users would greatly benefit from using scoop to handle the different packages and versions needed (sometimes your most valued plugins does not work with the latest Eclipse version etc, etc).
