### PR TITLE
Add Netbeans IDE

### DIFF
--- a/netbeans.json
+++ b/netbeans.json
@@ -1,0 +1,30 @@
+{
+   "version":"8.2",
+   "license":"CDDL-GPL2",
+   "url":"http://download.netbeans.org/netbeans/8.2/final/zip/netbeans-8.2-201609300101.zip",
+   "homepage":"https://netbeans.org",
+   "hash":"ad9888334b9a6c1f1138dcb2eccc8ce4921463e871e46def4ecc617538160948",
+   "extract_dir":"netbeans",
+   "architecture":{
+      "64bit":{
+         "shortcuts":[
+            [
+               "bin/netbeans64.exe",
+               "Netbeans"
+            ]
+         ]
+      },
+      "32bit":{
+         "shortcuts":[
+            [
+               "bin/netbeans.exe",
+               "Netbeans"
+            ]
+         ]
+      }
+   },
+   "checkver":{
+      "url":"https://netbeans.org/community/releases/roadmap.html",
+      "re":"([\\d.]+)<\/td>\\s+<td class=\"tbltd1\"><i><b>Released"
+   }
+}


### PR DESCRIPTION
This adds the full version of Netbeans. But, no automatic URL updating for version changes (fortunately it only updates about once a year).

&nbsp;

The official Netbeans website has some interesting design choices; you need JS enabled to view the downloads page.

Unfortunately, the download link not only requires the version, it also requires the build number. While I managed to scrape the latest version from the release notes, I could not find a non-JS page to scrape both version and build number in one go.

And, again, unfortunately, the Mercurial tags on the official Netbeans repo not only do not always list the releases (802 is missing), but they also do not list the build number or offer any helpful information to derive the build number from.

Interestingly, though, the build numbers appear to be hardcoded into the JS files for the downloads page. The URL for the build_info.js file appears to always either be "download/$version/js/build_info.js" or **"download/$version/*final*/js/build_info.js".

- https://netbeans.org/images_www/v6/download/8.2/final/js/build_info.js
- https://netbeans.org/images_www/v6/download/8.1/js/build_info.js

```JavaScript
build_info.ZIP_FILES_PREFIX            = "netbeans-8.2-201609300101";
```

&nbsp;

So, maybe someone else has a suggestion for getting URL updating to work. But, I'm a little stumped with just the basic manifest file - unless you can somehow do multistep checkver.


