### PR TITLE
Use same approach for download URL as official Docker images for Tomcat

### DIFF
--- a/tomcat.json
+++ b/tomcat.json
@@ -33,16 +33,14 @@
                 "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip",
                 "hash": {
                     "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip.sha1",
-                    "find": "([a-fA-F0-9]+)",
-                    "mode": "extract"
+                    "find": "([a-fA-F0-9]+)"
                 }
             },
             "32bit": {
                 "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip",
                 "hash": {
                     "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip.sha1",
-                    "find": "([a-fA-F0-9]+)",
-                    "mode": "extract"
+                    "find": "([a-fA-F0-9]+)"
                 }
             }
         },

--- a/tomcat.json
+++ b/tomcat.json
@@ -1,21 +1,27 @@
 {
     "homepage": "https://tomcat.apache.org/",
-    "version": "8.5.15",
+    "version": "8.5.16",
     "architecture": {
         "64bit": {
-            "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.15/bin/apache-tomcat-8.5.15-windows-x64.zip",
-            "hash": "sha1:20818069c553ecc84d31607d49acc6cdef51bc78"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.16/bin/apache-tomcat-8.5.16-windows-x64.zip",
+            "hash": "sha1:db816a28514952fcf586bdc312ab0991eedc876b"
         },
         "32bit": {
-            "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.15/bin/apache-tomcat-8.5.15-windows-x86.zip",
-            "hash": "sha1:4431ca4be08f26a815a4b821512cc2d680cc8b93"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.16/bin/apache-tomcat-8.5.16-windows-x86.zip",
+            "hash": "sha1:f15f7b342a541f50274079a500df7ce4a0ddfe14"
         }
     },
-    "extract_dir": "apache-tomcat-8.5.15",
+    "extract_dir": "apache-tomcat-8.5.16",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",
         "CATALINA_BASE": "$dir"
+    },
+    "suggest": {
+        "JRE": [
+            "extras/oraclejre-server",
+            "openjdk"
+        ]
     },
     "checkver": {
         "url": "https://www.apache.org/dist/tomcat/tomcat-8/",
@@ -24,15 +30,22 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip"
+                "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip",
+                "hash": {
+                    "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x64.zip.sha1",
+                    "find": "([a-fA-F0-9]+)",
+                    "mode": "extract"
+                }
             },
             "32bit": {
-                "url": "https://archive.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+                "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip",
+                "hash": {
+                    "url": "https://www.apache.org/dist/tomcat/tomcat-8/v$version/bin/apache-tomcat-$version-windows-x86.zip.sha1",
+                    "find": "([a-fA-F0-9]+)",
+                    "mode": "extract"
+                }
             }
         },
-        "extract_dir": "apache-tomcat-$version",
-        "hash": {
-            "url": "$url.sha1"
-        }
+        "extract_dir": "apache-tomcat-$version"
     }
 }


### PR DESCRIPTION
Tomcat Archive does not always carry the latest versions of Tomcat. This commit reuses the official [Dockerfile](https://github.com/docker-library/tomcat/blob/5ac222d258dc70c77bb3a9a4fab81ea286c9abd1/8.5/jre8/Dockerfile#L49) way.