### PR TITLE
Add LogExpert version 1.6.6

### DIFF
--- a/logexpert.json
+++ b/logexpert.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/zarunbal/LogExpert",
+    "version": "1.6.6",
+    "license": "MIT",
+    "url": "https://github.com/zarunbal/LogExpert/releases/download/1.6.6/LogExpert-1.6.6.zip",
+    "hash": "6b3ea60270c8731dd2e30050bb13fa7181caeb2581cf4e81e90c3cec23b57d3f",
+    "extract_dir": "LogExpert-1.6.6/LogExpert",
+    "bin": "LogExpert.exe",
+    "shortcuts": [
+        [
+            "LogExpert.exe",
+            "LogExpert"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/zarunbal/LogExpert"
+    }
+}


### PR DESCRIPTION
I've added LogExpert, a Windows tail program and log file analyzer.

While testing autoupdate, I found that either the file name or the packaged directory is different with each release. Because of this inconsistency, I left it out.
I think no autoupdate is better than an autoupdate that probably won't work, but feel free to add it if you think differently.