### PR TITLE
Update appengine-go to version 1.9.58

### DIFF
--- a/appengine-go.json
+++ b/appengine-go.json
@@ -1,23 +1,23 @@
 {
     "homepage": "https://developers.google.com/appengine/",
-    "version": "1.9.54",
+    "version": "1.9.58",
     "architecture": {
         "64bit": {
             "url": [
-                "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_windows_amd64-1.9.54.zip",
+                "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_windows_amd64-1.9.58.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/pyshim.ps1"
             ],
             "hash": [
-                "c2b27e754d4102c36ba23bff1f02d27dc1c0e57cc0ce5ca04196733d8b21adc2"
+                "sha1:7051826bc90062b8cc3a708cb429bc5a28643b24"
             ]
         },
         "32bit": {
             "url": [
-                "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_windows_386-1.9.54.zip",
+                "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_windows_386-1.9.58.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/pyshim.ps1"
             ],
             "hash": [
-                "6bde099ef3c836b4a786012c854a344e79877a4a094bc922bd4a5a31f250f127"
+                "sha1:2fcd568eacf4a84f0529fd34554613825cbb5ca3"
             ]
         }
     },


### PR DESCRIPTION
SHA1 hash copied from Google's download page. 