### PR TITLE
csharp-snippetcompiler: remove defunct project

### DIFF
--- a/CSharp-SnippetCompiler.json
+++ b/CSharp-SnippetCompiler.json
@@ -1,8 +1,0 @@
-{
-    "version": "3.0.2",
-    "extract_dir": "SnippetCompiler",
-    "url": "http://www.sliver.com/Downloads/SnippetCompiler_3.0.2.zip",
-    "homepage": "http://www.sliver.com/dotnet/snippetcompiler/",
-    "hash": "3e098118d5160e3356a754cb4fd41c094315855cb9a7f41bc4fd81c12bc56f0f",
-    "bin": "snippetcompiler.exe"
-}


### PR DESCRIPTION
This project no longer exists and is uninstallable via this manifest. 