### PR TITLE
WIP: Add Oracle JDK 9

### DIFF
--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -1,14 +1,10 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "8u144-b01",
+    "version": "9-181",
     "architecture": {
         "64bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-x64.exe",
-            "hash": "be9f6e920f817757ce1913c9c3f0a5d63046c720f37a95e4a14450a179f48a18"
-        },
-        "32bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-i586.exe",
-            "hash": "f2c6657812986aa4b992173da495cdc3620edcdc26927860d7d920958f12575c"
+            "url": "http://download.oracle.com/otn-pub/java/jdk/9+181/jdk-9_windows-x64_bin.exe",
+            "hash": "d4885a5fbd2dce383c579fe4a1569b6d8b5db1574af602e37cadcac781115297"
         }
     },
     "cookie": {
@@ -27,20 +23,17 @@
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
-        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows"
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html",
+        "re": "(?<version>[\\d\\+]+)/jdk-9_windows-x64_bin"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe"
-            },
-            "32bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe"
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/jdk-9_windows-x64_bin.exe"
             }
         },
         "hash": {
-            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html",
             "find": "$basename.*([a-fA-F0-9]{64})\"};"
         }
     }

--- a/oraclejdk8.json
+++ b/oraclejdk8.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "8u144-b01",
+    "architecture": {
+        "64bit": {
+            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-x64.exe",
+            "hash": "be9f6e920f817757ce1913c9c3f0a5d63046c720f37a95e4a14450a179f48a18"
+        },
+        "32bit": {
+            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-i586.exe",
+            "hash": "f2c6657812986aa4b992173da495cdc3620edcdc26927860d7d920958f12575c"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "installer": {
+        "args": [
+            "/s",
+            "ADDLOCAL=\"ToolsFeature,SourceFeature\"",
+            "INSTALLDIR=$dir"
+        ],
+        "keep": "true"
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe"
+            },
+            "32bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe"
+            }
+        },
+        "hash": {
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        }
+    }
+}


### PR DESCRIPTION
Proposal to add Oracle JDK 9. I basically modified `oraclejdk` to install Oracle JDK 9+181, and passed Oracle JDK 8 into `oraclejdk8`.

Installation is working properly, but I didn't test `checkver` and `checkver`.