### PR TITLE
Make KeePass plugin dir persistent

### DIFF
--- a/keepass.json
+++ b/keepass.json
@@ -10,6 +10,9 @@
             "KeePass"
         ]
     ],
+    "persist": [
+        "Plugins"
+    ],
     "checkver": {
         "url": "https://keepass.info/update/version2x.txt",
         "re": "KeePass:([\\d.]+)"


### PR DESCRIPTION
I've made the KeePass plugin dir persistent, to keep installed plugins when updating.

The plugin dir is initially empty, and KeePass plugins are installed by placing them there.