### PR TITLE
change mpv 64 bit hash

### DIFF
--- a/mpv.json
+++ b/mpv.json
@@ -4,7 +4,7 @@
     "architecture": {
         "64bit": {
             "url": "https://mpv.srsfckn.biz/mpv-x86_64-20171225.7z",
-            "hash": "64a0505f5d58ed13b8417f9ed2399df13cf64ddc936e1489c136dbd8ec9ce141"
+            "hash": "d402f9a90c034117fdfad5a3a1de04fa66795b94b34a514edc3d316020863819"
         },
         "32bit": {
             "url": "https://mpv.srsfckn.biz/mpv-i686-20171225.7z",

--- a/mpv.json
+++ b/mpv.json
@@ -8,7 +8,7 @@
         },
         "32bit": {
             "url": "https://mpv.srsfckn.biz/mpv-i686-20171225.7z",
-            "hash": "f78d070103ccaf8bff508513b37be7e98a77035957eefbb5c33455ea0c230e3a"
+            "hash": "494c54624ebe60c8485979dc218b163bf86254201d2370c651e42bd5d3715db2"
         }
     },
     "bin": [


### PR DESCRIPTION
Installing mpv get me this message:

Installing 'mpv' (2017-12-25) [64bit]
mpv-x86_64-20171225.7z (14.4 MB) [============================================================================] 100%
Checking hash of mpv-x86_64-20171225.7z... Hash check failed for 'https://mpv.srsfckn.biz/mpv-x86_64-20171225.7z'.
Expected:
    64a0505f5d58ed13b8417f9ed2399df13cf64ddc936e1489c136dbd8ec9ce141
Actual:
    d402f9a90c034117fdfad5a3a1de04fa66795b94b34a514edc3d316020863819