### PR TITLE
Fix extract_dir to work with 64bit

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -5,14 +5,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-windows.zip",
-            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf"
+            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf",
+            "extract_dir": "Atom x64"
         },
         "32bit": {
             "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-windows.zip",
-            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf"
+            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf",
+            "extract_dir": "Atom"
         }
     },
-    "extract_dir": "Atom",
     "bin": [
         "\\resources\\cli\\atom.cmd",
         "\\resources\\app\\apm\\bin\\apm.cmd"


### PR DESCRIPTION
After the 64bit architecture was fixed, there was an issue where the 64bit download would extract to "Atom x64", not "Atom" as the original extract_dir held. I localized the extract_dir property to each architecture and update the 64bit one accordingly.