### PR TITLE
Update ZeroNet to version 0.6.0

### DIFF
--- a/ZeroNet.json
+++ b/ZeroNet.json
@@ -1,11 +1,11 @@
 {
-    "version":  "0.5.7",
-    "license":  "GPLv2",
-    "extract_dir":  "ZeroNet-win-dist",
-    "url":  "https://github.com/HelloZeroNet/ZeroNet-win/archive/dist/ZeroNet-win.zip",
-    "homepage":  "https://zeronet.io/",
-    "hash":  "489178ea72592fd16b5cde7541907c366eb9ee0abbe4e4d7989be1db17760a90",
-    "bin":  "ZeroNet.exe",
+    "version": "0.6.0",
+    "license": "GPLv2",
+    "extract_dir": "ZeroNet-win-dist",
+    "url": "https://github.com/HelloZeroNet/ZeroNet-win/archive/dist/ZeroNet-win.zip",
+    "homepage": "https://zeronet.io/",
+    "hash": "0f2c2429f45ad8be96168bdaf16bb802146413a34efd3340a0213b3aa6719c81",
+    "bin": "ZeroNet.exe",
     "persist": [
         "data",
         "log"
@@ -18,5 +18,8 @@
     ],
     "checkver": {
         "github": "https://github.com/HelloZeroNet/ZeroNet"
+    },
+    "autoupdate": {
+        "url": "https://github.com/HelloZeroNet/ZeroNet-win/archive/dist/ZeroNet-win.zip"
     }
 }


### PR DESCRIPTION
Implement `autoupdate` - the dist link always points to latest

Update to version 0.6.0