### PR TITLE
Remove nonexistent executables from wireshark

### DIFF
--- a/wireshark.json
+++ b/wireshark.json
@@ -6,22 +6,14 @@
     "bin": [
         "App\\Wireshark\\capinfos.exe",
         "App\\Wireshark\\captype.exe",
-        "App\\Wireshark\\dftest.exe",
         "App\\Wireshark\\dumpcap.exe",
         "App\\Wireshark\\editcap.exe",
-        "App\\Wireshark\\exntest.exe",
-        "App\\Wireshark\\lemon.exe",
         "App\\Wireshark\\mergecap.exe",
-        "App\\Wireshark\\oids_test.exe",
         "App\\Wireshark\\randpkt.exe",
         "App\\Wireshark\\rawshark.exe",
-        "App\\Wireshark\\reassemble_test.exe",
         "App\\Wireshark\\reordercap.exe",
         "App\\Wireshark\\text2pcap.exe",
-        "App\\Wireshark\\tfshark.exe",
         "App\\Wireshark\\tshark.exe",
-        "App\\Wireshark\\tvbtest.exe",
-        "App\\Wireshark\\wmem_test.exe",
         [
             "WiresharkPortable.exe",
             "Wireshark"


### PR DESCRIPTION
These executables were removed from the Wireshark PortableApps build in change [25291](https://code.wireshark.org/review/#/c/25291/). This broke the package installation, as scoop tried to shim them.