### PR TITLE
Update php-xdebug to version 2.6.0beta1-7.2

### DIFF
--- a/php-xdebug.json
+++ b/php-xdebug.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://xdebug.org/",
-    "version": "2.5.5-7.1",
+    "version": "2.6.0beta1-7.2",
     "license": "https://xdebug.org/license.php",
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-2.5.5-7.1-vc14-x86_64.dll#/php_xdebug.dll",
-            "hash": "f6603e4cbe0b9dc6323f0e9fc66f2ef3bcca558f009528749f245f6e50f1d4b4"
+            "url": "https://xdebug.org/files/php_xdebug-2.6.0beta1-7.2-vc15-x86_64.dll#/php_xdebug.dll",
+            "hash": "220753648cd589fb523cc998a91966749d8d50acfa42d7be7284ee155770ade5"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-2.5.5-7.1-vc14.dll#/php_xdebug.dll",
-            "hash": "370834f3666e7e690d876a58b9b10a416b2284681d72809c7a45a893dec19ab2"
+            "url": "https://xdebug.org/files/php_xdebug-2.6.0beta1-7.2-vc15.dll#/php_xdebug.dll",
+            "hash": "32d30673d235338b37a84266b5994c0e7c63e4db1fef4b314602690caa9624f9"
         }
     },
     "post_install": "
@@ -22,7 +22,7 @@
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",
     "checkver": {
         "url": "https://xdebug.org/download.php",
-        "re": "php_xdebug-([\\d.]+-7.1)-vc14-x86_64.dll"
+        "re": "php_xdebug-([\\d.]+-7.2)-vc15-x86_64.dll"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Since the php package was updated to the version 7.2 the php-xdebug package stopped working. They have the only beta version of xdebug for php 7.2 on their site http://xdebug.org.