### PR TITLE
Update KeePass to version 2.37

### DIFF
--- a/keepass.json
+++ b/keepass.json
@@ -1,8 +1,8 @@
 {
     "homepage": "http://keepass.info/",
-    "version": "2.36",
-    "url": "https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.36/KeePass-2.36.zip",
-    "hash": "5fb46a14e19b47e354e3e7d36c9a85965d62a2d181ac746cff33053a521a77b1",
+    "version": "2.37",
+    "url": "https://sourceforge.net/projects/keepass/files/KeePass%202.x/2.37/KeePass-2.37.zip",
+    "hash": "aafe301ef2fe6052041a44394eb428516505eff2efda2034ef32fb9347e4980d",
     "bin": "KeePass.exe",
     "shortcuts": [
         [
@@ -11,8 +11,8 @@
         ]
     ],
     "checkver": {
-        "url": "http://keepass.info/download.html",
-        "re": "Professional.*\\s+.*<i>KeePass ([\\d.]+)</i>"
+        "url": "https://sourceforge.net/projects/keepass/",
+        "re": "KeePass-([\\d.]+)-Setup.exe"
     },
     "autoupdate": {
         "url": "https://sourceforge.net/projects/keepass/files/KeePass%20$majorVersion.x/$version/KeePass-$version.zip"


### PR DESCRIPTION
Fix `checkver`, now using sourceforge homepage
Update to version 2.37