### PR TITLE
added faststone capture v5.3 (fscapture) (last freeware verrsion)

### DIFF
--- a/fscapture.json
+++ b/fscapture.json
@@ -1,0 +1,13 @@
+﻿{
+	"homepage": "http://www.faststone.org/FSCaptureDetail.htm",
+    "version": "5.3",
+    "url":  "https://www.portablefreeware.com/download.php?id=775#/fscapture.zip",
+    "hash": "e43be2f9e191d295eadc2e20884b45e91a81af00a4952ce77c7a729c25d3258c",
+    "bin": "FSCapture.exe",
+    "shortcuts": [
+        [
+            "FSCapture.exe",
+            "FSCapture"
+        ]
+    ]
+}

--- a/fscapture.json
+++ b/fscapture.json
@@ -1,5 +1,5 @@
-﻿{
-	"homepage": "http://www.faststone.org/FSCaptureDetail.htm",
+{
+    "homepage": "http://www.faststone.org/FSCaptureDetail.htm",
     "version": "5.3",
     "url":  "https://www.portablefreeware.com/download.php?id=775#/fscapture.zip",
     "hash": "e43be2f9e191d295eadc2e20884b45e91a81af00a4952ce77c7a729c25d3258c",


### PR DESCRIPTION
FastStone Capture is an easy and leightweight tool for taking snapshots and editing them. This is version 5.3 from 2007, the last freeware version. Since version 5.4 it's only a 30 days trial before one has to pay for it.
Don't know why AppVeyor fails to build :/ I tested it on my machine and it worked.