### PR TITLE
Add Arduino IDE

### DIFF
--- a/arduino.json
+++ b/arduino.json
@@ -1,0 +1,25 @@
+{
+    "homepage": "https://www.arduino.cc/",
+    "version": "1.8.4",
+    "url": "https://downloads.arduino.cc/arduino-1.8.4-windows.zip",
+    "hash": "md5:ad8801eacbf73e87ab35429e8a83ae03",
+    "extract_dir": "arduino-1.8.4",
+    "bin": "arduino.exe",
+    "checkver": {
+        "url": "https://www.arduino.cc/en/Main/Software",
+        "re": "ARDUINO ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://downloads.arduino.cc/arduino-$version-windows.zip",
+        "hash": {
+            "url": "https://downloads.arduino.cc/arduino-$version.md5sum.txt"
+        },
+        "extract_dir": "arduino-$version"
+    },
+    "shortcuts": [
+        [
+            "arduino.exe",
+            "Arduino"
+        ]
+    ]
+}


### PR DESCRIPTION
Added [Arduino 1.8.4](https://www.arduino.cc/en/Main/Software), the official open source IDE for writing programs for the Arduino board.