### PR TITLE
Remove errant quotes around $dir var

### DIFF
--- a/darktable.json
+++ b/darktable.json
@@ -8,7 +8,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {

--- a/foobar2000.json
+++ b/foobar2000.json
@@ -13,7 +13,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {

--- a/gpg4win.json
+++ b/gpg4win.json
@@ -21,7 +21,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\\Gpg4win\""
+            "/D=$dir\\Gpg4win"
         ]
     },
     "uninstaller": {

--- a/heroku-cli.json
+++ b/heroku-cli.json
@@ -11,7 +11,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {

--- a/openvpn.json
+++ b/openvpn.json
@@ -20,7 +20,7 @@
             "/SELECT_LZODLLS=1",
             "/SELECT_PKCS11DLLS=1",
             "/SELECT_LAUNCH=0",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {

--- a/streamlink.json
+++ b/streamlink.json
@@ -8,7 +8,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "uninstaller": {

--- a/yatqa.json
+++ b/yatqa.json
@@ -12,7 +12,7 @@
         ]
     ],
     "installer": {
-        "args": "/S /D=\"$dir\""
+        "args": "/S /D=$dir"
     },
     "checkver": {
         "url": "http://31.172.95.122/yatqa/.update",


### PR DESCRIPTION
See http://nsis.sourceforge.net/Docs/Chapter3.html#installerusagecommon :
/D sets the default installation directory ($INSTDIR), overriding InstallDir and InstallDirRegKey. It must be the last parameter used in the command line and must not contain any quotes, even if the path contains spaces. Only absolute paths are supported.