### PR TITLE
Update winmerge2011 to version 0.2011.008.226

### DIFF
--- a/winmerge2011.json
+++ b/winmerge2011.json
@@ -1,14 +1,15 @@
 {
     "homepage": "https://bitbucket.org/jtuc/winmerge2011",
-    "version": "0.2011.007.444",
+    "version": "0.2011.008.226",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "32bit": {
-            "url": "https://bitbucket.org/jtuc/winmerge2011/downloads/WinMerge_0.2011.007.444_change_7z_to_exe_if_you_want_a_setup.7z",
-            "hash": "sha1:492ca287ee3b07b6886208c2f9b74064bc0a0a6e"
+            "url": "https://bitbucket.org/jtuc/winmerge2011/downloads/WinMerge_0.2011.008.226_setup.cpl#/dl.7z",
+            "hash": "4ccc80404a86c3920000ecb708da7bb5732040ebd5577c4b9b48a04b978f07bb"
         },
         "64bit": {
-            "url": "https://bitbucket.org/jtuc/winmerge2011/downloads/WinMerge_0.2011.007.444_x64_change_7z_to_exe_if_you_want_a_setup.7z",
-            "hash": "sha1:936ab9585e92a3704b3ddc7c02d8b775e2348df6"
+            "url": "https://bitbucket.org/jtuc/winmerge2011/downloads/WinMerge_0.2011.008.226_x64_setup.cpl#/dl.7z",
+            "hash": "09b9f1baeea09ae6c99bc6a9b7314c2c35a2bffbc340b592ec4f20bb1b552e0e"
         }
     },
     "bin": "WinMergeU.exe",


### PR DESCRIPTION
Maintainer also changed to CPL file format as the only download option, but it can still be extracted with 7-Zip. Details: https://bitbucket.org/jtuc/winmerge2011/downloads/Rationale_for_using_CPL_as_an_installer_format.txt

First contrib, so please let me know if I should do anything different in the future.