### PR TITLE
update netlifyctl to correct hash

### DIFF
--- a/netlifyctl.json
+++ b/netlifyctl.json
@@ -3,7 +3,7 @@
     "license": "MIT",
     "url": "https://github.com/netlify/netlifyctl/releases/download/v0.3.2/netlifyctl-windows-amd64-0.3.2.zip",
     "homepage": "https://www.netlify.com/",
-    "hash": "89ebbe29d597d1e111c736c7d3d9395e37da1f38f8a8fa8ed2cd87d475c3550e",
+    "hash": "5b004752270bbcf319f675bb2e65087a97daa768f7f6b1b03a1213ce15e8a1a0",
     "bin": "netlifyctl.exe",
     "checkver": {
         "github": "https://github.com/netlify/netlifyctl"


### PR DESCRIPTION
the hash for the v0.3.2 version was incorrect:

```
C:\Users\klauer
λ  scoop install netlifyctl
Installing 'netlifyctl' (0.3.2) [64bit]
netlifyctl-windows-amd64-0.3.2.zip (6.5 MB) [==================================================================================================================================================] 100%
Checking hash of netlifyctl-windows-amd64-0.3.2.zip... Hash check failed for 'https://github.com/netlify/netlifyctl/releases/download/v0.3.2/netlifyctl-windows-amd64-0.3.2.zip'.
Expected:
    89ebbe29d597d1e111c736c7d3d9395e37da1f38f8a8fa8ed2cd87d475c3550e
Actual:
    5b004752270bbcf319f675bb2e65087a97daa768f7f6b1b03a1213ce15e8a1a0
```