### PR TITLE
pandoc: Update mechanism and version

### DIFF
--- a/pandoc.json
+++ b/pandoc.json
@@ -1,17 +1,32 @@
 {
     "homepage": "https://pandoc.org/",
-    "version": "2.1.3",
+    "version": "2.2.1",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/jgm/pandoc/releases/download/2.1.3/pandoc-2.1.3-windows.msi",
-    "hash": "2b8710e00ac50c2f8266bdd3bc10d0899168be9ff8b84437c09a891cfc434e4b",
-    "extract_dir": "Pandoc",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-windows-x86_64.zip",
+            "hash": "034cb93640ae31d0739539d1ad9e6aa4dce36433a366e245aa0a0ab158ff156d"
+        },
+        "32bit": {
+            "url": "https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-windows-i386.zip",
+            "hash": "7190abc7fb217ca242ff76ef300b2de4b90897103671d5ec74944c4ce70bf80d"
+        }
+    },
+    "extract_dir": "pandoc-2.2.1",
     "bin": "pandoc.exe",
     "checkver": {
-        "url": "https://github.com/jgm/pandoc/releases",
-        "re": "pandoc-([^-]+)-windows\\.msi"
+        "github": "https://github.com/jgm/pandoc"
     },
     "autoupdate": {
-        "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows.msi"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows-x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/jgm/pandoc/releases/download/$version/pandoc-$version-windows-i386.zip"
+            }
+        },
+        "extract_dir": "pandoc-$version"
     },
     "suggest": {
         "MiKTeX": [


### PR DESCRIPTION
Update to the newer github autoupdate mechanism.

Support new 64-bit pandoc releases.

Update to 2.2.1