### PR TITLE
Update VS Code to 1.12.1

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://code.visualstudio.com/",
-    "version": "1.11.2",
+    "version": "1.12.1",
     "license": "https://code.visualstudio.com/License/",
-    "url": "https://vscode-update.azurewebsites.net/1.11.2/win32-archive/stable#dl.zip",
-    "hash": "ccbc65679ba52b88bfe11223ed5ac4012cbc77c794626a5716234542b5c3b3eb",
+    "url": "https://vscode-update.azurewebsites.net/1.12.1/win32-archive/stable#dl.zip",
+    "hash": "3604246af8276b8961b99b971795191c05d0d5146850e070288d32448132207a",
     "bin": [
         "code.exe"
     ],


### PR DESCRIPTION
Maybe we need to find a better way to check for updates, the VS Code guys often forget to make a proper GitHub release.