### PR TITLE
Add Emacs HOME environment variable

### DIFF
--- a/emacs.json
+++ b/emacs.json
@@ -46,6 +46,9 @@
             }
         }
     },
+    "env_set": {
+        "HOME": "$HOME"
+    },
     "shortcuts": [
         [
             "bin\\runemacs.exe",


### PR DESCRIPTION
Adding this variable sets the location of the init file for emacs.
The value points to the users home directory which allows a
configuration through ~/.emacs and ~/.emacs.d like on unix machines.