### PR TITLE
Fix Nomacs shim and shortcut binary path

### DIFF
--- a/nomacs.json
+++ b/nomacs.json
@@ -4,14 +4,14 @@
     "license": "GPL-3.0",
     "url": "http://download.nomacs.org/portable/nomacs-3.10.2.zip",
     "hash": "e789b6c712ddbd490e5a1353462b215b8721418a8af1dc03de34576bb47d33cb",
-    "extract_dir": "nomacs-3.10.2",
-    "bin": "bin/nomacs.exe",
+    "extract_dir": "nomacs-3.10.2\\bin",
+    "bin": "nomacs.exe",
     "persist": [
         "settings.ini"
     ],
     "shortcuts": [
         [
-            "bin/nomacs.exe",
+            "nomacs.exe",
             "nomacs"
         ]
     ],
@@ -20,6 +20,6 @@
     },
     "autoupdate": {
         "url": "http://download.nomacs.org/portable/nomacs-$version.zip",
-        "extract_dir": "nomacs-$version"
+        "extract_dir": "nomacs-$version\\bin"
     }
 }

--- a/nomacs.json
+++ b/nomacs.json
@@ -5,13 +5,13 @@
     "url": "http://download.nomacs.org/portable/nomacs-3.10.2.zip",
     "hash": "e789b6c712ddbd490e5a1353462b215b8721418a8af1dc03de34576bb47d33cb",
     "extract_dir": "nomacs-3.10.2",
-    "bin": "nomacs.exe",
+    "bin": "bin/nomacs.exe",
     "persist": [
         "settings.ini"
     ],
     "shortcuts": [
         [
-            "nomacs.exe",
+            "bin/nomacs.exe",
             "nomacs"
         ]
     ],


### PR DESCRIPTION
Nomacs seems to have changed folder structure. Executable now resides in bin subfolder upon extraction.

```powershell
PS > scoop install nomacs
Installing 'nomacs' (3.10.2) [64bit]
Loading nomacs-3.10.2.zip from cache
Checking hash of nomacs-3.10.2.zip... ok.
Extracting... done.
Linking ~\scoop\apps\nomacs\current => ~\scoop\apps\nomacs\3.10.2
Creating shim for 'nomacs'.
Can't shim 'nomacs.exe': File doesn't exist.
```

Both bin and shortcut needs to be changed accordingly.