### PR TITLE
vcxsrv: Fixed incorrect hash

### DIFF
--- a/vcxsrv.json
+++ b/vcxsrv.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.19.3.0/vcxsrv-64.1.19.3.0.installer.exe?r=scoop#/dl.7z",
-            "hash": "3977e07515d99fa07fa6d8672e9cc1bb75896a73a1f3914d90ccb8fa21d916af"
+            "hash": "9761b9ab6917475e5ecffc093d2c27e5f0589df37b2a8c520811caa2e6a1daac"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.19.3.0/vcxsrv.1.19.3.0.installer.exe?r=scoop#/dl.7z",
-            "hash": "9eaf18969f1c2b8e8a80559f3dba8b6e8906250318ec2c45f2bd3e3bf2177db8"
+            "hash": "ce6e90725deca162d45685b3f178c75040c263f304ef37325564f7d0650dff84"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
For some reason the hash values were incorrect in the latest autoupdate. Fixed with checkver -u.