### PR TITLE
add normal nonportable calibre

### DIFF
--- a/calibre-normal.json
+++ b/calibre-normal.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://calibre-ebook.com/",
+    "version": "3.11.1",
+    "license": "GNU General Public License v3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v3.11.1/calibre-64bit-3.11.1.msi",
+            "hash": "b278f0272c84981cdae4baa4c09a55b8a30a76e8e891cdc89b790aa9182b9a66"
+        },
+        "32bit": {
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v3.11.1/calibre-3.11.1.msi",
+            "hash": "47a3d444ef1766e9cc1789965f647e6a0d764a46482aa5a6f6e15696b1d5abc9"
+        }
+    },
+    "extract_dir": "PFiles\\Calibre2",
+    "bin": "calibre.exe",
+    "shortcuts": [
+        [
+            "calibre.exe",
+            "Calibre"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/kovidgoyal/calibre"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-$version.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a normal nonportable version of Calibre.

* The portable Scoop version of Calibre does not use the settings and the library of the Calibre version that I had installed.
* Scoop Calibre keeps the settings and the library outside of the Calibre folder. This is a good thing, but it keeps them in a non-standard location which can lead to all kinds of other problems. It can happen that this location is not backed up for example.