### PR TITLE
Add Tomcat 6.0, 7.0 and 8.0, suggest server-jre or openjdk.

### DIFF
--- a/tomcat6.json
+++ b/tomcat6.json
@@ -1,0 +1,44 @@
+{
+    "homepage": "https://tomcat.apache.org/",
+    "version": "6.0.53",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.apache.org/dist/tomcat/tomcat-6/v6.0.53/bin/apache-tomcat-6.0.53-windows-x64.zip",
+            "hash": "sha1:d1e46e3760ea02eca20a89d86a37ef382ee060eb"
+        },
+        "32bit": {
+            "url": "https://www.apache.org/dist/tomcat/tomcat-6/v6.0.53/bin/apache-tomcat-6.0.53-windows-x86.zip",
+            "hash": "sha1:74feb07d4bc275a0dac551b1f7bb7c2252e5505a"
+        }
+    },
+    "extract_dir": "apache-tomcat-6.0.53",
+    "bin": "bin\\catalina.bat",
+    "env_set": {
+        "CATALINA_HOME": "$dir",
+        "CATALINA_BASE": "$dir"
+    },
+    "suggest": {
+        "JRE": [
+            "extras/oraclejre-server",
+            "openjdk"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.apache.org/dist/tomcat/tomcat-6/",
+        "re": "v(?<version>6.0.[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.apache.org/dist/tomcat/tomcat-6/v$version/bin/apache-tomcat-$version-windows-x64.zip"
+            },
+            "32bit": {
+                "url": "https://www.apache.org/dist/tomcat/tomcat-6/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+            }
+        },
+        "extract_dir": "apache-tomcat-$version",
+        "hash": {
+            "url": "$url.sha1"
+        }
+    }
+}

--- a/tomcat7.json
+++ b/tomcat7.json
@@ -1,0 +1,44 @@
+{
+    "homepage": "https://tomcat.apache.org/",
+    "version": "7.0.77",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.apache.org/dist/tomcat/tomcat-7/v7.0.77/bin/apache-tomcat-7.0.77-windows-x64.zip",
+            "hash": "sha1:f10686f7ad4aa228db1513d07db23d0eb62bb300"
+        },
+        "32bit": {
+            "url": "https://www.apache.org/dist/tomcat/tomcat-7/v7.0.77/bin/apache-tomcat-7.0.77-windows-x86.zip",
+            "hash": "sha1:0b88062b43d00cdb7f3611dea3528967d1bb9a57"
+        }
+    },
+    "extract_dir": "apache-tomcat-7.0.77",
+    "bin": "bin\\catalina.bat",
+    "env_set": {
+        "CATALINA_HOME": "$dir",
+        "CATALINA_BASE": "$dir"
+    },
+    "suggest": {
+        "JRE": [
+            "extras/oraclejre-server",
+            "openjdk"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.apache.org/dist/tomcat/tomcat-7/",
+        "re": "v(?<version>7.0.[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x64.zip"
+            },
+            "32bit": {
+                "url": "https://www.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+            }
+        },
+        "extract_dir": "apache-tomcat-$version",
+        "hash": {
+            "url": "$url.sha1"
+        }
+    }
+}

--- a/tomcat80.json
+++ b/tomcat80.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://tomcat.apache.org/",
-    "version": "8.5.14",
+    "version": "8.0.43",
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.14/bin/apache-tomcat-8.5.14-windows-x64.zip",
-            "hash": "sha1:151eafa33c72407af6c015e86e7ad0d48ecb2b97"
+            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.0.43/bin/apache-tomcat-8.0.43-windows-x64.zip",
+            "hash": "sha1:f44e6103d1ba9b4cdfb52d23dfe816198c2d482a"
         },
         "32bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.14/bin/apache-tomcat-8.5.14-windows-x86.zip",
-            "hash": "sha1:15c5145cbe2652f3fd9d198795e5cd6bbc7e45b8"
+            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.0.43/bin/apache-tomcat-8.0.43-windows-x86.zip",
+            "hash": "sha1:313ab4da78c4b41a9646588c5f0af55f261c9201"
         }
     },
-    "extract_dir": "apache-tomcat-8.5.14",
+    "extract_dir": "apache-tomcat-8.0.43",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",
@@ -25,7 +25,7 @@
     },
     "checkver": {
         "url": "https://www.apache.org/dist/tomcat/tomcat-8/",
-        "re": "v(?<version>8.5.[\\d]+)"
+        "re": "v(?<version>8.0.[\\d]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Some applications require a specific release (major version) of Tomcat.