### PR TITLE
Fix ccleaner version 5.39.6399 hash value

### DIFF
--- a/ccleaner.json
+++ b/ccleaner.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.piriform.com/ccleaner",
     "version": "5.39.6399",
     "url": "https://www.piriform.com/ccleaner/download/portable/downloadfile#/dl.7z",
-    "hash": "ab17a4fa1b1c88d2d49a96c22703cf6479ddd040c756ab3e333fffc121eb6203",
+    "hash": "f7215379adc09e8c05ba3c26ee0dcdc0f928e715cb80270d21b494a6b8d88bca",
     "architecture": {
         "64bit": {
             "bin": [


### PR DESCRIPTION
It seems the hash value was not updated with the last version update [commit](https://github.com/lukesampson/scoop-extras/commit/0e824a59f091ac78530294f4efef86773ddbb190) which keeps the latest version from being installed.

Cheers!

