### PR TITLE
Fix installer args, remove double quotes in foobar2000

### DIFF
--- a/foobar2000.json
+++ b/foobar2000.json
@@ -13,7 +13,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
The foobar2000 installer file don't work to enclose output path in double quotes.

This commit remove double quotes around `$dir` .