### PR TITLE
Update nteract manifest.

### DIFF
--- a/nteract.json
+++ b/nteract.json
@@ -5,10 +5,10 @@
     "homepage": "https://nteract.io/",
     "hash": "0c4881f42b70858e869e477fca3aeec0fd75090b5ea31409c33ac7bd67e066e5",
     "bin": "nteract.exe",
-    "depends": "miniconda3",
+    "depends": "python",
     "post_install": "
-        Write-Host 'Installing Python3 kernel using conda...' -Foreground Magenta
-        conda install ipykernel -y
+        Write-Host 'Installing Python3 kernel...' -Foreground Magenta
+        python3 -m pip install ipykernel
         python3 -m ipykernel install --user
     ",
     "checkver": {
@@ -22,5 +22,6 @@
             "nteract.exe",
             "nteract"
         ]
-    ]
+    ],
+    "notes": "Instructions for downloading more kernels can be found at: https://nteract.io/kernels"
 }


### PR DESCRIPTION
This removes the miniconda3 dependency and replaces it with the default python manifest from the main scoop bucket. 

This also adds a note explaining where to find more kernels and instructions on how to download them.