### PR TITLE
Persist personal path setting for ShareX

### DIFF
--- a/ShareX.json
+++ b/ShareX.json
@@ -11,6 +11,9 @@
             "ShareX"
         ]
     ],
+    "persist": [
+        "PersonalPath.cfg"
+    ],
     "checkver": {
         "github": "https://github.com/ShareX/ShareX"
     },


### PR DESCRIPTION
This file constains the path setting, which tells ShareX where to save configuration files and such.