### PR TITLE
Add Greenshot

### DIFF
--- a/greenshot.json
+++ b/greenshot.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://getgreenshot.org",
+    "version": "1.2.9.129",
+    "url": "https://github.com/greenshot/greenshot/releases/download/Greenshot-RELEASE-1.2.9.129/Greenshot-NO-INSTALLER-1.2.9.129-RELEASE.zip",
+    "hash": "51fb65892180bb3342946ba47170e0a161af63d9d9656d03c848aba806505e08",
+    "bin": [
+        "Greenshot.exe"
+    ],
+    "shortcuts": [
+        [
+            "Greenshot.exe",
+            "Greenshot"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/greenshot/greenshot",
+        "re": "Greenshot-RELEASE-([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/greenshot/greenshot/releases/download/Greenshot-RELEASE-$version/Greenshot-NO-INSTALLER-$version-RELEASE.zip"
+    }
+}


### PR DESCRIPTION
Added [Greenshot](http://getgreenshot.org/). References portable version, no installation. 