### PR TITLE
Update MobaXterm to v10.5

### DIFF
--- a/mobaxterm.json
+++ b/mobaxterm.json
@@ -1,24 +1,25 @@
 {
-    "version": "v9.4",
-    "url": "https://mobaxterm.mobatek.net/MobaXterm_v9.4.zip",
+    "version": "10.5",
+    "url": "https://download.mobatek.net/10520180106182002/MobaXterm_Portable_v10.5.zip",
     "homepage": "https://mobaxterm.mobatek.net/",
-    "hash": "c9c002995a7ac92e145ae42519b576bb89f5b8b8c52c1462b607c3d03b5f47d7",
+    "checkver": {
+        "url": "https://mobaxterm.mobatek.net/download-home-edition.html",
+        "re": "MobaXterm Home Edition v([\\d.]+)"
+    },
+    "hash": "34ff15ade9a7e435509aaa4747eb5e9792eb68232bfbe0cdeee0a228dcae31d2",
     "bin": [
         [
-            "mobaxterm_personal_9.4.exe",
+            "MobaXterm_Personal_10.5.exe",
             "mobaxterm"
-        ],
-        [
-            "mobaxterm_personal_customizer_9.4.exe",
-            "mobaxterm-customizer"
         ]
     ],
     "persist": [
-        "MobaXterm.ini"
+        "MobaXterm.ini",
+        "MobaXterm backup.zip"
     ],
     "shortcuts": [
         [
-            "mobaxterm_personal_9.4.exe",
+            "MobaXterm_Personal_10.5.exe",
             "MobaXterm Personal"
         ]
     ]


### PR DESCRIPTION
Changes:
- update to v10.5
- remove 'v' from version
- add `checkVer` for automatic update checks
- remove non-existing MobaXterm Customizer (not delivered anymore)
- persist backups of configuration file changes

I removed the `v` from the `version` tag because it seems to be the usual to not use the prefix, please correct me if I'm wrong.

### Picture of the Archive and App Folder
![grafik](https://user-images.githubusercontent.com/3075401/40350961-83a4fe36-5dab-11e8-905c-5b200355400f.png)


