### PR TITLE
Update enpass to version 5.6.5

### DIFF
--- a/enpass.json
+++ b/enpass.json
@@ -1,9 +1,10 @@
 {
     "homepage": "https://www.enpass.io/",
-    "version": "5.6.0",
-    "url": "https://dl.sinew.in/windows/setup/5-6-0-0/Enpass_5.6.0_Setup.exe#/dl.7z",
-    "hash": "937b3ea2331bc96289fbf6ec9c3a2259c1c6e44657ec57a1e70d0248da27d8c2",
+    "version": "5.6.5",
+    "url": "https://dl.sinew.in/windows/package/EnpassPackage-5.6.5.zip",
+    "hash": "56f8ef34cd22a04c70c8d34852fdd3ad6bb4c8e39306ed0d2eb8479a428034a7",
     "bin": "Enpass.exe",
+    "pre_install": "extract_7zip \"$dir\\Enpass_*_Setup.exe\" \"$dir\"",
     "shortcuts": [
         [
             "Enpass.exe",
@@ -15,6 +16,6 @@
         "re": "<title>Version\\s+([\\d.]+)</title>"
     },
     "autoupdate": {
-        "url": "https://dl.sinew.in/windows/setup/$dashVersion-0/Enpass_$version_Setup.exe#/dl.7z"
+        "url": "https://dl.sinew.in/windows/package/EnpassPackage-$version.zip"
     }
 }


### PR DESCRIPTION
- Update to use URL from `checkver` source
- Update to version 5.6.5