### PR TITLE
Add Foobar2000

### DIFF
--- a/foobar2000.json
+++ b/foobar2000.json
@@ -2,30 +2,29 @@
     "version": "1.3.16",
     "license": "Commercial",
     "homepage": "http://www.foobar2000.org/",
-    "url": "https://www.videohelp.com/download/foobar2000_v1.3.16_portable.zip",
-    "hash": "747c33d75cdf0c9f5e70bfda5acc5fd6d5f90693c7dadfc1be71e7f1be471f6b",
-    "extract_dir": "foobar2000",
-    "persist": [
-        "configuration",
-        "index-data",
-        "LargeFieldsConfig.txt",
-        "library",
-        "library.old",
-        "library.new",
-        "playlists-v1.3"
-    ],
-    "notes": "The theme.fth won't be preserved because Foobar2000 can't handle the Hardlink. Please export your Theme before every update!",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.3.16.exe",
+    "hash": "c4be0fbdcbac2378c837b3eefc65e033ff7da592317017c373399f6cb2763f94",
     "shortcuts": [
         [
             "foobar2000.exe",
             "Foobar2000"
         ]
     ],
+    "installer": {
+        "args": [
+            "/S",
+            "/D=$dir"
+        ]
+    },
+    "uninstaller": {
+        "file": "uninstall.exe",
+        "args": "/S"
+    },
     "checkver": {
         "url": "http://www.foobar2000.org/download",
         "re": "foobar2000_v([\\d\\.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/foobar2000_v$version_portable.zip"
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe"
     }
 }

--- a/foobar2000.json
+++ b/foobar2000.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.3.16",
+    "license": "Commercial",
+    "homepage": "http://www.foobar2000.org/",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.3.16.exe#/dl.7z",
+    "hash": "c4be0fbdcbac2378c837b3eefc65e033ff7da592317017c373399f6cb2763f94",
+    "shortcuts": [
+        [
+            "foobar2000.exe",
+            "Foobar2000"
+        ]
+    ],
+    "checkver": {
+        "url": "http://www.foobar2000.org/download",
+        "re": "foobar2000_v([\\d\\.]+)\\."
+    },
+    "autoupdate": {
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
+    }
+}

--- a/foobar2000.json
+++ b/foobar2000.json
@@ -2,8 +2,19 @@
     "version": "1.3.16",
     "license": "Commercial",
     "homepage": "http://www.foobar2000.org/",
-    "url": "https://www.videohelp.com/download/foobar2000_v1.3.16.exe#/dl.7z",
-    "hash": "c4be0fbdcbac2378c837b3eefc65e033ff7da592317017c373399f6cb2763f94",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.3.16_portable.zip",
+    "hash": "747c33d75cdf0c9f5e70bfda5acc5fd6d5f90693c7dadfc1be71e7f1be471f6b",
+    "extract_dir": "foobar2000",
+    "persist": [
+        "configuration",
+        "index-data",
+        "LargeFieldsConfig.txt",
+        "library",
+        "library.old",
+        "library.new",
+        "playlists-v1.3"
+    ],
+    "notes": "The theme.fth won't be preserved because Foobar2000 can't handle the Hardlink. Please export your Theme before every update!",
     "shortcuts": [
         [
             "foobar2000.exe",
@@ -15,6 +26,6 @@
         "re": "foobar2000_v([\\d\\.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
+        "url": "https://www.videohelp.com/download/foobar2000_v$version_portable.zip"
     }
 }


### PR DESCRIPTION
Adds Foobar2000 - a very popular and powerful music player.

Using Videhelp as a mirror because the official site uses a timed hash to prevent hotlinking.