### PR TITLE
Add DDU - Display Driver Uninstaller

### DIFF
--- a/ddu.json
+++ b/ddu.json
@@ -3,7 +3,7 @@
     "description": "Driver removal utility that can help you completely uninstall AMD/NVIDIA graphics card drivers and packages from your system, without leaving leftovers behind (including registry keys, folders and files, driver store)",
     "license": "Freeware",
     "version": "17.0.9.0",
-    "url": "https://www.wagnardsoft.com/DDU/download/DDU v17.0.9.0.exe#/DDU-17.0.9.0.7z",
+    "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v17.0.9.0.exe#/DDU-17.0.9.0.7z",
     "hash": "baa1620d6e9a6a5767af43871c6ba672ebbb59e249c167008fdf83472fc8a25f",
     "extract_dir": "DDU v17.0.9.0",
     "shortcuts": [
@@ -17,7 +17,7 @@
         "re": "Display Driver Uninstaller \\(DDU\\) V([\\d\\.]*) Released"
     },
     "autoupdate": {
-        "url": "https://www.wagnardsoft.com/DDU/download/DDU v$version.exe#/DDU-$version.7z",
+        "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v$version.exe#/DDU-$version.7z",
         "extract_dir": "DDU v$version"
     }
 }

--- a/ddu.json
+++ b/ddu.json
@@ -3,7 +3,7 @@
     "description": "Driver removal utility that can help you completely uninstall AMD/NVIDIA graphics card drivers and packages from your system, without leaving leftovers behind (including registry keys, folders and files, driver store)",
     "license": "Freeware",
     "version": "17.0.9.0",
-    "url": "https://www.wagnardsoft.com/DDU/download/DDU v17.0.9.0.exe#/DDU.7z",
+    "url": "https://www.wagnardsoft.com/DDU/download/DDU v17.0.9.0.exe#/DDU-17.0.9.0.7z",
     "hash": "baa1620d6e9a6a5767af43871c6ba672ebbb59e249c167008fdf83472fc8a25f",
     "extract_dir": "DDU v17.0.9.0",
     "shortcuts": [
@@ -17,7 +17,7 @@
         "re": "Display Driver Uninstaller \\(DDU\\) V([\\d\\.]*) Released"
     },
     "autoupdate": {
-        "url": "https://www.wagnardsoft.com/DDU/download/DDU v$version.exe#/DDU.7z",
+        "url": "https://www.wagnardsoft.com/DDU/download/DDU v$version.exe#/DDU-$version.7z",
         "extract_dir": "DDU v$version"
     }
 }

--- a/ddu.json
+++ b/ddu.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://www.wagnardsoft.com/",
+    "description": "Driver removal utility that can help you completely uninstall AMD/NVIDIA graphics card drivers and packages from your system, without leaving leftovers behind (including registry keys, folders and files, driver store)",
+    "license": "Freeware",
+    "version": "17.0.9.0",
+    "url": "https://www.wagnardsoft.com/DDU/download/DDU v17.0.9.0.exe#/DDU.7z",
+    "hash": "baa1620d6e9a6a5767af43871c6ba672ebbb59e249c167008fdf83472fc8a25f",
+    "extract_dir": "DDU v17.0.9.0",
+    "shortcuts": [
+        [
+            "Display Driver Uninstaller.exe",
+            "DDU - Display Driver Uninstaller"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.wagnardsoft.com/",
+        "re": "Display Driver Uninstaller \\(DDU\\) V([\\d\\.]*) Released"
+    },
+    "autoupdate": {
+        "url": "https://www.wagnardsoft.com/DDU/download/DDU v$version.exe#/DDU.7z",
+        "extract_dir": "DDU v$version"
+    }
+}


### PR DESCRIPTION
> Driver removal utility that can help you completely uninstall AMD/NVIDIA graphics card drivers and packages from your system, without leaving leftovers behind (including registry keys, folders and files, driver store)