### PR TITLE
Create initial dhcpsrv.ini without BOM

### DIFF
--- a/dhcp-server.json
+++ b/dhcp-server.json
@@ -14,7 +14,7 @@
         ]
     ],
     "persist": "dhcpsrv.ini",
-    "pre_install": "echo $null >> $dir\\dhcpsrv.ini",
+    "pre_install": "Add-Content \"$dir\\dhcpsrv.ini\" $null",
     "checkver": {
         "url": "http://www.dhcpserver.de/cms/download/",
         "re": "download.php\\?id=(?<id>[\\d]+)\" class=\"attachment-link\" title=\"DHCP Server V([\\d.]+)\""


### PR DESCRIPTION
Minor change. `echo $null >> $dir\\dhcpsrv.ini` creates `dhcpsrv.ini` with BOM, replaced it with `Add-Content`.