### PR TITLE
Update tomcat.json

### DIFF
--- a/tomcat.json
+++ b/tomcat.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://tomcat.apache.org/",
-    "version": "8.5.14",
+    "version": "8.5.15",
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.14/bin/apache-tomcat-8.5.14-windows-x64.zip",
-            "hash": "sha1:151eafa33c72407af6c015e86e7ad0d48ecb2b97"
+            "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.15/bin/apache-tomcat-8.5.15-windows-x64.zip",
+            "hash": "sha1:20818069c553ecc84d31607d49acc6cdef51bc78"
         },
         "32bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-8/v8.5.14/bin/apache-tomcat-8.5.14-windows-x86.zip",
-            "hash": "sha1:15c5145cbe2652f3fd9d198795e5cd6bbc7e45b8"
+            "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.15/bin/apache-tomcat-8.5.15-windows-x86.zip",
+            "hash": "sha1:4431ca4be08f26a815a4b821512cc2d680cc8b93"
         }
     },
-    "extract_dir": "apache-tomcat-8.5.14",
+    "extract_dir": "apache-tomcat-8.5.15",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",
@@ -24,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip"
+                "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip"
             },
             "32bit": {
-                "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+                "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip"
             }
         },
         "extract_dir": "apache-tomcat-$version",


### PR DESCRIPTION
fix: made URLs time-resistant

www.apache.org only seems to keep the latest version, so whenever there's an update we had to manually update the initial URL
archive.apache.org seems to keep all the versions.