### PR TITLE
Add dungeon crawl stone soup tiles and console version.

### DIFF
--- a/stone-soup-tiles.json
+++ b/stone-soup-tiles.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.20.1",
+    "license": "GPL-2.0",
+    "extract_dir": "stone_soup-tiles-0.20",
+    "url": "https://crawl.develz.org/release/0.20/stone_soup-0.20.1-tiles-win32.zip#/dl.7z",
+    "homepage": "https://crawl.develz.org/",
+    "hash": "b79a28098df550e098a3df7157364580ea48c72423d291d18aa7e322c3a27612",
+    "bin": [
+        [
+            "crawl.exe",
+            "crawl-tiles"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "crawl.exe",
+            "DCSS Tiles"
+        ]
+    ],
+    "checkver": {
+        "url": "http://crawl.develz.org/download.htm",
+        "re": "Latest Stable Version: <strong>([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "url": "https://crawl.develz.org/release/$majorVersion.$minorVersion/stone_soup-$version-tiles-win32.zip#/dl.7z",
+        "extract_dir": "stone_soup-tiles-$majorVersion.$minorVersion"
+    }
+}

--- a/stone-soup.json
+++ b/stone-soup.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.20.1",
+    "license": "GPL-2.0",
+    "extract_dir": "stone_soup-0.20",
+    "url": "https://crawl.develz.org/release/0.20/stone_soup-0.20.1-console-win32.zip#/dl.7z",
+    "homepage": "https://crawl.develz.org/",
+    "hash": "ee3783bcedb92c52f151b77e63129dad53c892cec1ef054551148393b482fca5",
+    "bin": "crawl.exe",
+    "shortcuts": [
+        [
+            "crawl.exe",
+            "DCSS Console"
+        ]
+    ],
+    "checkver": {
+        "url": "http://crawl.develz.org/download.htm",
+        "re": "Latest Stable Version: <strong>([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "url": "https://crawl.develz.org/release/$majorVersion.$minorVersion/stone_soup-$version-console-win32.zip#/dl.7z",
+        "extract_dir": "stone_soup-$majorVersion.$minorVersion"
+    }
+}


### PR DESCRIPTION
This adds manifests for the ASCII version and graphical version of the roguelike [Dungeon Crawl Stone Soup](https://crawl.develz.org/).