### PR TITLE
xmllint: Download via http rather than ftp

### DIFF
--- a/xmllint.json
+++ b/xmllint.json
@@ -5,10 +5,10 @@
     "architecture": {
         "64bit": {
             "url": [
-                "ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86_64.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86_64.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86_64.7z"
+                "http://xmlsoft.org/sources/win32/64bit/iconv-1.14-win32-x86_64.7z",
+                "http://xmlsoft.org/sources/win32/64bit/libxml2-2.9.3-win32-x86_64.7z",
+                "http://xmlsoft.org/sources/win32/64bit/mingwrt-5.2.0-win32-x86_64.7z",
+                "http://xmlsoft.org/sources/win32/64bit/zlib-1.2.8-win32-x86_64.7z"
             ],
             "hash": [
                 "789ff211527bdeb80003b39b67c57742c23286db33c1b3d1622f52fc67612f60",
@@ -19,10 +19,10 @@
         },
         "32bit": {
             "url": [
-                "ftp://ftp.zlatkovic.com/libxml/64bit/iconv-1.14-win32-x86.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/libxml2-2.9.3-win32-x86.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/mingwrt-5.2.0-win32-x86.7z",
-                "ftp://ftp.zlatkovic.com/libxml/64bit/zlib-1.2.8-win32-x86.7z"
+                "http://xmlsoft.org/sources/win32/64bit/iconv-1.14-win32-x86.7z",
+                "http://xmlsoft.org/sources/win32/64bit/libxml2-2.9.3-win32-x86.7z",
+                "http://xmlsoft.org/sources/win32/64bit/mingwrt-5.2.0-win32-x86.7z",
+                "http://xmlsoft.org/sources/win32/64bit/zlib-1.2.8-win32-x86.7z"
             ],
             "hash": [
                 "8e8483c3314f9ab44422873a41b0b1048c5a89682d977538e1a16b7114801135",


### PR DESCRIPTION
I couldn't get scoop to download the files via ftp (timeout or file-not-found), but http seemed to work fine.