### PR TITLE
Added JPEGView

### DIFF
--- a/jpegview.json
+++ b/jpegview.json
@@ -1,0 +1,42 @@
+{
+    "homepage": "http://jpegview.sourceforge.net/",
+    "version": "1.0.35.1",
+    "license": "GPLv2",
+    "url": "https://sourceforge.net/projects/jpegview/files/jpegview/1.0.35.1/JPEGView_1_0_35_1.zip",
+    "hash": "md5:1511286222377d3a91b2a347b2ac3124",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "JPEGView64"
+        },
+        "32bit": {
+            "extract_dir": "JPEGView32"
+        }
+    },
+    "bin": "JPEGView.exe",
+    "shortcuts": [
+        [
+            "JPEGView.exe",
+            "JPEGView"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/jpegview/files/",
+        "re": "title=\"/jpegview/([\\d.]+)/JPEGView_"
+    },
+    "autoupdate": {
+        "url": "https://sourceforge.net/projects/jpegview/files/jpegview/$version/JPEGView_$underscoreVersion.zip",
+        "hash": {
+            "mode": "extract",
+            "url": "https://sourceforge.net/projects/jpegview/rss?path=/jpegview/$version",
+            "find": "/(?:$basename)/download\" filesize=\"(?<size>[\\d]+)\"><media:hash algo=\"md5\">([a-fA-F0-9]{32})</media:hash>"
+        },
+        "architecture": {
+            "64bit": {
+                "extract_dir": "JPEGView64"
+            },
+            "32bit": {
+                "extract_dir": "JPEGView32"
+            }
+        }
+    }
+}

--- a/jpegview.json
+++ b/jpegview.json
@@ -26,17 +26,8 @@
     "autoupdate": {
         "url": "https://sourceforge.net/projects/jpegview/files/jpegview/$version/JPEGView_$underscoreVersion.zip",
         "hash": {
-            "mode": "extract",
             "url": "https://sourceforge.net/projects/jpegview/rss?path=/jpegview/$version",
             "find": "/(?:$basename)/download\" filesize=\"(?<size>[\\d]+)\"><media:hash algo=\"md5\">([a-fA-F0-9]{32})</media:hash>"
-        },
-        "architecture": {
-            "64bit": {
-                "extract_dir": "JPEGView64"
-            },
-            "32bit": {
-                "extract_dir": "JPEGView32"
-            }
         }
     }
 }


### PR DESCRIPTION
Added [JPEGView](http://jpegview.sourceforge.net/), a lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF and TIFF images with a minimal GUI.

I had to include `extract_dir` in the autoupdate section, even though they are static. Otherwise, they are reset during auto update (bug?).