### PR TITLE
Update Azure CLI to version 2.0.19

### DIFF
--- a/azure-cli.json
+++ b/azure-cli.json
@@ -1,15 +1,15 @@
 {
     "description": "Microsoft Azure CLI 2.0",
     "homepage": "https://aka.ms/cli",
-    "version": "2.0.16",
+    "version": "2.0.19",
     "license": "https://raw.githubusercontent.com/Azure/azure-cli/master/LICENSE.txt",
-    "url": "https://azurecliprod.blob.core.windows.net/msi/azure-cli-2.0.16.msi",
-    "hash": "dc90f9fb45e821b848fca11fc6623b19a66068de2779bcc0ca03e1d07e457654",
+    "url": "https://azurecliprod.blob.core.windows.net/msi/azure-cli-2.0.19.msi",
+    "hash": "a0f8902bdd7eb906d5153dc631821062d4d85119d83af69dbb7fee0b79b0804c",
     "extract_dir": "Microsoft SDKs/Azure/CLI2",
     "bin": "wbin/az.cmd",
     "checkver": {
-        "url": "https://github.com/Azure/azure-cli/releases",
-        "re": "/Azure/azure-cli/releases/tag/azure-cli-([\\d.]+)"
+        "url": "https://api.github.com/repos/Azure/azure-cli/releases",
+        "re": "azure-cli-([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://azurecliprod.blob.core.windows.net/msi/azure-cli-$version.msi"


### PR DESCRIPTION
Fix `checkver`, now using the GitHub API to load releases. This project has a high volume of [releases](https://github.com/Azure/azure-cli/releases) and most of them are for sub-modules. The releases page only shows 10 so the release we are looking for is often off the first page and is missed. The API returns 30 results, increasing the odds of finding a version.

Update version to 2.0.19.