### PR TITLE
Added ImageGlass v4.5.11.27!

### DIFF
--- a/imageglass.json
+++ b/imageglass.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "http://www.imageglass.org/",
+    "description": "A lightweight, versatile image viewer.",
+    "license": "https://github.com/d2phap/ImageGlass/blob/master/LICENSE",
+    "version": "4.5.11.27",
+    "url": "https://github.com/d2phap/ImageGlass/releases/download/4.5.11.27/ImageGlass_4.5.11.27.zip",
+    "hash": "6e518b82b2d9521ec977a66c94a756f304f430c6332634280d02ca554cb0940b",
+    "extract_dir": "ImageGlass_4.5.11.27",
+    "persist": [
+        "igconfig.xml"
+    ],
+    "bin": [
+        [
+            "ImageGlass.exe",
+            "imageglass"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "ImageGlass.exe",
+            "imageglass"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/d2phap/ImageGlass/"
+    },
+    "autoupdate": {
+        "url": "https://github.com/d2phap/ImageGlass/releases/download/4.5.11.27/ImageGlass_$version.zip"
+    }
+}

--- a/imageglass.json
+++ b/imageglass.json
@@ -25,6 +25,7 @@
         "github": "https://github.com/d2phap/ImageGlass/"
     },
     "autoupdate": {
-        "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version.zip"
+        "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version.zip",
+        "extract_dir": "ImageGlass_$version"
     }
 }

--- a/imageglass.json
+++ b/imageglass.json
@@ -25,6 +25,6 @@
         "github": "https://github.com/d2phap/ImageGlass/"
     },
     "autoupdate": {
-        "url": "https://github.com/d2phap/ImageGlass/releases/download/4.5.11.27/ImageGlass_$version.zip"
+        "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version.zip"
     }
 }


### PR DESCRIPTION
Added ImageGlass v4.5.11.27!
Is `extract_dir` can take `$version` variable? When zip file downloaded it has main folder named with version number.
```
┌[⚡ yigit] [17:22]
└[~\scoop\cache]> zipinfo -1 .\imageglass#4.5.11.27#https_github.com_d2phap_ImageGlass_releases_download_4.5.11.27_ImageGlass_4.5.11.27.zip
ImageGlass_4.5.11.27/
ImageGlass_4.5.11.27/default.png
ImageGlass_4.5.11.27/DefaultTheme/
...
...
```