### PR TITLE
Qbittorrent: download url changed (fixes #789)

### DIFF
--- a/qbittorrent.json
+++ b/qbittorrent.json
@@ -4,11 +4,11 @@
     "version": "4.0.4",
     "architecture": {
         "64bit": {
-            "url": "https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.0.4/qbittorrent_4.0.4_x64_setup.exe#/dl.7z",
+            "url": "https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.0.4/qbittorrent_4.0.4_x64_setup.exe#/dl.7z",
             "hash": "27420dec31a55b6e4745be7db1e12feb82a5a18b8186a7f0fc339fc97a7b612f"
         },
         "32bit": {
-            "url": "https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-4.0.4/qbittorrent_4.0.4_setup.exe#/dl.7z",
+            "url": "https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.0.4/qbittorrent_4.0.4_setup.exe#/dl.7z",
             "hash": "886f14f9becf831c44f794867bd7fce2c847ce57c8423dab57ca6a5fcff38081"
         }
     },
@@ -26,14 +26,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z",
+                "url": "https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z",
                 "hash": {
                     "url": "https://www.qbittorrent.org/download.php",
                     "find": "64-bit.*\\s+.*<code>([a-fA-F0-9]{40,128})</code>"
                 }
             },
             "32bit": {
-                "url": "https://sourceforge.net/projects/qbittorrent/files/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z",
+                "url": "https://netix.dl.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z",
                 "hash": {
                     "url": "https://www.qbittorrent.org/download.php",
                     "find": "32-bit.*\\s+.*<code>([a-fA-F0-9]{40,128})</code>"


### PR DESCRIPTION
~Alternative links are also available at fosshub if preferred.~
* ~`https://www.fosshub.com/qBittorrent.html/qbittorrent_4.0.4_x64_setup.exe`~
* ~`https://www.fosshub.com/qBittorrent.html/qbittorrent_4.0.4_setup.exe`~