### PR TITLE
Update GIMP to version 2.10.0

### DIFF
--- a/gimp.json
+++ b/gimp.json
@@ -2,12 +2,8 @@
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0",
     "version": "2.10.0",
-    "architecture": {
-        "64bit": {
-            "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.0-x64-setup.exe",
-            "hash": "1babc967a37ad4692d0c2cfb76309c381bab0f4208077e9e2f38c8deec5e0a44"
-        }
-    },
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.0-setup-1.exe",
+    "hash": "76819fad10db52844bcf3d1f6a5cfbf1671b3eff783e63149af7218c8d191bf5",
     "installer": {
         "args": [
             "/VERYSILENT",
@@ -28,15 +24,11 @@
         ]
     ],
     "checkver": {
-        "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/",
-        "re": "0.0_LATEST-IS-([\\d.]+)"
+        "url": "https://www.gimp.org/downloads/",
+        "re": "gimp-([\\d.]+)-setup-1.exe"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$version-x64-setup.exe"
-            }
-        },
+        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$version-setup-1.exe",
         "hash": {
             "url": "$baseurl/SHA256SUMS"
         }

--- a/gimp.json
+++ b/gimp.json
@@ -1,9 +1,13 @@
 {
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0",
-    "version": "2.8.22",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v2.8/windows/gimp-2.8.22-setup.exe",
-    "hash": "a2e52129a28feec1ee3f22f5aaf9bdecbb02d51af6da408ace0a2ac2e0365c8b",
+    "version": "2.10.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.0-x64-setup.exe",
+            "hash": "1babc967a37ad4692d0c2cfb76309c381bab0f4208077e9e2f38c8deec5e0a44"
+        }
+    },
     "installer": {
         "args": [
             "/VERYSILENT",
@@ -19,16 +23,20 @@
     },
     "bin": [
         [
-            "bin\\gimp-2.8.exe",
+            "bin\\gimp-2.10.exe",
             "gimp"
         ]
     ],
     "checkver": {
-        "url": "https://download.gimp.org/mirror/pub/gimp/v2.8/",
+        "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/",
         "re": "0.0_LATEST-IS-([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$version-setup.exe",
+        "architecture": {
+            "64bit": {
+                "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$version-x64-setup.exe"
+            }
+        },
         "hash": {
             "url": "$baseurl/SHA256SUMS"
         }


### PR DESCRIPTION
GIMP 2.10 is out. Updated the manifest to the new version.

It seems that there's only a 64bit build, so I've added an `architecture` tag. I don't know if that will cause problems when updating.