### PR TITLE
mkvtoolnix: Remove mkvinfo-gui

### DIFF
--- a/mkvtoolnix.json
+++ b/mkvtoolnix.json
@@ -14,7 +14,6 @@
     "extract_dir": "mkvtoolnix",
     "bin": [
         "mkvextract.exe",
-        "mkvinfo-gui.exe",
         "mkvinfo.exe",
         "mkvmerge.exe",
         "mkvpropedit.exe",


### PR DESCRIPTION
MKVInfo GUI is no longer included; installation errors with "Can't shim 'mkvinfo-gui.exe': File doesn't exist".