### PR TITLE
add autohotkey-installer

### DIFF
--- a/autohotkey-installer.json
+++ b/autohotkey-installer.json
@@ -2,13 +2,13 @@
     "version": "1.1.29.01",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.autohotkey.com/",
-    "pre_install": " Write-Host 'Installing AutoHotKey in silent mode using installer ( full shell menu items creation )' -ForegroundColor Magenta ",
+    "pre_install": " Write-Host 'Installing AutoHotKey with their installer and its own options ( create registry keys removed by uninstaller )' -ForegroundColor Magenta ",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-reg.exe",
+            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-installer.exe",
             "hash": "0e0006f9b4544dc71054debc678baf120bdbd3c96c791b84b911a97368835ca6",
             "installer": {
-                "file": "autohotkey-reg.exe",
+                "file": "autohotkey-installer.exe",
                 "args": [
                     "/S",
                     "/x64",
@@ -16,10 +16,10 @@
                     "/IsHostApp=1",
                     "/D=$dir"
                 ],
-                "keep": "true"
+                "keep": true
             },
             "uninstaller": {
-                "file": "autohotkey-reg.exe",
+                "file": "autohotkey-installer.exe",
                 "args": [
                     "/Uninstall"
                 ]
@@ -33,10 +33,10 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-reg.exe",
+            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-installer.exe",
             "hash": "0e0006f9b4544dc71054debc678baf120bdbd3c96c791b84b911a97368835ca6",
             "installer": {
-                "file": "autohotkey-reg.exe",
+                "file": "autohotkey-installer.exe",
                 "args": [
                     "/S",
                     "/U32",
@@ -44,10 +44,10 @@
                     "/IsHostApp=1",
                     "/D=$dir"
                 ],
-                "keep": "true"
+                "keep": true
             },
             "uninstaller": {
-                "file": "autohotkey-reg.exe",
+                "file": "autohotkey-installer.exe",
                 "args": [
                     "/Uninstall"
                 ]
@@ -67,10 +67,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-reg.exe"
+                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-installer.exe"
             },
             "32bit": {
-                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-reg.exe"
+                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-installer.exe"
             }
         }
     }

--- a/autohotkey-reg.json
+++ b/autohotkey-reg.json
@@ -1,0 +1,77 @@
+{
+    "version": "1.1.29.01",
+    "license": "GPL-2.0-or-later",
+    "homepage": "https://www.autohotkey.com/",
+    "pre_install": " Write-Host 'Installing AutoHotKey in silent mode using installer ( full shell menu items creation )' -ForegroundColor Magenta ",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-reg.exe",
+            "hash": "0e0006f9b4544dc71054debc678baf120bdbd3c96c791b84b911a97368835ca6",
+            "installer": {
+                "file": "autohotkey-reg.exe",
+                "args": [
+                    "/S",
+                    "/x64",
+                    "/uiAccess=0",
+                    "/IsHostApp=1",
+                    "/D=$dir"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "autohotkey-reg.exe",
+                "args": [
+                    "/Uninstall"
+                ]
+            },
+            "bin": [
+                [
+                    "autohotkeyu64.exe",
+                    "autohotkey"
+                ],
+                "compiler/ahk2exe.exe"
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.29.01/AutoHotkey_1.1.29.01_setup.exe#/autohotkey-reg.exe",
+            "hash": "0e0006f9b4544dc71054debc678baf120bdbd3c96c791b84b911a97368835ca6",
+            "installer": {
+                "file": "autohotkey-reg.exe",
+                "args": [
+                    "/S",
+                    "/U32",
+                    "/uiAccess=0",
+                    "/IsHostApp=1",
+                    "/D=$dir"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "autohotkey-reg.exe",
+                "args": [
+                    "/Uninstall"
+                ]
+            },
+            "bin": [
+                [
+                    "autohotkeyu32.exe",
+                    "autohotkey"
+                ],
+                "compiler/ahk2exe.exe"
+            ]
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/lexikos/autohotkey_l"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-reg.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v$version/AutoHotkey_$version_setup.exe#/autohotkey-reg.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I use autohotkey a lot and was a bit frustrated by the original scoop install. After readings i propose this manifest as a new type of AHK installation using their installer and its command line options to get a more complete installation with shell menu entries.
Please consider adding it if you dont see too many mistakes, i am quite new in this.
 