### PR TITLE
Update atom.json to correct 64bit download w/ hash

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -27,6 +27,13 @@
         "github": "https://github.com/atom/atom"
     },
     "autoupdate": {
-        "url": "https://github.com/atom/atom/releases/download/v$version/atom-windows.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-windows.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-windows.zip"
+            }
+        }
     }
 }

--- a/atom.json
+++ b/atom.json
@@ -4,8 +4,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-windows.zip",
-            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf"
+            "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-x64-windows.zip",
+            "hash": "e5acbe98d202f096210c26448632e1a753cb40d3e87096dd5d98e0a8bee6b570"
         },
         "32bit": {
             "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-windows.zip",


### PR DESCRIPTION
The previous version of atom.json had the same download link and hash for both the 64bit and 32 architectures. This commit corrects this issues by updating the download link and adding its hash.