### PR TITLE
Update Kibana to 6.2.4 and fix autoupdate

### DIFF
--- a/kibana.json
+++ b/kibana.json
@@ -1,9 +1,10 @@
+
 {
     "homepage": "https://www.elastic.co/products/kibana",
-    "version": "5.6.1",
-    "url": "https://artifacts.elastic.co/downloads/kibana/kibana-5.6.1-windows-x86.zip",
-    "hash": "sha1:0d5a19de15e6ed3484f32dd77d44c7b7f66b72de",
-    "extract_dir": "kibana-5.6.1-windows-x86",
+    "version": "6.2.4",
+    "url": "https://artifacts.elastic.co/downloads/kibana/kibana-6.2.4-windows-x86_64.zip",
+    "hash": "sha512:531033b133629de2067c6c86e031e43e6daf1c3ab63c9764b5082f4be48dd1a98fa8a6c7783550d3aa7fb5a50a2c07fc1e87e708fddee6b2a411e1b1f8ea4229",
+    "extract_dir": "kibana-6.2.4-windows-x86_64",
     "bin": [
         [
             "bin\\kibana.bat",
@@ -27,13 +28,13 @@
     },
     "checkver": {
         "url": "https://www.elastic.co/downloads/past-releases",
-        "re": "kibana-([\\d.]+)-windows-x86.zip.sha1"
+        "re": "kibana-([\\d.]+)-windows-x86_64.zip"
     },
     "autoupdate": {
-        "url": "https://artifacts.elastic.co/downloads/kibana/kibana-$version-windows-x86.zip",
-        "extract_dir": "kibana-$version-windows-x86",
+        "url": "https://artifacts.elastic.co/downloads/kibana/kibana-$version-windows-x86_64.zip",
+        "extract_dir": "kibana-$version-windows-x86_64",
         "hash": {
-            "url": "$url.sha1"
+            "url": "$url.sha512"
         }
     }
 }


### PR DESCRIPTION
* Update Kibana to 6.2.4 so that it use the same version with Elasticsearch
* Fix autoupdate fail due to url changed
