### PR TITLE
Update xdebug to version 2.6 for php 7.2

### DIFF
--- a/php-xdebug.json
+++ b/php-xdebug.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://xdebug.org/",
-    "version": "2.6.0-7.1",
+    "version": "2.6.0-7.2",
     "license": "https://xdebug.org/license.php",
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-2.6.0-7.1-vc14-x86_64.dll#/php_xdebug.dll",
-            "hash": "2746dd13c77f1155c17dd0bae6308da9d857ea42507dc33977700ede5a107514"
+            "url": "https://xdebug.org/files/php_xdebug-2.6.0-7.2-vc15-x86_64.dll#/php_xdebug.dll",
+            "hash": "76939525651805c9c598fc81d8c7bae09b33a6d9aa594f1b373f72e3d538d20d"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-2.6.0-7.1-vc14.dll#/php_xdebug.dll",
-            "hash": "3482bab240b2879b1b4f10bb7c4ab8a4167db85bb98c6c26be8d6b36c5fa6934"
+            "url": "https://xdebug.org/files/php_xdebug-2.6.0-7.2-vc15.dll#/php_xdebug.dll",
+            "hash": "86dbc07066644a2afb6d632c57903bfedd24d023f9a9515a6b59aeb972474694"
         }
     },
     "post_install": "
@@ -22,15 +22,15 @@
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",
     "checkver": {
         "url": "https://xdebug.org/download.php",
-        "re": "php_xdebug-([\\d.]+-7.1)-vc14-x86_64.dll"
+        "re": "php_xdebug-([\\d.]+-7.2)-vc15-x86_64.dll"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vc14-x86_64.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vc15-x86_64.dll#/php_xdebug.dll"
             },
             "32bit": {
-                "url": "https://xdebug.org/files/php_xdebug-$version-vc14.dll#/php_xdebug.dll"
+                "url": "https://xdebug.org/files/php_xdebug-$version-vc15.dll#/php_xdebug.dll"
             }
         }
     }


### PR DESCRIPTION
As we provide php 7.2 in the main repo, we have to provide the xdebug dll for the correct version

Superseeds #747 

@lukesampson could you give me write access to the extras repo too?