### PR TITLE
Vim

### DIFF
--- a/gvim.json
+++ b/gvim.json
@@ -14,6 +14,12 @@
         "vim\\vim80"
     ],
     "bin": "gvim.exe",
+    "shortcuts": [
+        [
+            "gvim.exe",
+            "gVim"
+        ]
+    ],
     "post_install": "
         if(!(test-path ~\\.vimrc)) {
         cp \"$dir\\vimrc_example.vim\" ~\\.vimrc

--- a/neovim.json
+++ b/neovim.json
@@ -24,7 +24,7 @@
             "Neovim"
         ]
     ],
-    "notes": "Windows support is (currently) experimental. Use a front-end such as Neovim-Qt. (scoop install neovim-qt)",
+    "notes": "Windows support is (currently) experimental.",
     "checkver": {
         "github": "https://github.com/neovim/neovim"
     },

--- a/neovim.json
+++ b/neovim.json
@@ -18,6 +18,12 @@
     },
     "homepage": "https://neovim.io/",
     "bin": "Neovim\\bin\\nvim.exe",
+    "shortcuts": [
+        [
+            "Neovim\\bin\\nvim-qt.exe",
+            "Neovim"
+        ]
+    ],
     "notes": "Windows support is (currently) experimental. Use a front-end such as Neovim-Qt. (scoop install neovim-qt)",
     "checkver": {
         "github": "https://github.com/neovim/neovim"


### PR DESCRIPTION
- Add shortcuts for package 'gvim'
- Add shortcuts for nvim-qt shipped with package 'neovim', to use extra tools like 'win32yank' which support clipboard under windows.