### PR TITLE
Update Spring Boot CLI to 2.0.1

### DIFF
--- a/springboot.json
+++ b/springboot.json
@@ -14,7 +14,7 @@
     },
     "checkver": {
         "github": "https://github.com/spring-projects/spring-boot",
-        "re": "\/releases\/tag\/(?:v)?(2[\\d.]+)\\.RELEASE"
+        "re": "/releases/tag/(?:v)?(2[\\d.]+)\\.RELEASE"
     },
     "autoupdate": {
         "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version.RELEASE/spring-boot-cli-$version.RELEASE-bin.zip",

--- a/springboot.json
+++ b/springboot.json
@@ -2,7 +2,7 @@
     "homepage": "https://projects.spring.io/spring-boot/",
     "version": "2.0.1",
     "license": "Apache 2.0",
-    "hash": "d1a01429822b0b54444fa6a3fdd92b78255756df42ec7e0f9ed9d67e2ec6ff77",
+    "hash": "17b42622d708e725a50c81d17967eefaadc8a0ef048a0d394ce2662da7b8b7ba",
     "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/2.0.1.RELEASE/spring-boot-cli-2.0.1.RELEASE-bin.zip",
     "extract_dir": "spring-2.0.1.RELEASE",
     "bin": "bin\\spring.bat",

--- a/springboot.json
+++ b/springboot.json
@@ -1,8 +1,8 @@
 {
     "homepage": "https://projects.spring.io/spring-boot/",
     "version": "2.0.1",
-    "license": "Apache-2.0",
-    "hash": "17b42622d708e725a50c81d17967eefaadc8a0ef048a0d394ce2662da7b8b7ba",
+    "license": "Apache 2.0",
+    "hash": "d1a01429822b0b54444fa6a3fdd92b78255756df42ec7e0f9ed9d67e2ec6ff77",
     "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/2.0.1.RELEASE/spring-boot-cli-2.0.1.RELEASE-bin.zip",
     "extract_dir": "spring-2.0.1.RELEASE",
     "bin": "bin\\spring.bat",
@@ -14,7 +14,7 @@
     },
     "checkver": {
         "github": "https://github.com/spring-projects/spring-boot",
-        "re": "/releases/tag/(?:v)?([\\d.]+).RELEASE"
+        "re": "\/releases\/tag\/(?:v)?(2[\\d.]+)\\.RELEASE"
     },
     "autoupdate": {
         "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version.RELEASE/spring-boot-cli-$version.RELEASE-bin.zip",

--- a/springboot.json
+++ b/springboot.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://projects.spring.io/spring-boot/",
-    "version": "1.5.12",
+    "version": "2.0.1",
     "license": "Apache-2.0",
-    "hash": "d1a01429822b0b54444fa6a3fdd92b78255756df42ec7e0f9ed9d67e2ec6ff77",
-    "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/1.5.12.RELEASE/spring-boot-cli-1.5.12.RELEASE-bin.zip",
-    "extract_dir": "spring-1.5.12.RELEASE",
+    "hash": "17b42622d708e725a50c81d17967eefaadc8a0ef048a0d394ce2662da7b8b7ba",
+    "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/2.0.1.RELEASE/spring-boot-cli-2.0.1.RELEASE-bin.zip",
+    "extract_dir": "spring-2.0.1.RELEASE",
     "bin": "bin\\spring.bat",
     "suggest": {
         "JDK": [


### PR DESCRIPTION
Auto-Update rolled it back to 1.5.12 because it was published after 2.0.1 https://github.com/spring-projects/spring-boot/releases