### PR TITLE
Add Textadept version 9.6

### DIFF
--- a/textadept.json
+++ b/textadept.json
@@ -4,7 +4,7 @@
     "version": "9.6",
     "license": "MIT",
     "extract_dir": "textadept_9.6.win32",
-    "url": "https://foicica.com/textadept/download/textadept_LATEST.win32.zip",
+    "url": "https://foicica.com/textadept/download/textadept_9.6.win32.zip",
     "hash": "fdde05ce4f9f3ff2b24e294f73e3170901880672e92ef4fa600dc1411b63d5f0",
     "bin": "textadept.exe",
     "shortcuts": [
@@ -12,5 +12,10 @@
             "textadept.exe",
             "Textadept"
         ]
-    ]
+    ],
+    "checkver": "Download \\(v([\\d.]+)\\)",
+    "autoupdate": {
+        "url": "https://foicica.com/textadept/download/textadept_$version.win32.zip",
+        "extract_dir": "textadept_$version.win32"
+    }
 }

--- a/textadept.json
+++ b/textadept.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://foicica.com/textadept/",
+    "description": "A fast, minimalist, and remarkably extensible cross-platform text editor",
+    "version": "9.6",
+    "license": "MIT",
+    "extract_dir": "textadept_9.6.win32",
+    "url": "https://foicica.com/textadept/download/textadept_LATEST.win32.zip",
+    "hash": "fdde05ce4f9f3ff2b24e294f73e3170901880672e92ef4fa600dc1411b63d5f0",
+    "bin": "textadept.exe",
+    "shortcuts": [
+        [
+            "textadept.exe",
+            "Textadept"
+        ]
+    ]
+}


### PR DESCRIPTION
This adds [Textadept](https://foicica.com/textadept/) to scoop-extras.

I couldn't figure out automatic updates here, since the download URL only has "LATEST" in it (and not the actual version number).