### PR TITLE
updated the vlc version regex

### DIFF
--- a/vlc.json
+++ b/vlc.json
@@ -22,7 +22,7 @@
         }
     },
     "checkver": {
-        "url": "http://www.videolan.org/vlc/download-windows.html",
+        "url": "https://www.videolan.org/vlc/download-windows.html",
         "re": "\\s+([\\d.]+)</span>"
     },
     "autoupdate": {

--- a/vlc.json
+++ b/vlc.json
@@ -22,8 +22,8 @@
         }
     },
     "checkver": {
-        "url": "https://download.videolan.org/pub/vlc/last/win64/",
-        "re": "vlc-([\\d.]+)-win64.7z"
+        "url": "http://www.videolan.org/vlc/download-windows.html",
+        "re": "\\s+([\\d.]+)</span>"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
I updated the autoupdate regex for vlc to check the http://www.videolan.org/vlc/download-windows.html page instead of the previously used page