### PR TITLE
Update elasticsearch's post_install

### DIFF
--- a/elasticsearch.json
+++ b/elasticsearch.json
@@ -31,8 +31,8 @@
         "plugins"
     ],
     "post_install": "
-    # we have to overwrite SCRIPT_DIR because elasticsearch.in.bat doesn't care if SCRIPT_DIR or ES_HOME are already set ...
-    (gc \"$original_dir\\bin\\elasticsearch.in.bat\") | % { $_ -replace 'set SCRIPT_DIR=%~dp0', \"set SCRIPT_DIR=$original_dir\" } | sc \"$original_dir\\bin\\elasticsearch.in.bat\"
+    # we have to overwrite SCRIPT because elasticsearch-env.bat doesn't care if SCRIPT or ES_HOME are already set ...
+    (gc \"$original_dir\\bin\\elasticsearch-env.bat\") | % { $_ -replace 'set SCRIPT=%0', \"set SCRIPT=$original_dir\\bin\\elasticsearch.bat\" } | sc \"$original_dir\\bin\\elasticsearch-env.bat\"
     # use persistent data/logs directory
     (gc \"$dir\\config\\elasticsearch.yml\") | % { $_ -replace '#path.data: /path/to/data', \"path.data: $persist_dir\\data\" } | % { $_ -replace '#path.logs: /path/to/logs', \"path.logs: $persist_dir\\logs\" } | sc \"$dir\\config\\elasticsearch.yml\"
     ",


### PR DESCRIPTION
* Fix the issue [Elasticsearch post-install script error](https://github.com/lukesampson/scoop/issues/2172) which was opened in the main bucket
* ```elasticsearch.in.bat``` was renamed to ```elasticsearch-env.bat``` in Elasticsearch 6.2.4
* The method to find out ES_HOME was also changed