### PR TITLE
Add winpython manifest

### DIFF
--- a/winpython.json
+++ b/winpython.json
@@ -1,0 +1,44 @@
+{
+    "version": "3.6.5.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython64-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "sha1:4cb2e0144a182343a129519b837daa6de0b728dc",
+            "extract_dir": "python-3.6.5.amd64"
+        },
+        "32bit": {
+            "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython32-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "sha1:b0326e3af9e7f56c948bb24dcba2ba8069abb51e",
+            "extract_dir": "python-3.6.5"
+        }
+    },
+    "homepage": "https://winpython.github.io/",
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts"
+    ],
+    "checkver": {
+        "url": "https://winpython.github.io/md5_sha1.txt",
+        "re": "-([\\d.]+)Zero.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe#/dl.7z",
+                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion.amd64"
+            },
+            "32bit": {
+                "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe#/dl.7z",
+                "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion"
+            }
+        }
+    }
+}

--- a/winpython.json
+++ b/winpython.json
@@ -3,13 +3,13 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython64-3.6.5.0Zero.exe#/dl.7z",
-            "hash": "sha1:4cb2e0144a182343a129519b837daa6de0b728dc",
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython64-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "83cb7ccf519a7fffc0cf6b00f0cb2d45f8d4cbf55b6e9b463fcd2534fa6f450a",
             "extract_dir": "python-3.6.5.amd64"
         },
         "32bit": {
-            "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython32-3.6.5.0Zero.exe#/dl.7z",
-            "hash": "sha1:b0326e3af9e7f56c948bb24dcba2ba8069abb51e",
+            "url": "https://downloads.sourceforge.net/project/winpython/WinPython_3.6/3.6.5.0/WinPython32-3.6.5.0Zero.exe#/dl.7z",
+            "hash": "83cb7ccf519a7fffc0cf6b00f0cb2d45f8d4cbf55b6e9b463fcd2534fa6f450a",
             "extract_dir": "python-3.6.5"
         }
     },
@@ -32,13 +32,17 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe#/dl.7z",
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython64-$versionZero.exe#/dl.7z",
                 "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion.amd64"
             },
             "32bit": {
-                "url": "https://netcologne.dl.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe#/dl.7z",
+                "url": "https://downloads.sourceforge.net/project/winpython/WinPython_$majorVersion.$minorVersion/$version/WinPython32-$versionZero.exe#/dl.7z",
                 "extract_dir": "python-$majorVersion.$minorVersion.$patchVersion"
             }
+        },
+        "hash": {
+            "url": "https://winpython.github.io/md5_sha1.txt",
+            "find": "([a-fA-F\\d]{64})\\s|\\s$basename"
         }
     }
 }


### PR DESCRIPTION
Not really sure if this belongs here, but since some people (me included) had trouble with the Python installer not being always handled properly by Scoop and/or not installing some .dll files and libraries even when installed manually (https://github.com/lukesampson/scoop/issues/504, https://github.com/lukesampson/scoop/issues/324, https://github.com/lukesampson/scoop/issues/2290, https://github.com/lukesampson/scoop/issues/856), I thought a 100% portable and working Python distribution could be useful for many.

I made it so that only Python is extracted, while the GUI tool developed by winpython is not, so no 3rd party software will be extracted (no launchers, no configuration tools other than Scoop).

I hope you'll find this useful.