### PR TITLE
Add Rainmeter

### DIFF
--- a/rainmeter.json
+++ b/rainmeter.json
@@ -2,8 +2,12 @@
     "homepage": "https://rainmeter.net/",
     "version": "4.1.0.2989",
     "license": "GPLv2",
-    "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.1.0.2989/Rainmeter-4.1.exe#/Rainmeter.7z",
-    "hash": "5351c37bc348f6ff32bf1b1df1910f1088cf79d0b1abd4ddf8550f41d8b3de69",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.1.0.2989/Rainmeter-4.1.exe#/Rainmeter.7z",
+            "hash": "5351c37bc348f6ff32bf1b1df1910f1088cf79d0b1abd4ddf8550f41d8b3de69"
+        }
+    },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse; Remove-Item \"$dir\\uninst.exe.nsis\"",
     "bin": [
         "Rainmeter.exe",
@@ -19,6 +23,10 @@
         "github": "https://github.com/rainmeter/rainmeter"
     },
     "autoupdate": {
-        "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe#/Rainmeter.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe#/Rainmeter.7z"
+            }
+        }
     }
 }

--- a/rainmeter.json
+++ b/rainmeter.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://rainmeter.net/",
+    "version": "4.1.0.2989",
+    "license": "GPLv2",
+    "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.1.0.2989/Rainmeter-4.1.exe#/Rainmeter.7z",
+    "hash": "5351c37bc348f6ff32bf1b1df1910f1088cf79d0b1abd4ddf8550f41d8b3de69",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse; Remove-Item \"$dir\\uninst.exe.nsis\"",
+    "bin": [
+        "Rainmeter.exe",
+        "SkinInstaller.exe"
+    ],
+    "shortcuts": [
+        [
+            "Rainmeter.exe",
+            "Rainmeter"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/rainmeter/rainmeter"
+    },
+    "autoupdate": {
+        "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe#/Rainmeter.7z"
+    }
+}


### PR DESCRIPTION
I've added Rainmeter, a desktop customization tool.

The package is an NSIS executable installer, and contains both 32 and 64 bit versions.
It's unpacked with 7Zip, and it works on my 64 bit Windows, but I don't know if it will work in a 32 bit environment.
If not, it should probably use the installer instead.