### PR TITLE
XMedia-Recode: extract_dir name was reverted

### DIFF
--- a/xmedia-recode.json
+++ b/xmedia-recode.json
@@ -11,7 +11,7 @@
             "XMedia Recode"
         ]
     ],
-    "extract_dir": "XMedia Recode",
+    "extract_dir": "XMediaRecode3434",
     "pre_install": "if(!(test-path $dir\\Fav.ini)) { write-host \"\" | out-file -encoding oem $dir\\Fav.ini }",
     "persist": [
         "XMediaRecode.ini",
@@ -23,6 +23,6 @@
     },
     "autoupdate": {
         "url": "https://www.xmedia-recode.de/download/XMediaRecode$cleanVersion.zip",
-        "extract_dir": "XMedia Recode"
+        "extract_dir": "XMediaRecode$cleanVersion"
     }
 }


### PR DESCRIPTION
Following on from #890, the naming scheme for the inner dir was reverted back again in v3.4.3.4