### PR TITLE
Add Mill, a next generation Scala build tool

### DIFF
--- a/mill.json
+++ b/mill.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.3",
+    "license": "MIT",
+    "url": "https://github.com/lihaoyi/mill/releases/download/0.2.3/0.2.3-14-c7c914#/mill.bat",
+    "bin": "mill.bat",
+    "homepage": "http://www.lihaoyi.com/mill/",
+    "hash": "611ff0ded19e798b308e1f974f3f1e7ca77bac2b9f350f0e895f25bc96117131",
+    "checkver": {
+        "url": "https://github.com/lihaoyi/mill/releases/latest",
+        "re": "<strong class=\"pl-1\">(?<version>\\d\\.\\d\\.\\d)(?<patch>-.+)</strong>",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "https://github.com/lihaoyi/mill/releases/download/$version/$matchVersion$matchPatch#/mill.bat"
+    },
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    }
+}


### PR DESCRIPTION
Mill is a new Scala build tool which aims to be much simpler than SBT.
One question that came up while building the autoupdate/checkver part:
Is it possible to find the longest/highest number via Regex?
The [patch numbers are > 9 here](https://github.com/lihaoyi/mill/releases/tag/0.2.3), so I can't seem to locate the highest version `14`, instead it finds the lexicographically later version `2`.
I assume it is not, but maybe someone has an idea 😃 