### PR TITLE
add manifest for DiffPDF

### DIFF
--- a/diffpdf.json
+++ b/diffpdf.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "http://soft.rubypdf.com/software/diffpdf",
+    "version": "2.1.3",
+    "license": "GPL-2.0",
+    "url": "http://soft.rubypdf.com/wp-content/uploads/2010/08/diffpdf-2.1.3-win32-static.zip",
+    "hash": "b698b9c3c3c0582c2b5ea474d4df0c5f864b649774e857fdc423b4949ef79b6d",
+    "bin": "diffpdf.exe",
+    "shortcuts": [
+        [
+            "diffpdf.exe",
+            "DiffPDF"
+        ]
+    ]
+}


### PR DESCRIPTION
I have added a manifest for the latest open source version of [DiffPDF](http://soft.rubypdf.com/software/diffpdf). Later versions are closed source.