### PR TITLE
Add app manifest for Force.com CLI

### DIFF
--- a/force.json
+++ b/force.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "http://force-cli.herokuapp.com/",
+    "version": "0.24.1",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/ForceCLI/force/releases/download/v0.24.1/force_windows_386.exe#/force.exe",
+            "hash": "31e568879c2c407b123f94cb3bb589d25e04f2b14f02445990c966815ad92113"
+        },
+        "64bit": {
+            "url": "https://github.com/ForceCLI/force/releases/download/v0.24.1/force_windows_amd64.exe#/force.exe",
+            "hash": "64becf76831abe489e44a526712cbbc5b1996eefe7b73024b7346b53c03f4e14"
+        }
+    },
+    "bin": "force.exe",
+    "description": "Force.com CLI tool"
+}


### PR DESCRIPTION
@lukesampson scoop is super useful.  Thanks so much!

I'm proposing to add a manifest for the Force.com CLI, which is a command-line tool I use all the time for interacting with the Salesforce PAAS backend.  Thanks for your consideration!