### PR TITLE
Changed atom.exe to atom.cmd

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -15,7 +15,7 @@
         }
     },
     "bin": [
-        "atom.exe",
+        "\\resources\\cli\\atom.cmd",
         "\\resources\\app\\apm\\bin\\apm.cmd"
     ],
     "shortcuts": [


### PR DESCRIPTION
In atom.json I have changed atom.exe to atom.cmd. atom.exe blocks the command line, while atom.cmd does not.