### PR TITLE
Fixing WinDirStat Address!

### DIFF
--- a/windirstat.json
+++ b/windirstat.json
@@ -2,7 +2,7 @@
     "version": "1.1.2",
     "homepage": "https://windirstat.net/",
     "license": "GPL2",
-    "url": "https://windirstat.net/wds_current_setup.exe#/dl.7z",
+    "url": "https://windirstat.mirror.wearetriple.com//wds_current_setup.exe#/dl.7z",
     "hash": "sha1:6fa92dd2ca691c11dfbfc0a239e34369897a7fab",
     "bin": "windirstat.exe",
     "shortcuts": [
@@ -16,7 +16,7 @@
         "re": "Latest version: ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://windirstat.net/wds_current_setup.exe#/dl.7z",
+        "url": "https://windirstat.mirror.wearetriple.com//wds_current_setup.exe#/dl.7z",
         "hash": {
             "url": "https://windirstat.net/download.html",
             "find": "<tt>SHA1:\\s([a-fA-F0-9]{40})</tt>"


### PR DESCRIPTION
The address of `https://windirstat.net/wds_current_setup.exe` is probably redirecting to SourceForge.

```
┌[⚡ yigit] [ windirstat-fix ≢] [18:01]
└[~\gitforks\scoop-extras]> scoop install .\windirstat.json
Installing 'windirstat' (1.1.2) [64bit]
wds_current_setup.exe (215.4 KB) [===================================================================================================================] 100%
Checking hash of wds_current_setup.exe... Hash check failed for 'https://windirstat.net/wds_current_setup.exe#/dl.7z'.
Expected:
    6fa92dd2ca691c11dfbfc0a239e34369897a7fab
Actual:
    68100fbdd2330622ea31fa15b4cfd38347390fab
```