### PR TITLE
WIP: Add Angry IP Scanner

### DIFF
--- a/ipscan.json
+++ b/ipscan.json
@@ -1,0 +1,46 @@
+{
+    "homepage": "http://angryip.org/",
+    "version": "3.5.2",
+    "license": "GPL-2.0-or-later",
+    // 64bit URL needs 64bit Java
+    // and 32bit URL needs 32bit Java
+    // TODO: Use ``java -d64 -version`` and ``java -d32 -version`` to detect
+    // which URL to use
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/angryip/ipscan/releases/download/3.5.2/ipscan-win64-3.5.2.exe#/ipscan.exe",
+            "hash": "a75a10d43c1ec77f2e59232d6c4f66662d7d3c9d28195d3b4aa9e201d0d28ae6"
+        },
+        "32bit": {
+            "url": "https://github.com/angryip/ipscan/releases/download/3.5.2/ipscan-win32-3.5.2.exe#/ipscan.exe",
+            "hash": "bb1ce1e7d92f6ac0da1bd1b8cee56d6139b9dc41f5821e58e7d07063805e7b3f"
+        }
+    },
+    "bin": [
+        "ipscan.exe"
+    ],
+    "shortcuts": [
+        [
+            "ipscan.exe",
+            "Angry IP Scanner"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/angryip/ipscan"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/angryip/ipscan/releases/download/$version/ipscan-win64-$version.exe#/ipscan.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/angryip/ipscan/releases/download/$version/ipscan-win32-$version.exe#/ipscan.exe"
+            }
+        }
+    },
+    "suggest": {
+        "JRE": [
+            "java/oraclejre8"
+        ]
+    }
+}

--- a/ipscan.json
+++ b/ipscan.json
@@ -2,10 +2,6 @@
     "homepage": "http://angryip.org/",
     "version": "3.5.2",
     "license": "GPL-2.0-or-later",
-    // 64bit URL needs 64bit Java
-    // and 32bit URL needs 32bit Java
-    // TODO: Use ``java -d64 -version`` and ``java -d32 -version`` to detect
-    // which URL to use
     "architecture": {
         "64bit": {
             "url": "https://github.com/angryip/ipscan/releases/download/3.5.2/ipscan-win64-3.5.2.exe#/ipscan.exe",
@@ -16,6 +12,7 @@
             "hash": "bb1ce1e7d92f6ac0da1bd1b8cee56d6139b9dc41f5821e58e7d07063805e7b3f"
         }
     },
+    "notes": "If you have 64bit Windows but 32bit Java, you MUST reinstall this package with the following option: --arch 32bit",
     "bin": [
         "ipscan.exe"
     ],

--- a/ipscan.json
+++ b/ipscan.json
@@ -12,7 +12,7 @@
             "hash": "bb1ce1e7d92f6ac0da1bd1b8cee56d6139b9dc41f5821e58e7d07063805e7b3f"
         }
     },
-    "notes": "If you have 64bit Windows but 32bit Java, you MUST reinstall this package with the following option: --arch 32bit",
+    "notes": "If you have 64bit Windows but 32bit Java, you MUST reinstall 'ipscan' with the following option:\n\t--arch 32bit",
     "bin": [
         "ipscan.exe"
     ],


### PR DESCRIPTION
The `64bit` URL is for users that have 64-bit Java installed and the `32bit` URL is for users with the 32-bit version.  However, users with a 64-bit OS might have the 32-bit version of Java installed and be unable to use the binary at the `64bit` URL.

Java's architecture can be detected with the commands: `java -d64 -version` and `java -d32 -version`, and they should yield a non-zero return code when their respective versions are not installed.

Does any of you know how to add some simple logic to select the proper URL based on the user's Java architecture?