### PR TITLE
Add persist to audacity, mpv, bleachbit, and ccleaner. Fix Everything config

### DIFF
--- a/audacity.json
+++ b/audacity.json
@@ -10,6 +10,7 @@
             "Audacity"
         ]
     ],
+    "persist": "Portable Settings",
     "checkver": {
         "url": "https://fossies.org/windows/misc/",
         "re": "<B>audacity-win-([\\d.]+).zip</B>"

--- a/bleachbit.json
+++ b/bleachbit.json
@@ -13,6 +13,7 @@
             "BleachBit"
         ]
     ],
+    "persist": "BleachBit.ini",
     "checkver": {
         "github": "https://github.com/bleachbit/bleachbit"
     },

--- a/ccleaner.json
+++ b/ccleaner.json
@@ -30,6 +30,10 @@
             ]
         }
     },
+    "persist": "ccleaner.ini",
+    "pre_install": [
+        "if(!(test-path \"$dir\\ccleaner.ini\")) { Add-Content \"$dir\\ccleaner.ini\" $null }"
+    ],
     "checkver": {
         "url": "https://www.piriform.com/ccleaner/download",
         "re": "<strong>v([\\d.]+)</strong>"

--- a/everything.json
+++ b/everything.json
@@ -19,7 +19,7 @@
         "Everything.db"
     ],
     "pre_install": [
-        "if(!(test-path \"$dir\\Everything.ini\")) { Add-Content \"$dir\\Everything.ini\" $null }",
+        "if(!(test-path \"$dir\\Everything.ini\")) { & \"$dir\\Everything.exe\" -install-config default }",
         "if(!(test-path \"$dir\\Everything.db\")) { Add-Content \"$dir\\Everything.db\" $null }"
     ],
     "autoupdate": {

--- a/everything.json
+++ b/everything.json
@@ -19,7 +19,7 @@
         "Everything.db"
     ],
     "pre_install": [
-        "if(!(test-path \"$dir\\Everything.ini\")) { & \"$dir\\Everything.exe\" -install-config default }",
+        "if(!(test-path \"$dir\\Everything.ini\")) { & \"$dir\\Everything.exe\" -install-config null }",
         "if(!(test-path \"$dir\\Everything.db\")) { Add-Content \"$dir\\Everything.db\" $null }"
     ],
     "autoupdate": {

--- a/mpv-git.json
+++ b/mpv-git.json
@@ -20,6 +20,7 @@
             "mpv"
         ]
     ],
+    "persist": "portable_config",
     "post_install": [
         "(Get-Content \"$(shimdir $global)\\mpv.ps1\").replace('mpv.exe','mpv.com') | Out-File \"$(shimdir $global)\\mpv.ps1\" -encoding utf8",
         "(Get-Content \"$(shimdir $global)\\mpv.shim\").replace('mpv.exe','mpv.com') | Out-File \"$(shimdir $global)\\mpv.shim\" -encoding utf8"

--- a/mpv.json
+++ b/mpv.json
@@ -20,6 +20,7 @@
             "mpv"
         ]
     ],
+    "persist": "portable_config",
     "post_install": [
         "(Get-Content \"$(shimdir $global)\\mpv.ps1\").replace('mpv.exe','mpv.com') | Out-File \"$(shimdir $global)\\mpv.ps1\" -encoding utf8",
         "(Get-Content \"$(shimdir $global)\\mpv.shim\").replace('mpv.exe','mpv.com') | Out-File \"$(shimdir $global)\\mpv.shim\" -encoding utf8"


### PR DESCRIPTION
Makes audacity and mpv portable since they will read/write settings from persistent directory instead of %AppData%.
See:
+ https://wiki.audacityteam.org/wiki/Portable_Audacity
+ https://mpv.io/manual/master/#files-on-windows