### PR TITLE
telegram: Fix inability to run executable

### DIFF
--- a/telegram.json
+++ b/telegram.json
@@ -2,18 +2,16 @@
     "version": "1.2.1",
     "license": "https://github.com/telegramdesktop/tdesktop/blob/master/LICENSE",
     "extract_dir": "Telegram",
-    "url": [
-        "https://updates.tdesktop.com/tsetup/tportable.1.2.1.zip",
-        "https://gist.githubusercontent.com/rasa/306925371f233de032ab03e9582042e9/raw/33dded05cb40094f4d59461dd6b282b6e32f8a63/telegram.ps1"
-    ],
+    "url": "https://updates.tdesktop.com/tsetup/tportable.1.2.1.zip",
     "homepage": "https://telegram.org/",
-    "hash": [
-        "58bcc1b91d5d313afa4b5f9cf6ec7f96911474984c1384adaf3dd5a218634049",
-        "edb63a319b45d6383475634ae1cb2d6a2e7e569b089e3ae0bfc1bcf73be497b3"
-    ],
+    "hash": "58bcc1b91d5d313afa4b5f9cf6ec7f96911474984c1384adaf3dd5a218634049",
     "bin": [
-        "telegram.ps1"
+        "telegram.cmd"
     ],
+    "persist": [
+        "tdata"
+    ],
+    "pre_install": "\"@start \"\"Telegram\"\" /D \"\"%~dp0\"\" \"\"%~dp0Telegram.exe\"\" %*\" | out-file \"$dir\\telegram.cmd\" -encoding oem",
     "shortcuts": [
         [
             "Telegram.exe",

--- a/telegram.json
+++ b/telegram.json
@@ -4,12 +4,12 @@
     "extract_dir": "Telegram",
     "url": [
         "https://updates.tdesktop.com/tsetup/tportable.1.2.1.zip",
-        "https://gist.githubusercontent.com/deevus/3fbc29bddca4d39ad9c7/raw/4433c3ea3ea34f76652b3f576de6063d6bb75978/telegram.ps1"
+        "https://gist.githubusercontent.com/rasa/306925371f233de032ab03e9582042e9/raw/33dded05cb40094f4d59461dd6b282b6e32f8a63/telegram.ps1"
     ],
     "homepage": "https://telegram.org/",
     "hash": [
         "58bcc1b91d5d313afa4b5f9cf6ec7f96911474984c1384adaf3dd5a218634049",
-        "12b5e9a4de1d840169008aa2df49ecc760c3f6835d71ec190e0b82c67d893bbf"
+        "edb63a319b45d6383475634ae1cb2d6a2e7e569b089e3ae0bfc1bcf73be497b3"
     ],
     "bin": [
         "telegram.ps1"


### PR DESCRIPTION
As `scoop which telegram` finds the telegram.cmd in the shims folder, I get the following error with the https://gist.githubusercontent.com/deevus/3fbc29bddca4d39ad9c7/raw/4433c3ea3ea34f76652b3f576de6063d6bb75978/telegram.ps1 script:
````
./Telegram.exe : The term './Telegram.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a pat
included, verify that the path is correct and try again.
At C:\Users\ross\scoop\apps\telegram\current\telegram.ps1:3 char:1
+ ./Telegram.exe
+ ~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (./Telegram.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
````
The included script works:
```
push-location $PSScriptRoot
./Telegram.exe
pop-location
```