### PR TITLE
Oracle Java 9

### DIFF
--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -1,46 +1,34 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "8u144-b01",
+    "version": "9-181",
     "architecture": {
         "64bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-x64.exe",
-            "hash": "be9f6e920f817757ce1913c9c3f0a5d63046c720f37a95e4a14450a179f48a18"
-        },
-        "32bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-i586.exe",
-            "hash": "f2c6657812986aa4b992173da495cdc3620edcdc26927860d7d920958f12575c"
+            "url": "http://download.oracle.com/otn-pub/java/jdk/9+181/jdk-9_windows-x64_bin.exe#/dl.7z",
+            "hash": "d4885a5fbd2dce383c579fe4a1569b6d8b5db1574af602e37cadcac781115297"
         }
     },
     "cookie": {
         "oraclelicense": "accept-securebackup-cookie"
     },
-    "installer": {
-        "args": [
-            "/s",
-            "ADDLOCAL=\"ToolsFeature,SourceFeature\"",
-            "INSTALLDIR=$dir"
-        ],
-        "keep": "true"
-    },
+    "pre_install": "7z.exe x -o\"$dir\" \"$dir\\tools.zip\" -y | out-null",
+    "post_install": "rm \"$dir\\tools.zip\"",
     "env_add_path": "bin",
     "env_set": {
         "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
-        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows"
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/jdk-(?:.*?)_windows-x64_bin.exe)",
+        "replace": "${major}-${build}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe"
-            },
-            "32bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe"
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath#/dl.7z"
             }
         },
         "hash": {
-            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk9-downloads-3848520.html",
             "find": "$basename.*([a-fA-F0-9]{64})\"};"
         }
     }

--- a/oraclejdk8.json
+++ b/oraclejdk8.json
@@ -1,0 +1,47 @@
+{
+    "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
+    "version": "8u144-b01",
+    "architecture": {
+        "64bit": {
+            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-x64.exe",
+            "hash": "be9f6e920f817757ce1913c9c3f0a5d63046c720f37a95e4a14450a179f48a18"
+        },
+        "32bit": {
+            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jdk-8u144-windows-i586.exe",
+            "hash": "f2c6657812986aa4b992173da495cdc3620edcdc26927860d7d920958f12575c"
+        }
+    },
+    "cookie": {
+        "oraclelicense": "accept-securebackup-cookie"
+    },
+    "installer": {
+        "args": [
+            "/s",
+            "ADDLOCAL=\"ToolsFeature,SourceFeature\"",
+            "INSTALLDIR=$dir"
+        ],
+        "keep": "true"
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "JAVA_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jdk-(?<short>[u\\d]+)-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-x64.exe"
+            },
+            "32bit": {
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jdk-$matchShort-windows-i586.exe"
+            }
+        },
+        "hash": {
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html",
+            "find": "$basename.*([a-fA-F0-9]{64})\"};"
+        }
+    }
+}

--- a/oraclejre-server.json
+++ b/oraclejre-server.json
@@ -1,34 +1,35 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "8u144-b01",
+    "version": "9-181",
     "architecture": {
         "64bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/server-jre-8u144-windows-x64.tar.gz",
-            "hash": "20d5e1b2b4c789b6d0c378ffa9b2ff12448f31f0224ba482a338790cff18020a"
+            "url": "http://download.oracle.com/otn-pub/java/jdk/9+181/serverjre-9_windows-x64_bin.tar.gz",
+            "hash": "24a6d3ab835895976f99851d1f2bc98c49ce1ffc481322d4574cc213be1c3d90"
         }
     },
     "cookie": {
         "oraclelicense": "accept-securebackup-cookie"
     },
-    "extract_dir": "jdk1.8.0_144",
+    "extract_dir": "jdk-9",
     "env_add_path": "bin",
     "env_set": {
-        "JAVA_HOME": "$dir",
-        "JRE_HOME": "$dir\\jre"
+        "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html",
-        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/server-jre-(?<short>(?<release>[\\d]+)u(?<shorter>[\\d]+))-windows-x64.tar.gz"
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/server-jre9-downloads-3848530.html",
+        "_ref": "http://download.oracle.com/otn-pub/java/jdk/9+181/serverjre-9_windows-x64_bin.tar.gz",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/serverjre-(?:.*?)_windows-x64_bin.tar.gz)",
+        "replace": "${major}-${build}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/server-jre-$matchShort-windows-x64.tar.gz"
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
             }
         },
-        "extract_dir": "jdk1.$matchRelease.0_$matchShorter",
+        "extract_dir": "jdk-$matchMajor",
         "hash": {
-            "url": "http://www.oracle.com/technetwork/java/javase/downloads/server-jre8-downloads-2133154.html",
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/server-jre9-downloads-3848530.html",
             "find": "$basename.*([a-fA-F0-9]{64})\"};"
         }
     }

--- a/oraclejre-server.json
+++ b/oraclejre-server.json
@@ -17,7 +17,6 @@
     },
     "checkver": {
         "url": "http://www.oracle.com/technetwork/java/javase/downloads/server-jre9-downloads-3848530.html",
-        "_ref": "http://download.oracle.com/otn-pub/java/jdk/9+181/serverjre-9_windows-x64_bin.tar.gz",
         "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/serverjre-(?:.*?)_windows-x64_bin.tar.gz)",
         "replace": "${major}-${build}"
     },

--- a/oraclejre.json
+++ b/oraclejre.json
@@ -1,40 +1,34 @@
 {
     "homepage": "http://www.oracle.com/technetwork/java/javase/overview/index.html",
-    "version": "8u144-b01",
+    "version": "9-180",
     "architecture": {
         "64bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-windows-x64.tar.gz",
-            "hash": "6ce4c4c67c231f9dcf02e3063b251b65f30b2e7d3cc3081fe483a265ae909746"
-        },
-        "32bit": {
-            "url": "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/jre-8u144-windows-i586.tar.gz",
-            "hash": "d5f2c37b00ac8cd7044ca6fe657584b2882c37aa47ffb90b6d4095247536015d"
+            "url": "http://download.oracle.com/otn-pub/java/jdk/9+181/jre-9_windows-x64_bin.tar.gz",
+            "hash": "597178b4ba5b4c00a8bac2ca00b99e2c033116222be33ac968a34dfbbc8adbe1"
         }
     },
     "cookie": {
         "oraclelicense": "accept-securebackup-cookie"
     },
-    "extract_dir": "jre1.8.0_144",
+    "extract_dir": "jre-9",
     "env_add_path": "bin",
     "env_set": {
-        "JRE_HOME": "$dir"
+        "JAVA_HOME": "$dir"
     },
     "checkver": {
-        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html",
-        "re": "(?<version>[ub\\-\\d]+)/(?<random>[a-fA-F0-9]{32})/jre-(?<short>(?<release>[\\d]+)u(?<shorter>[\\d]+))-windows-x64.tar.gz"
+        "url": "http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html",
+        "re": "otn-pub/java/jdk/(?<path>(?<major>[\\d.]+)\\+(?<build>[\\d]+)/jre-(?:.*?)_windows-x64_bin.tar.gz)",
+        "replace": "${major}-${build}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jre-$matchShort-windows-x64.tar.gz"
-            },
-            "32bit": {
-                "url": "http://download.oracle.com/otn-pub/java/jdk/$version/$matchRandom/jre-$matchShort-windows-i586.tar.gz"
+                "url": "http://download.oracle.com/otn-pub/java/jdk/$matchPath"
             }
         },
-        "extract_dir": "jre1.$matchRelease.0_$matchShorter",
+        "extract_dir": "jre-$matchMajor",
         "hash": {
-            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html",
+            "url": "http://www.oracle.com/technetwork/java/javase/downloads/jre9-downloads-3848532.html",
             "find": "$basename.*([a-fA-F0-9]{64})\"};"
         }
     }


### PR DESCRIPTION
Should be future proof with the new version naming model.

I am aware of the work from PR #569, but this also includes the other Java 9 manifests. Also, installer is not run for the JDK, it's just unzipped.

The version should be harmonized with [scoop](https://github.com/lukesampson/scoop) PR [#1727](https://github.com/lukesampson/scoop/pull/1727)