### PR TITLE
Fix pre-install command in godot.json

### DIFF
--- a/godot.json
+++ b/godot.json
@@ -12,10 +12,13 @@
             "hash": "4b02b3d1ec75d332ff7aa699e5ceb5e9a54bf1479fc8607e0a2481d8fa26b883"
         }
     },
-    "pre_install": "Rename-Item $dir\\Godot_*.exe $dir\\Godot.exe",
+    "pre_install": "Get-ChildItem \"$dir\\Godot_*.exe\" | Rename-Item -NewName \"$dir\\godot.exe\"",
+    "bin": [
+        "godot.exe"
+    ],
     "shortcuts": [
         [
-            "Godot.exe",
+            "godot.exe",
             "Godot"
         ]
     ],


### PR DESCRIPTION
This fixes a PowerShell error when installing Godot. This also renames `Godot.exe` to `godot.exe` and adds it to the PATH, as calling it from the command line can be useful.