### PR TITLE
xmedia-recode 3.4.3.0: extract_dir changed

### DIFF
--- a/xmedia-recode.json
+++ b/xmedia-recode.json
@@ -11,7 +11,7 @@
             "XMedia Recode"
         ]
     ],
-    "extract_dir": "XMediaRecode3430",
+    "extract_dir": "XMedia Recode",
     "pre_install": "if(!(test-path $dir\\Fav.ini)) { write-host \"\" | out-file -encoding oem $dir\\Fav.ini }",
     "persist": [
         "XMediaRecode.ini",
@@ -23,6 +23,6 @@
     },
     "autoupdate": {
         "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion.zip",
-        "extract_dir": "XMediaRecode$cleanVersion"
+        "extract_dir": "XMedia Recode"
     }
 }


### PR DESCRIPTION
Xmedia Recode v3.4.3.0 fails to install. The name of the inner dir to copy was changed.

Will have to see if this change is permanent or if they go back to the old scheme in the next version.