### PR TITLE
Add Linux Live USB creator.

### DIFF
--- a/lili.json
+++ b/lili.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.9.4",
+    "license": "GPL",
+    "url": "https://www.linuxliveusb.com/downloads/?version=stable-portable#/dl.7z",
+    "homepage": "https://www.linuxliveusb.com",
+    "extract_dir": "LinuxLive USB Creator 2.9.4",
+    "bin": [
+        "LiLi USB Creator.exe",
+        [
+          "LiLi USB Creator.exe",
+          "lili"
+        ]
+    ],
+    "hash": "d6259681b8006c6dd9635b8709f890c82ea13a14a33da6563b44edc37fcd93a5",
+    "shortcuts": [
+        [
+            "LiLi USB Creator.exe",
+            "Linux Live USB Creator"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.linuxliveusb.com/en/other-versions",
+        "re": "Version (\\d+\\.\\d+\\.\\d+) Final - Portable Edition"
+    },
+    "autoupdate": {
+        "url": "https://www.linuxliveusb.com/downloads/?version=stable-portable#/dl.7z",
+        "extract_dir": "LinuxLive USB Creator $version"
+    }
+}


### PR DESCRIPTION
Adds lili version 2.4.9, a tool for creating bootable USB drives from Linux ISOs.