### PR TITLE
added hash to whois

### DIFF
--- a/whois.json
+++ b/whois.json
@@ -5,5 +5,6 @@
     "url": [
         "https://download.sysinternals.com/files/WhoIs.zip"
     ],
+    "hash": "4110c9d1068131c17a3f42155724873e21883d1dd3aece5e0e744a855f3a1d11",
     "bin": "whois.exe"
 }


### PR DESCRIPTION
Noticed it was missing while installing a bunch of packages.