### PR TITLE
add openhardwaremonitor 0.8.0

### DIFF
--- a/openhardwaremonitor.json
+++ b/openhardwaremonitor.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "http://openhardwaremonitor.org/",
+    "url": "http://openhardwaremonitor.org/files/openhardwaremonitor-v0.8.0-beta.zip",
+    "version": "0.8.0",
+    "hash": "eba0f937f37901d86a245a4963049462c8ae30beafb05f08afed1bcdcc13634d",
+    "extract_dir": "OpenHardwareMonitor",
+    "bin": "OpenHardwareMonitor.exe",
+    "shortcuts": [
+        [
+            "OpenHardwareMonitor.exe",
+            "Open Hardware Monitor"
+        ]
+    ],
+    "checkver": {
+        "url": "http://openhardwaremonitor.org/",
+        "re": "Download Open Hardware Monitor ([\\d.]+) Beta"
+    },
+    "autoupdate": {
+        "url": "http://openhardwaremonitor.org/files/openhardwaremonitor-v$version-beta.zip"
+    }
+}


### PR DESCRIPTION
Open Hardware Monitor is a free open source software that monitors temperature sensors, fan speeds, voltages, load and clock speeds of a computer.