### PR TITLE
add auto update function to go-ipfs

### DIFF
--- a/go-ipfs.json
+++ b/go-ipfs.json
@@ -1,8 +1,8 @@
 {
-    "version":  "v0.4.8",
-    "license":  "MIT",
-    "extract_dir":  "go-ipfs",
-        "architecture": {
+    "homepage": "https://ipfs.io/",
+    "version": "0.4.8",
+    "license": "MIT",
+    "architecture": {
         "64bit": {
             "url": "https://dist.ipfs.io/go-ipfs/v0.4.8/go-ipfs_v0.4.8_windows-amd64.zip",
             "hash": "f14e025c72db2324757e5ddebc6b11569c6467e9856a4a388cd6cfec3f0ed5f9"
@@ -12,6 +12,20 @@
             "hash": "57a94b09556c4948731109e8b86d5fd01fd25e1ee11aea92da1bd7275f6680d8"
         }
     },
-    "homepage":  "https://ipfs.io/",
-    "bin":  "ipfs.exe"
+    "extract_dir": "go-ipfs",
+    "bin": "ipfs.exe",
+    "checkver": {
+        "url": "https://dist.ipfs.io",
+        "re": "go-ipfs_v([\\d.]+)_windows-amd64.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dist.ipfs.io/go-ipfs/v$version/go-ipfs_v$version_windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://dist.ipfs.io/go-ipfs/v$version/go-ipfs_v$version_windows-386.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
 i got the version check regex to work but i'm not sure if my regex is too much or not. 

this is what i currently have for the regex

`"data-id=\"go-ipfs\" data-version=\"(?<version>[^\\ ]+)\""`

its meant to extract the version from this html element `<a class="d-component-download-btn btn btn-primary" data-id="go-ipfs" data-version="v0.4.8" href="go-ipfs/v0.4.8/go-ipfs_v0.4.8_windows-amd64.zip">Download go-ipfs</a>` this element is the blue Download go-ipfs button on the page.

i feel like this is dirty and could be done a better way but if it can't then this is merge ready