### PR TITLE
dartium*: remove autoupdates

### DIFF
--- a/dartium-dev.json
+++ b/dartium-dev.json
@@ -11,16 +11,5 @@
         ]
     ],
     "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/1.25.0-dev.6.0/dartium/dartium-windows-ia32-release.zip",
-    "hash": "21b2d945372727c52b113d8261ca8971ab67145bd2d2224fd00015fe4444915b",
-    "checkver": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/latest/VERSION",
-        "re": "\"version\":\\s*\"(.*)\","
-    },
-    "autoupdate": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/$version/dartium/dartium-windows-ia32-release.zip",
-        "extract_dir": "dartium-win-ia32-dev-$version.0",
-        "hash": {
-            "url": "$url.sha256sum"
-        }
-    }
+    "hash": "21b2d945372727c52b113d8261ca8971ab67145bd2d2224fd00015fe4444915b"
 }

--- a/dartium.json
+++ b/dartium.json
@@ -11,16 +11,5 @@
         ]
     ],
     "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/dartium/dartium-windows-ia32-release.zip",
-    "hash": "0c08f8e8e2b0a2414c6d49fb65eabf48274c03e01d3fd526ee0e3edfe0daf062",
-    "checkver": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION",
-        "re": "\"version\":\\s*\"(.*)\","
-    },
-    "autoupdate": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/$version/dartium/dartium-windows-ia32-release.zip",
-        "extract_dir": "dartium-win-ia32-stable-$version.0",
-        "hash": {
-            "url": "$url.sha256sum"
-        }
-    }
+    "hash": "0c08f8e8e2b0a2414c6d49fb65eabf48274c03e01d3fd526ee0e3edfe0daf062"
 }

--- a/dartium_content_shell-dev.json
+++ b/dartium_content_shell-dev.json
@@ -7,16 +7,5 @@
         "content_shell.exe"
     ],
     "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/1.25.0-dev.6.0/dartium/content_shell-windows-ia32-release.zip",
-    "hash": "c3c53bfadc6cdc8e1c84d7219e76b569bd24f0d8673e66232199f3161af69ed6",
-    "checkver": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/latest/VERSION",
-        "re": "\"version\":\\s*\"(.*)\","
-    },
-    "autoupdate": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/dev/release/$version/dartium/content_shell-windows-ia32-release.zip",
-        "extract_dir": "drt-win-ia32-dev-$version.0",
-        "hash": {
-            "url": "$url.sha256sum"
-        }
-    }
+    "hash": "c3c53bfadc6cdc8e1c84d7219e76b569bd24f0d8673e66232199f3161af69ed6"
 }

--- a/dartium_content_shell.json
+++ b/dartium_content_shell.json
@@ -7,16 +7,5 @@
         "content_shell.exe"
     ],
     "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/1.24.2/dartium/content_shell-windows-ia32-release.zip",
-    "hash": "a6422160fa382dab9e4e70aacb7abcc00a7a9d6abbbde37410f3d675a8636753",
-    "checkver": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/latest/VERSION",
-        "re": "\"version\":\\s*\"(.*)\","
-    },
-    "autoupdate": {
-        "url": "https://storage.googleapis.com/dart-archive/channels/stable/release/$version/dartium/content_shell-windows-ia32-release.zip",
-        "extract_dir": "drt-win-ia32-stable-$version.0",
-        "hash": {
-            "url": "$url.sha256sum"
-        }
-    }
+    "hash": "a6422160fa382dab9e4e70aacb7abcc00a7a9d6abbbde37410f3d675a8636753"
 }


### PR DESCRIPTION
These 4 manifests are at their __final__ version. Removing `autoupdate` since the checks are no longer valid. The two dev manifest are currently failing autoupdate and the stable manifest will start failing once 2.0 is released. 

The next stable release will be Dart 2.0 which will no longer include Dartium. All dev releases are now onto 2.0 with no ongoing work on 1.x.

>Dartium is going away in Dart 2.0 

> we don’t plan to release a 1.25 Dart SDK on the stable channel

More info can be found on Dart's [install](https://www.dartlang.org/install) page.