### PR TITLE
Add shortcut to emacs manifest.

### DIFF
--- a/emacs.json
+++ b/emacs.json
@@ -35,5 +35,11 @@
     "checkver": {
         "url": "https://www.gnu.org/software/emacs/",
         "re": "Emacs ([\\d.]+)"
-    }
+    },
+    "shortcuts": [
+        [
+            "bin\\runemacs.exe",
+            "Emacs"
+        ]
+    ]
 }


### PR DESCRIPTION
This pull request just adds a shortcut to `runemacs.exe` in the `emacs.json` manifest.