### PR TITLE
Cleanup wox directory and update sqlitebrowser to use portable release

### DIFF
--- a/lunacy.json
+++ b/lunacy.json
@@ -3,7 +3,7 @@
     "license": "https://www.mersenne.org/legal/#EULA",
     "version": "3.8",
     "url": "https://desktop.icons8.com/lunacy/LunacyPortable_3.8.zip",
-    "hash": "4187f0238980ba18d8709e5aaca82ea44ba6c4e8f7f1d4f5b6ff7286468b4e26",
+    "hash": "83754c3ed24f7f2d63a437488430cbaf4bd64a2f540b7545246ad010f8a97164",
     "architecture": {
         "64bit": {
             "extract_dir": "Lunacy_Portable/x64"

--- a/lunacy.json
+++ b/lunacy.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://icons8.com/lunacy",
+    "license": "https://www.mersenne.org/legal/#EULA",
+    "version": "3.8",
+    "url": "https://desktop.icons8.com/lunacy/LunacyPortable_3.8.zip",
+    "hash": "4187f0238980ba18d8709e5aaca82ea44ba6c4e8f7f1d4f5b6ff7286468b4e26",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "Lunacy_Portable/x64"
+        },
+        "32bit": {
+            "extract_dir": "Lunacy_Portable/x86"
+        }
+    },
+    "bin": [
+        [
+            "Lunacy.exe",
+            "lunacy"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Lunacy.exe",
+            "Lunacy"
+        ]
+    ],
+    "checkver": {
+        "url": "https://docs.icons8.com/release-notes",
+        "re": "<h2 id=\"[\\d]+\">(?<version>[\\d.]+)</h2>"
+    },
+    "autoupdate": {
+        "url": "https://desktop.icons8.com/lunacy/LunacyPortable_$version.zip"
+    }
+}

--- a/simplewall.json
+++ b/simplewall.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://www.henrypp.org/product/simplewall",
+    "homepage": "https://www.henrypp.org/product/simplewall",
     "license": "GPL-3.0-only",
     "version": "2.3.3",
     "url": "https://github.com/henrypp/simplewall/releases/download/v.2.3.3/simplewall-2.3.3-bin.zip#/dl.7z",
@@ -29,8 +29,8 @@
         "if(!(test-path \"$dir\\simplewall.ini\")) { Add-Content \"$dir\\simplewall.ini\" $null }"
     ],
     "checkver": {
-        "url": "https://github.com/henrypp/simplewall/releases/latest",
-        "re": "/releases/tag/v.([\\d.]+)"
+        "github": "https://github.com/henrypp/simplewall",
+        "re": "simplewall-([\\d.]+)-bin.zip"
     },
     "autoupdate": {
         "url": "https://github.com/henrypp/simplewall/releases/download/v.$version/simplewall-$version-bin.zip#/dl.7z",

--- a/simplewall.json
+++ b/simplewall.json
@@ -1,0 +1,41 @@
+{
+    "homepage": "http://www.henrypp.org/product/simplewall",
+    "license": "GPL-3.0-only",
+    "version": "2.3.3",
+    "url": "https://github.com/henrypp/simplewall/releases/download/v.2.3.3/simplewall-2.3.3-bin.zip#/dl.7z",
+    "hash": "742cc37d3999d07cb1e1f4092efcf5bb64b41df78d91c2f0d82f8e68af86ecca",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "simplewall/64"
+        },
+        "32bit": {
+            "extract_dir": "simplewall/32"
+        }
+    },
+    "bin": [
+        [
+            "simplewall.exe",
+            "simplewall"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "simplewall.exe",
+            "simplewall"
+        ]
+    ],
+    "persist": "simplewall.ini",
+    "pre_install": [
+        "if(!(test-path \"$dir\\simplewall.ini\")) { Add-Content \"$dir\\simplewall.ini\" $null }"
+    ],
+    "checkver": {
+        "url": "https://github.com/henrypp/simplewall/releases/latest",
+        "re": "/releases/tag/v.([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/henrypp/simplewall/releases/download/v.$version/simplewall-$version-bin.zip#/dl.7z",
+        "hash": {
+            "url": "$baseurl/simplewall-$version.sha256"
+        }
+    }
+}

--- a/sqlitebrowser.json
+++ b/sqlitebrowser.json
@@ -1,33 +1,27 @@
 {
     "homepage": "http://sqlitebrowser.org/",
+    "license": "MPL-2.0|GPL-3.0-or-later",
     "version": "3.10.1",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/DB.Browser.for.SQLite-3.10.1-win64.exe#/dl.7z",
-            "hash": "2a04eceaf32d5a96a8a7d8a91f78fdd0bc8c44a5ae7f86cde568fee27d422d12"
-        },
-        "32bit": {
-            "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/DB.Browser.for.SQLite-3.10.1-win32.exe#/dl.7z",
-            "hash": "2d4ee7c846aa0c9db36cc18a5078c7c296b8eddea8f8564622fef4bc23fa4368"
-        }
-    },
-    "shortcuts": [
+    "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v3.10.1/SQLiteDatabaseBrowserPortable_3.10.1_English.paf.exe#/dl.7z",
+    "hash": "bd55d13f3fd8fe82ec856cfb430e428b0d921622e0cc5ed192cb5af827bf5f77",
+    "bin": [
         [
-            "DB Browser for SQLite.exe",
-            "DB Browser for SQLite"
+            "SQLiteDatabaseBrowserPortable.exe",
+            "sqlitebrowser"
         ]
     ],
+    "shortcuts": [
+        [
+            "SQLiteDatabaseBrowserPortable.exe",
+            "SQLite Database Browser"
+        ]
+    ],
+    "persist": "Data",
+    "post_install": "Remove-Item -LiteralPath \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
     "checkver": {
         "github": "https://github.com/sqlitebrowser/sqlitebrowser"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v$version/DB.Browser.for.SQLite-$version-win64.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v$version/DB.Browser.for.SQLite-$version-win32.exe#/dl.7z"
-            }
-        }
+        "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/v$version/SQLiteDatabaseBrowserPortable_$version_English.paf.exe#/dl.7z"
     }
 }

--- a/wox.json
+++ b/wox.json
@@ -3,17 +3,17 @@
     "version": "1.3.524",
     "url": "https://github.com/Wox-launcher/Wox/releases/download/v1.3.524/Wox-1.3.524-full.nupkg#/dl.7z",
     "hash": "sha1:BFB73E46C3C054C00C24AB0F03ED441AB1308E07",
-    "bin": "lib\\net45\\Wox.exe",
+    "extract_dir": "lib\\net45",
+    "bin": "Wox.exe",
     "shortcuts": [
         [
-            "lib\\net45\\Wox.exe",
+            "Wox.exe",
             "Wox"
         ]
     ],
     "checkver": {
         "github": "https://github.com/Wox-launcher/Wox"
     },
-    "post_install": "New-Item -ItemType file -Path \"$dir\\lib\\Update.exe\" -force | out-null",
     "autoupdate": {
         "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/Wox-$version-full.nupkg#/dl.7z",
         "hash": {


### PR DESCRIPTION
I don't believe electron apps are able to auto update with the previous manifest format right? So add extract_dir since we don't need the other nupkg files.