### PR TITLE
Update hack-font to version 1.4.1

### DIFF
--- a/hack-font.json
+++ b/hack-font.json
@@ -1,15 +1,15 @@
 {
-    "version":  "1.2.0",
-    "license":  "MIT",
-    "url":  "https://github.com/source-foundry/Hack-windows-installer/releases/download/1.2.0/HackWindowsInstaller.exe",
-    "homepage":  "http://sourcefoundry.org/hack/",
+    "version": "1.4.1",
+    "license": "MIT",
+    "url": "https://github.com/source-foundry/Hack-windows-installer/releases/download/v1.4.1/HackWindowsInstaller.exe",
+    "homepage": "http://sourcefoundry.org/hack/",
     "checkver": {
-        "github" : "https://github.com/source-foundry/Hack-windows-installer"
+        "github": "https://github.com/source-foundry/Hack-windows-installer"
     },
     "autoupdate": {
-        "url": "https://github.com/source-foundry/Hack-windows-installer/releases/download/$version/HackWindowsInstaller.exe"
+        "url": "https://github.com/source-foundry/Hack-windows-installer/releases/download/v$version/HackWindowsInstaller.exe"
     },
-    "hash":  "d566623369d830afa7e4680ffdee13a2aac2b739fd58725a79ea793eabdb1428",
+    "hash": "29f73e7a57c0a33c01f7154178d36154aab2c1cfc26f386989ea0aab65db73b5",
     "installer": {
         "file": "HackWindowsInstaller.exe",
         "args": [


### PR DESCRIPTION
Update `autoupdate` to match current release url.

Update to 1.4.1