### PR TITLE
Update oraclejdk.json to account for Directories with spaces

### DIFF
--- a/oraclejdk.json
+++ b/oraclejdk.json
@@ -18,7 +18,7 @@
         "args": [
             "/s",
             "ADDLOCAL=\"ToolsFeature,SourceFeature\"",
-            "INSTALLDIR=$dir"
+            "INSTALLDIR=\"$dir\""
         ],
         "keep": "true"
     },


### PR DESCRIPTION
JDK install bombs out with error code -80 if there is a space in the directory. Adding escaped quotes to JSON to be passed to the program arguments as is done on the ADDLOCAL line above.