### PR TITLE
changed url for new installer

### DIFF
--- a/gimp.json
+++ b/gimp.json
@@ -3,7 +3,7 @@
     "license": "GPL-3.0",
     "version": "2.10.4",
     "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.4-setup-1.exe",
-    "hash": "23602c4a5c99eb4e9135e8df0a3f9cda6f4006c9a2223a55d1f241c1d3339520",
+    "hash": "608c12c66bccadbd46dd519b38337ebcda0cc6fc845bc3c8a943de43dccabfa9",
     "installer": {
         "args": [
             "/VERYSILENT",

--- a/gimp.json
+++ b/gimp.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0",
     "version": "2.10.4",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.4-setup.exe",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.4-setup-1.exe",
     "hash": "23602c4a5c99eb4e9135e8df0a3f9cda6f4006c9a2223a55d1f241c1d3339520",
     "installer": {
         "args": [


### PR DESCRIPTION
Previous installer is broken due to an error. See below:
https://gitlab.gnome.org/GNOME/gimp/issues/1789