### PR TITLE
Add Bitmessage

### DIFF
--- a/bitmessage.json
+++ b/bitmessage.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://bitmessage.org/",
+    "version": "0.6.3.2",
+    "license": "https://github.com/Bitmessage/PyBitmessage/blob/master/LICENSE",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Bitmessage/PyBitmessage/releases/download/0.6.3.2/Bitmessage_x86_0.6.3.2.exe",
+            "hash": "e714337ac069b06aa5ba66cc37c55ebf6da0546838e96850818474544742fe58"
+        },
+        "32bit": {
+            "url": "https://github.com/Bitmessage/PyBitmessage/releases/download/0.6.3.2/Bitmessage_x86_0.6.3.2.exe",
+            "hash": "e714337ac069b06aa5ba66cc37c55ebf6da0546838e96850818474544742fe58"
+        }
+    },
+    "bin": [
+        "Bitmessage_x86_0.6.3.2.exe"
+    ],
+    "shortcuts": [
+        [
+            "Bitmessage_x86_0.6.3.2.exe",
+            "Bitmessage"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Bitmessage/PyBitmessage"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Bitmessage/PyBitmessage/releases/download/$version/Bitmessage_x64_$version.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/Bitmessage/PyBitmessage/releases/download/$version/Bitmessage_x86_$version.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
It would be preferable if this manifest exposed a binary such as `Bitmessage.exe` to the PATH instead of `Bitmessage_x86_0.6.3.2.exe`.  Do any of you know how to do this?

[Bitmessage](https://bitmessage.org/) does not have a 64-bit binary for the `0.6.3.2` release but they are stated they will recontinue 64-bit builds at some future release.  Right now, both 32-bit and 64-bit fields in the manifest point to the 32-bit build.