### PR TITLE
mp3tag: add regex match word char to fix wrong download url

### DIFF
--- a/mp3tag.json
+++ b/mp3tag.json
@@ -1,8 +1,8 @@
 {
     "homepage": "https://www.mp3tag.de/",
-    "version": "2.87",
-    "url": "https://download.mp3tag.de/mp3tagv287setup.exe#dl.7z",
-    "hash": "adac4bbca51f7cf0208119d7497870c791279c9e8637b6e5e8728bcd36afeb97",
+    "version": "2.87a",
+    "url": "https://download.mp3tag.de/mp3tagv287asetup.exe#dl.7z",
+    "hash": "5856afed594e453174c4015b5f001ff5b288b203d0460a75268ea5ebfb58dec5",
     "license": "http://help.mp3tag.de/misc_license.html",
     "bin": "mp3tag.exe",
     "shortcuts": [

--- a/mp3tag.json
+++ b/mp3tag.json
@@ -16,7 +16,7 @@
         "export",
         "mp3tag.cfg"
     ],
-    "checkver": "Mp3tag v([\\d.]+)",
+    "checkver": "Mp3tag v([\\d\\w.]+)",
     "autoupdate": {
         "url": "https://download.mp3tag.de/mp3tagv$cleanVersionsetup.exe#dl.7z"
     },


### PR DESCRIPTION
current version is v2.87a and current download url is:

https://download.mp3tag.de/mp3tagv287asetup.exe