### PR TITLE
Filezilla: removed hash url

### DIFF
--- a/filezilla.json
+++ b/filezilla.json
@@ -34,9 +34,6 @@
             "32bit": {
                 "url": "https://download.filezilla-project.org/client/FileZilla_$version_win32.zip"
             }
-        },
-        "hash": {
-            "url": "https://download.filezilla-project.org/client/FileZilla_$version.sha512"
         }
     }
 }


### PR DESCRIPTION
I removed the hash url from the autoupdate section.