### PR TITLE
Add shortcuts for idea-ultimate, idea-ultimate-eap, idea-eap, and fix shortcut name for idea

### DIFF
--- a/idea-eap.json
+++ b/idea-eap.json
@@ -3,9 +3,6 @@
     "homepage": "https://www.jetbrains.com/idea/",
     "url": "https://download.jetbrains.com/idea/ideaIC-181.4203.519.win.zip",
     "hash": "48a907a1e29a6285c75840768219bbec6a3b6ed85fcea30b5cc82f3c9e2d7163",
-    "bin": "bin\\idea.bat",
-    "env_add_path": "bin",
-    "notes": "Please restart your command line for changes to take effect.",
     "architecture": {
         "64bit": {
             "bin": "bin\\idea64.exe",

--- a/idea-eap.json
+++ b/idea-eap.json
@@ -6,6 +6,26 @@
     "bin": "bin\\idea.bat",
     "env_add_path": "bin",
     "notes": "Please restart your command line for changes to take effect.",
+    "architecture": {
+        "64bit": {
+            "bin": "bin\\idea64.exe",
+            "shortcuts": [
+                [
+                    "bin/idea64.exe",
+                    "IntelliJ IDEA Community EAP"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "bin\\idea.exe",
+            "shortcuts": [
+                [
+                    "bin/idea.exe",
+                    "IntelliJ IDEA Community EAP"
+                ]
+            ]
+        }
+    },
     "checkver": {
         "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&type=eap",
         "jp": "$..build"

--- a/idea-ultimate-eap.json
+++ b/idea-ultimate-eap.json
@@ -6,6 +6,26 @@
     "bin": "bin\\idea.bat",
     "env_add_path": "bin",
     "notes": "Please restart your command line for changes to take effect.",
+    "architecture": {
+        "64bit": {
+            "bin": "bin\\idea64.exe",
+            "shortcuts": [
+                [
+                    "bin/idea64.exe",
+                    "IntelliJ IDEA Ultimate EAP"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "bin\\idea.exe",
+            "shortcuts": [
+                [
+                    "bin/idea.exe",
+                    "IntelliJ IDEA Ultimate EAP"
+                ]
+            ]
+        }
+    },
     "checkver": {
         "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=eap",
         "jp": "$..build"

--- a/idea-ultimate-eap.json
+++ b/idea-ultimate-eap.json
@@ -3,9 +3,6 @@
     "homepage": "https://www.jetbrains.com/idea/",
     "url": "https://download.jetbrains.com/idea/ideaIU-181.4203.519.win.zip",
     "hash": "668643abd0c8fcb41684db94010d02363771892d8105c266df4326d9cfe65da5",
-    "bin": "bin\\idea.bat",
-    "env_add_path": "bin",
-    "notes": "Please restart your command line for changes to take effect.",
     "architecture": {
         "64bit": {
             "bin": "bin\\idea64.exe",

--- a/idea-ultimate.json
+++ b/idea-ultimate.json
@@ -3,9 +3,6 @@
     "homepage": "https://www.jetbrains.com/idea/",
     "url": "https://download.jetbrains.com/idea/ideaIU-2018.1.3.win.zip",
     "hash": "a0316579887306f44b14e9d592b24d8d94e5201655fadc12784d101492531b8d",
-    "bin": "bin\\idea.bat",
-    "env_add_path": "bin",
-    "notes": "Please restart your command line for changes to take effect.",
     "architecture": {
         "64bit": {
             "bin": "bin\\idea64.exe",

--- a/idea-ultimate.json
+++ b/idea-ultimate.json
@@ -6,6 +6,26 @@
     "bin": "bin\\idea.bat",
     "env_add_path": "bin",
     "notes": "Please restart your command line for changes to take effect.",
+    "architecture": {
+        "64bit": {
+            "bin": "bin\\idea64.exe",
+            "shortcuts": [
+                [
+                    "bin/idea64.exe",
+                    "IntelliJ IDEA Ultimate"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "bin\\idea.exe",
+            "shortcuts": [
+                [
+                    "bin/idea.exe",
+                    "IntelliJ IDEA Ultimate"
+                ]
+            ]
+        }
+    },
     "checkver": {
         "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=release",
         "jp": "$..version"

--- a/idea.json
+++ b/idea.json
@@ -11,7 +11,7 @@
             "shortcuts": [
                 [
                     "bin/idea64.exe",
-                    "IntelliJ IDEA Ultimate"
+                    "IntelliJ IDEA Community"
                 ]
             ]
         },
@@ -20,7 +20,7 @@
             "shortcuts": [
                 [
                     "bin/idea.exe",
-                    "IntelliJ IDEA Ultimate"
+                    "IntelliJ IDEA Community"
                 ]
             ]
         }

--- a/idea.json
+++ b/idea.json
@@ -3,8 +3,6 @@
     "homepage": "https://www.jetbrains.com/idea/",
     "url": "https://download.jetbrains.com/idea/ideaIC-2018.1.3.win.zip",
     "hash": "bfc4b66cac6880659833e3d98cda328629be0ecce3d522a0764323429fc67cc1",
-    "env_add_path": "bin",
-    "notes": "Please restart your command line for changes to take effect.",
     "architecture": {
         "64bit": {
             "bin": "bin\\idea64.exe",


### PR DESCRIPTION
I want to use both Idea IntelliJ Ultimate and Community version as EAP version at the same time. I find only idea.json has shortcuts (with the wrong name). I also find the path add is not required for shortcuts.