### PR TITLE
Add IrfanView

### DIFF
--- a/irfanview.json
+++ b/irfanview.json
@@ -36,6 +36,14 @@
          ]
       }
    },
+   "pre_install": "
+        if(!(Test-Path(\"$dir\\i_view64.ini\"))) { New-Item \"$dir\\i_view64.ini\" | Out-Null }
+        if(!(Test-Path(\"$dir\\i_view32.ini\"))) { New-Item \"$dir\\i_view32.ini\" | Out-Null }
+   ",
+   "persist": [
+        "i_view64.ini",
+        "i_view32.ini"
+   ],
    "extract_to":[
       "",
       "Plugins"

--- a/irfanview.json
+++ b/irfanview.json
@@ -1,0 +1,47 @@
+{
+   "version":"4.44",
+   "license":"Commercial",
+   "homepage":"http://www.irfanview.com/",
+   "architecture":{
+      "64bit":{
+         "url":[
+            "http://irfanview.info/files/iview444_x64.zip",
+            "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444_x64.zip"
+         ],
+         "hash":[
+            "7608b879056b74a3c74e054fb9340eac6eac1367a6b02049b31079bec83f7bd1",
+            "5ff7c0e58a1ede9e3cb91dff3eb02319585f72e530c1caa2ffe4587c3ca2bb80"
+         ],
+         "shortcuts":[
+            [
+               "i_view64.exe",
+               "IrfanView"
+            ]
+         ]
+      },
+      "32bit":{
+         "url":[
+            "http://irfanview.info/files/iview444.zip",
+            "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444.zip"
+         ],
+         "hash":[
+            "38f3354489db8f4dcc6cbb4bea50db56a159417e987f8e67d20df99cc3e030e0",
+            "b56735710d2c3333af42ae05a36cb51d731a49811b2d41ea3c29b862542d21b1"
+         ],
+         "shortcuts":[
+            [
+               "i_view32.exe",
+               "IrfanView"
+            ]
+         ]
+      }
+   },
+   "extract_to":[
+      "",
+      "Plugins"
+   ],
+   "checkver":{
+      "url":"http://www.irfanview.com/main_start_engl.htm",
+      "re":"Current version: ([\\d\\.-]+)"
+   }
+}

--- a/irfanview.json
+++ b/irfanview.json
@@ -1,55 +1,55 @@
 {
-   "version":"4.44",
-   "license":"Commercial",
-   "homepage":"http://www.irfanview.com/",
-   "architecture":{
-      "64bit":{
-         "url":[
-            "http://irfanview.info/files/iview444_x64.zip",
-            "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444_x64.zip"
-         ],
-         "hash":[
-            "7608b879056b74a3c74e054fb9340eac6eac1367a6b02049b31079bec83f7bd1",
-            "5ff7c0e58a1ede9e3cb91dff3eb02319585f72e530c1caa2ffe4587c3ca2bb80"
-         ],
-         "shortcuts":[
-            [
-               "i_view64.exe",
-               "IrfanView"
+    "version": "4.44",
+    "license": "Commercial",
+    "homepage": "http://www.irfanview.com/",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "http://irfanview.info/files/iview444_x64.zip",
+                "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444_x64.zip"
+            ],
+            "hash": [
+                "7608b879056b74a3c74e054fb9340eac6eac1367a6b02049b31079bec83f7bd1",
+                "5ff7c0e58a1ede9e3cb91dff3eb02319585f72e530c1caa2ffe4587c3ca2bb80"
+            ],
+            "shortcuts": [
+                [
+                    "i_view64.exe",
+                    "IrfanView"
+                ]
             ]
-         ]
-      },
-      "32bit":{
-         "url":[
-            "http://irfanview.info/files/iview444.zip",
-            "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444.zip"
-         ],
-         "hash":[
-            "38f3354489db8f4dcc6cbb4bea50db56a159417e987f8e67d20df99cc3e030e0",
-            "b56735710d2c3333af42ae05a36cb51d731a49811b2d41ea3c29b862542d21b1"
-         ],
-         "shortcuts":[
-            [
-               "i_view32.exe",
-               "IrfanView"
+        },
+        "32bit": {
+            "url": [
+                "http://irfanview.info/files/iview444.zip",
+                "http://www.fosshub.com/IrfanView.html/irfanview_plugins_444.zip"
+            ],
+            "hash": [
+                "38f3354489db8f4dcc6cbb4bea50db56a159417e987f8e67d20df99cc3e030e0",
+                "b56735710d2c3333af42ae05a36cb51d731a49811b2d41ea3c29b862542d21b1"
+            ],
+            "shortcuts": [
+                [
+                    "i_view32.exe",
+                    "IrfanView"
+                ]
             ]
-         ]
-      }
-   },
-   "pre_install": "
+        }
+    },
+    "pre_install": "
         if(!(Test-Path(\"$dir\\i_view64.ini\"))) { New-Item \"$dir\\i_view64.ini\" | Out-Null }
         if(!(Test-Path(\"$dir\\i_view32.ini\"))) { New-Item \"$dir\\i_view32.ini\" | Out-Null }
    ",
-   "persist": [
+    "persist": [
         "i_view64.ini",
         "i_view32.ini"
-   ],
-   "extract_to":[
-      "",
-      "Plugins"
-   ],
-   "checkver":{
-      "url":"http://www.irfanview.com/main_start_engl.htm",
-      "re":"Current version: ([\\d\\.-]+)"
-   }
+    ],
+    "extract_to": [
+        "",
+        "Plugins"
+    ],
+    "checkver": {
+        "url": "http://www.irfanview.com/main_start_engl.htm",
+        "re": "Current version: ([\\d\\.-]+)"
+    }
 }


### PR DESCRIPTION
Adds IrfanView - an old, fairly lightweight, and powerful alternative to the built-in Windows photo viewer. 

Note: this manifest uses multiple URLs. So, while version checking works, there is no auto update. On the bright side, updates aren't so common.