### PR TITLE
Fix for love extract_dir

### DIFF
--- a/love.json
+++ b/love.json
@@ -5,12 +5,12 @@
         "64bit": {
             "url": "https://bitbucket.org/rude/love/downloads/love-11.1-win64.zip",
             "hash": "c52dac947e53f7460fa248b7cc4b7b57861922ae261aab250dcbe6f8b0261497",
-            "extract_dir": "love-11.1-win64"
+            "extract_dir": "love-11.1.0-win64"
         },
         "32bit": {
             "url": "https://bitbucket.org/rude/love/downloads/love-11.1-win32.zip",
             "hash": "e19a1aa40a20360b44a7ff5455df1e485094057f236765c2f832f3df06d64540",
-            "extract_dir": "love-11.1-win32"
+            "extract_dir": "love-11.1.0-win32"
         }
     },
     "bin": [


### PR DESCRIPTION
Love fails to install.

Replaced `love-11.1-winXX` with `love-11.1.0-winXX`. Zip and directory don't follow the same version scheme in 11.1, for 11.0.0 both zip and dir have the same versions.