### PR TITLE
Update Inkscape to 0.92.2 and remove autoupdate

### DIFF
--- a/inkscape.json
+++ b/inkscape.json
@@ -1,12 +1,16 @@
 {
     "homepage": "https://inkscape.org/",
     "license": "https://inkscape.org/en/about/license/",
-    "version": "0.92.1",
+    "version": "0.92.2",
     "description": "Inkscape is a professional vector graphics editor",
     "architecture": {
+        "32bit": {
+            "url": "https://inkscape.org/en/gallery/item/11264/inkscape-0.92.2-x86.7z",
+            "hash": "c5bac28436b6cf329b53ebdcc0308c0dd1393709eedc83ff5d2c83222ec11827"
+        },
         "64bit": {
-            "url": "https://inkscape.org/gallery/item/10687/Inkscape-0.92.1-x64.7z",
-            "hash": "480a4b6bd03c5bb15b91059b4ce40baa1c2908a21c955722fd26285f64096729"
+            "url": "https://inkscape.org/en/gallery/item/11261/inkscape-0.92.2-x64.7z",
+            "hash": "7642b0945f6e287c3062def1a360e7dd5eacec065f79cb0cfdcb33e72acb4a31"
         }
     },
     "extract_dir": "inkscape",
@@ -18,14 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://inkscape.org/en/download/windows/",
-        "re": "https://inkscape.org/gallery/item/(?<random>[\\d]+)/Inkscape-([\\d.]+)-x64.7z"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://inkscape.org/gallery/item/$matchRandom/Inkscape-$version-x64.7z"
-            }
-        }
+        "url": "https://inkscape.org/",
+        "re": "Current stable version: ([\\d.]+)"
     }
 }

--- a/inkscape32bit.json
+++ b/inkscape32bit.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://inkscape.org/",
     "license": "https://inkscape.org/en/about/license/",
-    "version": "0.92.1",
+    "version": "0.92.2",
     "description": "Inkscape is a professional vector graphics editor",
     "architecture": {
         "32bit": {
-            "url": "https://inkscape.org/gallery/item/10686/Inkscape-0.92.1.7z",
-            "hash": "78e524f584c63d062fca525e0ae4d689b2cf5f1cad355ba0ffb42e5e328c94a3"
+            "url": "https://inkscape.org/en/gallery/item/11264/inkscape-0.92.2-x86.7z",
+            "hash": "c5bac28436b6cf329b53ebdcc0308c0dd1393709eedc83ff5d2c83222ec11827"
         }
     },
     "extract_dir": "inkscape",
@@ -18,14 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://inkscape.org/en/download/windows/",
-        "re": "https://inkscape.org/gallery/item/(?<random>[\\d]+)/Inkscape-([\\d.]+).7z"
-    },
-    "autoupdate": {
-        "architecture": {
-            "32bit": {
-                "url": "https://inkscape.org/gallery/item/$matchRandom/Inkscape-$version.7z"
-            }
-        }
+        "url": "https://inkscape.org/",
+        "re": "Current stable version: ([\\d.]+)"
     }
 }


### PR DESCRIPTION
The old autoupdate didn't catch this version, as the site structure has changed, but the old page used in `checkver` is still available, listing the old version.

Autoupdate is not possible with the current site structure. The links to the .7z files can not be constructed from the version number alone, and the URL to the page where they can be parsed from, contains the version number.

I've updated both `inkscape` and `inkskape32bit`, but I've also added the 32 bit version to inkscape.
The architectures were split to make autoupdate work, but it won't work anyway now, so I think the manifest should follow best practice.