### PR TITLE
Fix Rufus hash

### DIFF
--- a/rufus.json
+++ b/rufus.json
@@ -2,7 +2,7 @@
     "homepage": "https://rufus.akeo.ie/",
     "version": "3.0",
     "license": "GPL-3.0",
-    "hash": "ff55d7bc3fe6cb2958e4bdda3d4a4a8e528fb67d9194991e9539d97a55cda2a3",
+    "hash": "5b84c76c94dbad568851a0401d5c8c6b6157fb023b9b203f33dc7de2c36803cb",
     "url": "https://rufus.akeo.ie/downloads/rufus-3.0p.exe#/rufus.exe",
     "bin": "rufus.exe",
     "checkver": {


### PR DESCRIPTION
Manually downloading the [Rufus executable](https://rufus.akeo.ie/downloads/rufus-3.0p.exe) over a TLS connection and computing its sha256 hash produces the hash prior to #960, so the PR likely made a simple mistake.  This PR changes the hash back to its original value