### PR TITLE
pandoc: remove optional dependency on latex, add suggestion instead

### DIFF
--- a/pandoc.json
+++ b/pandoc.json
@@ -2,7 +2,6 @@
     "homepage": "https://pandoc.org/",
     "version": "2.0",
     "license": "GPL",
-    "depends": "latex",
     "url": "https://github.com/jgm/pandoc/releases/download/2.0/pandoc-2.0-windows.msi",
     "hash": "30fd7386cdc3fe17f91c545626999bd121a2ec5d77a26b6988291af8012262fc",
     "extract_dir": "Pandoc",
@@ -13,5 +12,10 @@
     },
     "autoupdate": {
         "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows.msi"
+    },
+    "suggest": {
+        "MiKTeX": [
+            "latex"
+        ]
     }
 }


### PR DESCRIPTION
Hello,

I tried installing pandoc 2.0 and scoop started installing miktex. MiKTeX is a huge download 191 MB and an *optional* dependency and I already have it installed.

I changed MiKTeX from a dependency to a suggestion.