### PR TITLE
Fixed JPEGView download url

### DIFF
--- a/jpegview.json
+++ b/jpegview.json
@@ -2,8 +2,8 @@
     "homepage": "https://sourceforge.net/projects/jpegview/",
     "version": "1.0.36",
     "license": "GPLv2",
-    "url": "https://sourceforge.net/projects/jpegview/files/jpegview/1.0.36/JPEGView_1_0_36.zip",
-    "hash": "16fce5617bf1fa847bd7cf6ec12a27ed8445419b5585ce40ddae3a1ceca8282a",
+    "url": "https://sourceforge.net/projects/jpegview/files/jpegview/1.0.36/JPEGView_1.0.36.zip",
+    "hash": "sha1:951d72c24b795119e1f66a7aa50ea6aec344bb71",
     "architecture": {
         "64bit": {
             "extract_dir": "JPEGView64"
@@ -24,6 +24,6 @@
         "re": "title=\"/jpegview/([\\d.]+)/JPEGView_"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/projects/jpegview/files/jpegview/$version/JPEGView_$underscoreVersion.zip"
+        "url": "https://sourceforge.net/projects/jpegview/files/jpegview/$version/JPEGView_$version.zip"
     }
 }


### PR DESCRIPTION
Turns out the problem in #725 wasn't a wrong hash, but a wrong download url, resulting in a different hash each time.
The wrong url returned 404 as expected, shouldn't Scoop report that instead of a hash mismatch?