### PR TITLE
Add WinCompose: easily write special characters

### DIFF
--- a/WinCompose.json
+++ b/WinCompose.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://wincompose.info/",
+    "description": "Easily write special characters using short key combinations.",
+    "license": "https://github.com/samhocevar/wincompose/blob/master/COPYING",
+    "version": "0.8.0",
+    "url": "https://github.com/samhocevar/wincompose/releases/download/v0.8.0/WinCompose-NoInstall-0.8.0.zip",
+    "hash": "sha256:bfdfa0d472f008d921a571070addcedb82d91e37fec101be0ecf16369d3aaff3",
+    "extract_dir": "WinCompose-NoInstall-0.8.0",
+    "bin": [
+        "wincompose.exe"
+    ],
+    "persist": [
+        "settings.ini"
+    ],
+    "checkver": {
+        "github": "https://github.com/samhocevar/wincompose"
+    },
+    "autoupdate": {
+        "url": "https://github.com/samhocevar/wincompose/releases/download/v$version/WinCompose-NoInstall-$version.zip",
+        "extract_dir": "WinCompose-NoInstall-$version"
+    }
+}


### PR DESCRIPTION
A handy tool sitting in the system tray, adding the possibility to write accented characters (or any Unicode pattern) from a hot key.