### PR TITLE
Add IntelliJ IDEA Community

### DIFF
--- a/idea-community.json
+++ b/idea-community.json
@@ -1,0 +1,19 @@
+{
+    "version": "2017.2.5",
+    "homepage": "https://www.jetbrains.com/idea/",
+    "url": "https://download.jetbrains.com/idea/ideaIC-2017.2.5.win.zip",
+    "hash": "3e672975f0d3eb72d3570aa220dd3b6360dbfc529db4e9b83b2677434048ec4a",
+    "bin": "bin\\idea.bat",
+    "env_add_path": "bin",
+    "notes": "Please restart your command line for changes to take effect.",
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=release",
+        "jp": "$..version"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/idea/ideaIC-$version.win.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/idea-ultimate.json
+++ b/idea-ultimate.json
@@ -1,17 +1,17 @@
 {
     "version": "2017.2.5",
     "homepage": "https://www.jetbrains.com/idea/",
-    "url": "https://download.jetbrains.com/idea/ideaIC-2017.2.5.win.zip",
-    "hash": "3e672975f0d3eb72d3570aa220dd3b6360dbfc529db4e9b83b2677434048ec4a",
+    "url": "https://download.jetbrains.com/idea/ideaIU-2017.2.5.win.zip",
+    "hash": "1d39341de9f889b66f00559773ffc80b851f4545e8e2454d554b2e0cf87ca932",
     "bin": "bin\\idea.bat",
     "env_add_path": "bin",
     "notes": "Please restart your command line for changes to take effect.",
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=release",
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release",
         "jp": "$..version"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIC-$version.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIU-$version.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/idea.json
+++ b/idea.json
@@ -1,17 +1,17 @@
 {
     "version": "2017.2.5",
     "homepage": "https://www.jetbrains.com/idea/",
-    "url": "https://download.jetbrains.com/idea/ideaIU-2017.2.5.win.zip",
-    "hash": "1d39341de9f889b66f00559773ffc80b851f4545e8e2454d554b2e0cf87ca932",
+    "url": "https://download.jetbrains.com/idea/ideaIC-2017.2.5.win.zip",
+    "hash": "3e672975f0d3eb72d3570aa220dd3b6360dbfc529db4e9b83b2677434048ec4a",
     "bin": "bin\\idea.bat",
     "env_add_path": "bin",
     "notes": "Please restart your command line for changes to take effect.",
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release",
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=release",
         "jp": "$..version"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIU-$version.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIC-$version.win.zip",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
Added Community Edition of IntelliJ IDEA.

How about using the current idea.json for the Community edition instead. We can create an idea-ultimate.json for the Ultimate edition.