### PR TITLE
update love.json note

### DIFF
--- a/love.json
+++ b/love.json
@@ -24,7 +24,7 @@
         ]
     ],
     "license": "zlib/libpng",
-    "notes": "For alternate versions of the LÖVE engine, consider adding this bucket: https://github.com/Guard13007/ScoopBucket-LoveVersions",
+    "notes": "Alternate versions of the LÖVE engine included in versions bucket.",
     "checkver": "Download LÖVE ([\\d.]+)",
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Was recommending use of an unnecessary (and deprecated) bucket.

Left over from when I first added it and hadn't added the other versions to the versions bucket.