### PR TITLE
Update universalpausebutton to version 1.0.3

### DIFF
--- a/UniversalPauseButton.json
+++ b/UniversalPauseButton.json
@@ -1,7 +1,41 @@
 {
-    "version": "v1.0.2",
-    "url": "https://github.com/ryanries/UniversalPauseButton/releases/download/v1.0.2/UniversalPauseButton.exe",
     "homepage": "https://github.com/ryanries/UniversalPauseButton",
-    "hash": "a12c9bb7ad173ac4197490760e145eba838bc70c797b04c4d2de8b66ff3be8ce",
-    "bin": "UniversalPauseButton.exe"
+    "version": "1.0.3",
+    "url": "https://github.com/ryanries/UniversalPauseButton/releases/download/v1.0.3/UniversalPauseButton.zip",
+    "extract_dir": "UniversalPauseButton",
+    "hash": "e1b70ae7f0da7f9b7500689de69915ce1f9816f5c2f02d19b6e1070f15b09701",
+    "architecture": {
+        "32bit": {
+            "bin": [
+                [
+                    "UniversalPauseButton_x86.exe",
+                    "UniversalPauseButton"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "UniversalPauseButton_x86.exe",
+                    "Universal Pause Button"
+                ]
+            ]
+        },
+        "64bit": {
+            "bin": [
+                [
+                    "UniversalPauseButton_x64.exe",
+                    "UniversalPauseButton"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "UniversalPauseButton_x64.exe",
+                    "Universal Pause Button"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/ryanries/UniversalPauseButton/releases/download/v$version/UniversalPauseButton.zip"
+    }
 }


### PR DESCRIPTION
- Update to version `1.0.3`
- Add architecture specific bins
- Add shortcuts
- Add checkver and autoupdate