### PR TITLE
Update emacs to 25.2

### DIFF
--- a/emacs.json
+++ b/emacs.json
@@ -1,25 +1,25 @@
 {
     "url": "http://www.gnu.org/software/emacs/",
     "license": "GPL3",
-    "version": "25.1-2",
+    "version": "25.2",
     "architecture": {
         "64bit": {
             "url": [
-                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.1-2-x86_64-w64-mingw32.zip",
+                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.2-x86_64.zip",
                 "https://ftp.gnu.org/gnu/emacs/windows/emacs-25-x86_64-deps.zip"
             ],
             "hash": [
-                "5c2e1ef2bfca8aa516297471f16fa79ff98c7386a7db181a08044a6a9811267d",
+                "4f080e2a3a66580ad33ac190f1238f9a7e81b158ee5337035caca5a12864cb4e",
                 "d928e6caaeb5267f978dad0a54c90b0ea6f31ad384f43d8a6bb54c67d2b2f184"
             ]
         },
         "32bit": {
             "url": [
-                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.1-2-i686-w64-mingw32.zip",
+                "https://ftp.gnu.org/gnu/emacs/windows/emacs-25.2-i686.zip",
                 "https://ftp.gnu.org/gnu/emacs/windows/emacs-25-i686-deps.zip"
             ],
             "hash": [
-                "471f94bf64553f8f048019ed16559fa1f102e39262a1fde88bcf627d320f7266",
+                "8e7b47736bd76847125a7f2cec6b44566760ccd9617743938800e556608b8f82",
                 "37daea32cc054ae6b709c015704bdf7b7459c63b1be27cdd590d2807e50b236a"
             ]
         }


### PR DESCRIPTION
No threat detected for x86_64 binary by the 57 scanners at VirusTotal

One of 57 scanners at VirusTotal reported Trojan.Script.Vbs-heuristic.druvzi
for the i686 binary