### PR TITLE
Update Elasticsearch to version 6.1.1

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.elastic.co/products/elasticsearch",
     "version": "6.1.1",
     "url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.1.zip",
-    "hash": "sha1:ead35fb9b9d70d45d7d606fcc6c4e3cc5678b752",
+    "hash": "sha1:def99c3a0d26a31db1e6abfbe0ab546d2917a1bd",
     "extract_dir": "elasticsearch-6.1.1",
     "bin": [
         [

--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -1,9 +1,9 @@
 {
     "homepage": "https://www.elastic.co/products/elasticsearch",
-    "version": "5.6.1",
-    "url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.1.zip",
+    "version": "6.1.1",
+    "url": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.1.zip",
     "hash": "sha1:ead35fb9b9d70d45d7d606fcc6c4e3cc5678b752",
-    "extract_dir": "elasticsearch-5.6.1",
+    "extract_dir": "elasticsearch-6.1.1",
     "bin": [
         [
             "bin\\elasticsearch.bat",


### PR DESCRIPTION
Version:
6.1.1

Release date:
December 19, 2017
