### PR TITLE
Added love, a 2D lua-based gaming engine

### DIFF
--- a/love.json
+++ b/love.json
@@ -1,0 +1,38 @@
+{
+  "homepage": "https://love2d.org/",
+  "version": "0.10.2",
+  "architecture": {
+    "64bit": {
+      "url": "https://bitbucket.org/rude/love/downloads/love-0.10.2-win64.zip",
+      "hash": "a9603b1e1fb353bc0d5608629ea4c0d2e94df3598f3cc4c2e9e84723e6a5a2b9",
+      "extract_dir": "love-0.10.2-win64"
+    },
+    "32bit": {
+      "url": "https://bitbucket.org/rude/love/downloads/love-0.10.2-win32.zip",
+      "hash": "31132C176CD03E3EB2952C4B837E1049E907B8542DEAA297D8EFCD31CFA6A46A",
+      "extract_dir": "love-0.10.2-win32"
+    }
+  },
+  "bin": [
+    "love.exe",
+    "lovec.exe"
+  ],
+  "shortcuts": [
+    ["love.exe", "LÖVE"]
+  ],
+  "license": "zlib/libpng",
+  "notes": "For alternate versions of the LÖVE engine, consider adding this bucket: https://github.com/Guard13007/ScoopBucket-LoveVersions",
+  "checkver": "Download LÖVE ([\\d.]+)",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://bitbucket.org/rude/love/downloads/love-$version-win64.zip",
+        "extract_dir": "love-$version-win64"
+      },
+      "32bit": {
+        "url": "https://bitbucket.org/rude/love/downloads/love-$version-win32.zip",
+        "extract_dir": "love-$version-win32"
+      }
+    }
+  }
+}


### PR DESCRIPTION
I also added to the notes a link to a bucket that has alternate versions of the LÖVE engine. It's helpful when working on it to test code in multiple versions of the engine since there are significant changes between even patch releases.

I would submit those instead to the versions bucket, but as they are not popular-dev-tool related, I do not feel they are appropriate, and there is no scoop-extras-versions bucket.

If this is unacceptable, let me know and I will make another commit to remove the note.
