### PR TITLE
Added OpenResty, a fork of NGINX for writing webapps with Lua

### DIFF
--- a/openresty.json
+++ b/openresty.json
@@ -1,0 +1,20 @@
+{
+  "homepage": "https://github.com/openresty/openresty/blob/master/doc/README-win32.md#readme",
+  "version": "1.11.2.3",
+  "url": "https://openresty.org/download/openresty-1.11.2.3-win32.zip",
+  "hash": "0258124001fb5a5ef133cbee075829d331dffcb18a9791ccb64c7a75ed52c67e",
+  "extract_dir": "openresty-1.11.2.3-win32",
+  "bin": [
+    ["nginx.exe", "openresty"]
+  ],
+  "notes": "Use '-p $PWD' to specify current directory when running OpenResty.\n(Alternately, see documentation by running 'scoop home openresty'.)",
+  "license": "BSD",
+  "checkver": {
+    "url": "https://openresty.org/en/download.html",
+    "re": "openresty-([\\d.]+)-win32\\.zip"
+  },
+  "autoupdate": {
+    "url": "https://openresty.org/download/openresty-$version-win32.zip",
+    "extract_dir": "openresty-$version-win32"
+  }
+}


### PR DESCRIPTION
As requested, submitting to extras instead of the main bucket because of the niche-ness of it.

Also, as I mentioned in another pull on the main bucket, I can't figure out how to use autoupdate on stuff. This version is actually out of date, and I will run that on it as soon as I know how to.