### PR TITLE
Update linqpadless to version 1.1.0

### DIFF
--- a/LinqPadLess.json
+++ b/LinqPadLess.json
@@ -1,6 +1,15 @@
 {
-    "url": "https://api.nuget.org/packages/linqpadless.1.0.0.nupkg#/dl.7z",
-    "version": "1.0.0",
-    "hash": "7cb02a904e868631a0bab6dcf319499c9aaed7429de4821153671f13db694e81",
-    "bin": "tools\\lpless.exe"
+    "homepage": "https://github.com/linqpadless/LinqPadless",
+    "license": "Apache 2.0",
+    "version": "1.1.0",
+    "url": "https://api.nuget.org/packages/linqpadless.1.1.0.nupkg#/dl.7z",
+    "hash": "a0a2a261460ae18ab00be7e57a3e3b81d80f4a39b79160c8c7e0092492c216af",
+    "bin": "tools\\lpless.exe",
+    "checkver": {
+        "url": "https://www.nuget.org/packages/LinqPadless",
+        "re": "-Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://api.nuget.org/packages/linqpadless.$version.nupkg#/dl.7z"
+    }
 }


### PR DESCRIPTION
- Update to version `1.1.0`
- Implement checkver / autoupdate