### PR TITLE
Fix ccleaner 5.41.6446 hash

### DIFF
--- a/ccleaner.json
+++ b/ccleaner.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.piriform.com/ccleaner",
     "version": "5.41.6446",
     "url": "https://www.piriform.com/ccleaner/download/portable/downloadfile#/dl.7z",
-    "hash": "cc0a835ecbe6a28e4cec9d945e73f8ba08c58f4f28a21bc659e5638d5ed6c4a2",
+    "hash": "ee6620cf949fe00db6c01e57781efb9f174f6d87f8c117a70fc30a69345c3bdd",
     "architecture": {
         "64bit": {
             "bin": [


### PR DESCRIPTION
This is a simple hash update for the new version of ccleaner.

PS: Quick question, if you define a non-version specific download path (as is the case with ccleaner), won't the package break for everyone everytime a new version is available? Is that the best approach?