### PR TITLE
Add nteract version 0.2.0.

### DIFF
--- a/nteract.json
+++ b/nteract.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "license": "BSD",
+    "url": "https://github.com/nteract/nteract/releases/download/v0.2.0/nteract-0.2.0-win.zip#/dl.7z",
+    "homepage": "https://nteract.io/",
+    "hash": "9cae958e0c280365e76c6e88f218b7acdd13bca7045e25cc22a02f5ceddfe8da",
+    "bin": "nteract.exe",
+    "depends": "miniconda3",
+    "post_install": "
+        Write-Host 'Installing Python3 kernel using conda...' -Foreground Magenta
+        conda install ipykernel -y
+        python3 -m ipykernel install --user
+    ",
+    "checkver": {
+        "github": "https://github.com/nteract/nteract"
+    },
+    "autoupdate": {
+        "url": "https://github.com/nteract/nteract/releases/download/v$version/nteract-$version-win.zip#/dl.7z"
+    },
+    "shortcuts": [
+        [
+            "nteract.exe",
+            "nteract"
+        ]
+    ]
+}


### PR DESCRIPTION
This pull request adds [nteract](https://nteract.io), which is a desktop tool for writing and running Jupyter notebooks.