### PR TITLE
Add extract_dir property to VS Code manifest

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -11,6 +11,7 @@
             "code"
         ]
     ],
+    "extract_dir": "VSCode-win32-ia32",
     "shortcuts": [
         [
             "code.exe",


### PR DESCRIPTION
The archive format changed slightly.

We also have to watch out for the 64 Bit build of VS Code. AFAIK they wanted to enable it for Windows in this release, but I didn't find anything in the release notes.