### PR TITLE
pwsh: Shortcut name & website change

### DIFF
--- a/pwsh.json
+++ b/pwsh.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://microsoft.com/powershell",
+    "homepage": "https://github.com/PowerShell/PowerShell",
     "version": "6.0.2",
     "license": "MIT",
     "architecture": {
@@ -16,7 +16,7 @@
     "shortcuts": [
         [
             "pwsh.exe",
-            "Powershell 6"
+            "PowerShell Core"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Changed the homepage to a PowerShell Core specific page (the github repo seems best) rather than the generic MS powershell site.
Also it's not going to be "PowerShell 6" forever so changed the shortcut name to "PowerShell Core"