### PR TITLE
add normal nonportable Ditto

### DIFF
--- a/ditto.json
+++ b/ditto.json
@@ -3,15 +3,22 @@
     "extract_dir": "Ditto",
     "architecture": {
         "32bit": {
-            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.21.185.0/DittoPortable_3_21_185_0.zip",
-            "hash": "f438a687365a4db7738576cbcea6def65912f420ad5b48e255b85e7a220609e5"
+            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.21.185.0/DittoSetup_3_21_185_0.exe",
+            "hash": "f00d4e895110881cb79ba893939a1a0ff05ae9f6404eed2ec9a1792f9921d09f"
         },
         "64bit": {
-            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.21.185.0/DittoPortable_64bit_3_21_185_0.zip",
-            "hash": "2ec0349c93b646093e8b051c1af56b2d0eb4ec29decb59f19bac4455439976a8"
+            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/3.21.185.0/DittoSetup_64bit_3_21_185_0.exe",
+            "hash": "e7ed94a1426f5905cfe7b00b58e7c0e89ce7acbf8a9b92fa0aa8a0567182f081"
         }
     },
     "homepage": "http://ditto-cp.sourceforge.net/",
+    "installer": {
+        "args": ["/VERYSILENT", "/DIR=\"$dir\"", "/NORESTART"]
+    },
+    "uninstaller": {
+        "file": "unins000.exe",
+        "args": ["/VERYSILENT", "/NORESTART"]
+    },
     "bin": "Ditto.exe",
     "checkver": "var versionDots=\"([\\d.]+)\"",
     "pre_install": "$app = Start-Process -FilePath \"$dir\\Ditto.exe\" -WorkingDirectory \"$dir\" -PassThru
@@ -33,10 +40,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoPortable_$underscoreVersion.zip"
+                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoSetup_$underscoreVersion.exe"
             },
             "64bit": {
-                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoPortable_64bit_$underscoreVersion.zip"
+                "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/DittoSetup_64bit_$underscoreVersion.exe"
             }
         }
     }


### PR DESCRIPTION
This commit adds a normal nonportable version of Ditto. There are multiple problems with the portable version:

* when you update Ditto you lose your settings and the clipboard history
* after installation the portable version does not use the settings and clipboard history of the nonportable Ditto that I had installed