### PR TITLE
Add Godot Engine

### DIFF
--- a/godot.json
+++ b/godot.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://godotengine.org/",
+    "license": "MIT",
+    "version": "2.1.4",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.tuxfamily.org/godotengine/2.1.4/Godot_v2.1.4-stable_win64.exe.zip",
+            "hash": "e7b56a4a15bc87c1a034075a1d2b2d7b6bee1c2f6efe5d38fb0ff0d7b053fb05"
+        },
+        "32bit": {
+            "url": "https://downloads.tuxfamily.org/godotengine/2.1.4/Godot_v2.1.4-stable_win32.exe.zip",
+            "hash": "4b02b3d1ec75d332ff7aa699e5ceb5e9a54bf1479fc8607e0a2481d8fa26b883"
+        }
+    },
+    "pre_install": "Rename-Item $dir\\Godot_*.exe $dir\\Godot.exe",
+    "shortcuts": [
+        [
+            "Godot.exe",
+            "Godot"
+        ]
+    ],
+    "checkver": {
+        "url": "https://godotengine.org/download",
+        "re": "Godot Engine ([\\d.]+)-stable"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.tuxfamily.org/godotengine/$version/Godot_v$version-stable_win64.exe.zip"
+            },
+            "32bit": {
+                "url": "https://downloads.tuxfamily.org/godotengine/$version/Godot_v$version-stable_win32.exe.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds [Godot](https://godotengine.org/), an open source game engine.