### PR TITLE
Fix extract_dir for 64bit

### DIFF
--- a/atom.json
+++ b/atom.json
@@ -5,11 +5,13 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-x64-windows.zip",
-            "hash": "e5acbe98d202f096210c26448632e1a753cb40d3e87096dd5d98e0a8bee6b570"
+            "hash": "e5acbe98d202f096210c26448632e1a753cb40d3e87096dd5d98e0a8bee6b570",
+            "extract_dir": "Atom x64"
         },
         "32bit": {
             "url": "https://github.com/atom/atom/releases/download/v1.17.0/atom-windows.zip",
-            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf"
+            "hash": "c0b5629671898de757f76258893096467d99e3945d37af302c9a781368e469cf",
+            "extract_dir": "Atom"
         }
     },
     "extract_dir": "Atom",
@@ -29,10 +31,12 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-windows.zip"
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-windows.zip",
+                "extract_dir": "Atom x64"
             },
             "32bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-windows.zip"
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-windows.zip",
+                "extract_dir": "Atom"
             }
         }
     }


### PR DESCRIPTION
After the 64bit architecture was fixed, there was an issue where the 64bit download would extract to "Atom x64", not "Atom" as the original extract_dir held. I localized the extract_dir property to each architecture and update the 64bit one accordingly.