### PR TITLE
Hwmonitor hash problem fixed!

### DIFF
--- a/hwmonitor.json
+++ b/hwmonitor.json
@@ -3,7 +3,7 @@
     "architecture": {
         "32bit": {
             "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.34.zip",
-            "hash": "6615ad87048ccc9d3cc9ec57445c9a22ce31b5568e2a234ec0be0e44e116d677",
+            "hash": "bbaac4657e4c2725d1c491b5b0bdf2d250d3f79e1232e39b07ae0e44523fd714",
             "bin": [
                 [
                     "hwmonitor_x32.exe",
@@ -19,7 +19,7 @@
         },
         "64bit": {
             "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.34.zip",
-            "hash": "6615ad87048ccc9d3cc9ec57445c9a22ce31b5568e2a234ec0be0e44e116d677",
+            "hash": "bbaac4657e4c2725d1c491b5b0bdf2d250d3f79e1232e39b07ae0e44523fd714",
             "bin": [
                 [
                     "hwmonitor_x64.exe",


### PR DESCRIPTION
"Expected" values cause hash check failed error! "Actual" value fixed it.
```
Expected:
    6615ad87048ccc9d3cc9ec57445c9a22ce31b5568e2a234ec0be0e44e116d677
Actual:
    bbaac4657e4c2725d1c491b5b0bdf2d250d3f79e1232e39b07ae0e44523fd714
```