### PR TITLE
Add Tor Browser version 7.5.6

### DIFF
--- a/tor-browser.json
+++ b/tor-browser.json
@@ -1,0 +1,32 @@
+{
+    "description": "Web browser that connects to the internet via the Tor anonymity network",
+    "homepage": "https://www.torproject.org/",
+    "version": "7.5.6",
+    "##": "Multiple components under various open source licenses. Included HTTPS Everywhere extension is the strictest.",
+    "license": "GPL-3.0-or-later",
+    "url": "https://dist.torproject.org/torbrowser/7.5.6/torbrowser-install-7.5.6_en-US.exe#/dl.7z",
+    "hash": "475b2207314ddbf28ee79651b5d1154d59699e7b76a3b5081dce3caf97ab941e",
+    "extract_dir": "Browser",
+    "bin": [
+        [
+            "firefox.exe",
+            "tor-browser"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "firefox.exe",
+            "Tor Browser"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.torproject.org/download/download.html.en",
+        "re": "torbrowser/([0-9]+(\\.[0-9]+)*)/torbrowser-install-\\1_en-US.exe"
+    },
+    "autoupdate": {
+        "url": "https://dist.torproject.org/torbrowser/$version/torbrowser-install-$version_en-US.exe#/dl.7z",
+        "hash": {
+            "url": "https://dist.torproject.org/torbrowser/$version/sha256sums-signed-build.txt"
+        }
+    }
+}


### PR DESCRIPTION
Adds [Tor Browser](https://www.torproject.org/) to the extras bucket.