### PR TITLE
add some missing start menu shortcuts

### DIFF
--- a/mkvtoolnix.json
+++ b/mkvtoolnix.json
@@ -20,6 +20,12 @@
         "mkvpropedit.exe",
         "mkvtoolnix-gui.exe"
     ],
+    "shortcuts": [
+        [
+            "mkvtoolnix-gui.exe",
+            "MKVToolNix GUI"
+        ]
+    ],
     "checkver": "Released v([\\d.]+)",
     "autoupdate": {
         "architecture": {

--- a/sublime-text.json
+++ b/sublime-text.json
@@ -15,7 +15,7 @@
     "notes": "This is a beta version of Sublime Text 3. For more information please see http://www.sublimetext.com/3",
     "shortcuts": [
         [
-            "subl.exe",
+            "sublime_text.exe",
             "Sublime Text 3"
         ]
     ]

--- a/vlc.json
+++ b/vlc.json
@@ -3,6 +3,12 @@
     "version": "2.2.4",
     "license": "GPL",
     "bin": "vlc.exe",
+    "shortcuts": [
+        [
+            "vlc.exe",
+            "VLC media player"
+        ]
+    ],
     "architecture": {
         "64bit": {
             "url": "https://download.videolan.org/pub/vlc/2.2.4/win64/vlc-2.2.4-win64.7z",


### PR DESCRIPTION
While installing apps via Scoop, I noticed some missing start menu shortcuts.

I also changed `subl.exe` to `sublime_text.exe` to prevent the flashing cmd from opening before starting Sublime Text.