### PR TITLE
Add now-cli version 8.4

### DIFF
--- a/now-cli.json
+++ b/now-cli.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://zeit.co/now",
+    "license": "Apache 2.0",
+    "version": "8.4.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zeit/now-cli/releases/download/8.4.0/now-win.exe",
+            "hash": "fbc1c13e58960abcdc96dd82f8f42d8bc07d398667003f0c8c77c5206caf00fc"
+        }
+    },
+    "bin": [
+        [
+            "now-win.exe",
+            "now"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/zeit/now-cli"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zeit/now-cli/releases/download/$version/now-win.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add [now](https://zeit.co/now) CLI 