### PR TITLE
Fixed logexpert extract_dir

### DIFF
--- a/logexpert.json
+++ b/logexpert.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "url": "https://github.com/zarunbal/LogExpert/releases/download/v1.6.10/LogExpert-1.6.10.zip",
     "hash": "ece7aa778d27e82dd116badc28e16c41ec142803b75083e57e7e00936ca771c6",
-    "extract_dir": "LogExpert-1.6.10/LogExpert",
+    "extract_dir": "LogExpert",
     "bin": "LogExpert.exe",
     "shortcuts": [
         [
@@ -17,6 +17,6 @@
     },
     "autoupdate": {
         "url": "https://github.com/zarunbal/LogExpert/releases/download/v$version/LogExpert-$version.zip",
-        "extract_dir": "LogExpert-$version/LogExpert"
+        "extract_dir": "LogExpert"
     }
 }


### PR DESCRIPTION
The logexpert package structure changed (again).

As I noted in #657, maybe we're better off with no autoupdate than an autoupdate that breaks the install on every update.

I see the author added a .nupkg. Maybe it will be more stable?