### PR TITLE
Fixing MC SourceForge Address!

### DIFF
--- a/mc.json
+++ b/mc.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://midnight-commander.org/",
     "version": "4.8.19",
-    "url": "https://sourceforge.net/projects/mcwin32/files/mcwin32-build204-bin.zip",
+    "url": "https://downloads.sourceforge.net/project/mcwin32/mcwin32-build204-bin.zip",
     "hash": "sha1:ee48adb6718d414a043a2b4a30c7cc69dc68d77c",
     "bin": "mc.exe",
     "shortcuts": [
@@ -15,6 +15,6 @@
         "re": "Latest Build\\s+(?<version>[\\d.]+)\\s+(?<build>[\\d]+)"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/projects/mcwin32/files/mcwin32-build$matchBuild-bin.zip"
+        "url": "https://downloads.sourceforge.net/project/mcwin32/mcwin32-build$matchBuild-bin.zip"
     }
 }


### PR DESCRIPTION
Before link change (look at the file size):
```
┌[⚡ yigit] [ mc-hashfix ≢] [x] [14:56]
└[~\gitforks\scoop-extras]> scoop install .\mc.json
Installing 'mc' (4.8.19) [64bit]
mcwin32-build204-bin.zip (198.3 KB) [===================] 100%

Checking hash of mcwin32-build204-bin.zip... Hash check failed for 'https://sourceforge.net/projects/mcwin32/files/mcwin32-build204-bin.zip'.
Expected:
    ee48adb6718d414a043a2b4a30c7cc69dc68d77c
Actual:
```

After link change:
```
┌[⚡ yigit] [ mc-hashfix ≢ ~1 -0 !] [x] [15:01]
└[~\gitforks\scoop-extras]> scoop install .\mc.json
Installing 'mc' (4.8.19) [64bit]
mcwin32-build204-bin.zip (4.9 MB) [====================] 100%
Checking hash of mcwin32-build204-bin.zip... ok.
Extracting... done.
Linking ~\scoop\apps\mc\current => ~\scoop\apps\mc\4.8.19
Creating shim for 'mc'.
Creating shortcut for mc (mc.exe)
'mc' (4.8.19) was installed successfully!
```