### PR TITLE
Add JDownloader

### DIFF
--- a/jdownloader.json
+++ b/jdownloader.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "http://jdownloader.org/",
+    "description": "JDownloader is a free, open-source download management tool",
+    "license": "GNU GPLv3",
+    "version": "2",
+    "url": "http://installer.jdownloader.org/JDownloader.jar",
+    "depends": "java/oraclejre",
+    "persist": [
+        "cfg"
+    ],
+    "bin": "JDownloader.jar",
+    "pre_install": [
+        "Start-Process $(which javaw.exe) -ArgumentList '-jar', \"$dir\\JDownloader.jar\", '-?'",
+        "while (!(Test-Path $dir\\themes\\standard\\org\\jdownloader\\images\\logo\\icon.ico)) { Start-Sleep 1 }"
+    ],
+    "shortcuts": [
+        [
+            "..\\..\\..\\shims\\JDownloader.cmd",
+            "JDownloader 2"
+        ]
+    ],
+    "post_install": [
+        "$wsShell = New-Object -ComObject WScript.Shell",
+        "if($global) { $shortcut_path = [System.IO.Path]::Combine([Environment]::GetFolderPath('commonstartmenu'), 'Programs', 'Scoop Apps', 'JDownloader 2.lnk') }",
+        "else { $shortcut_path = [System.IO.Path]::Combine([Environment]::GetFolderPath('startmenu'), 'Programs', 'Scoop Apps', 'JDownloader 2.lnk') }",
+        "$wsShell = $wsShell.CreateShortcut($shortcut_path)",
+        "$wsShell.TargetPath = \"$(which javaw.exe)\"",
+        "$wsShell.WorkingDirectory = $dir",
+        "$wsShell.Arguments = \"-jar $(Join-Path $dir JDownloader.jar)\"",
+        "$wsShell.IconLocation = \"$(Join-Path $dir themes/standard/org/jdownloader/images/logo/icon.ico)\"",
+        "$wsShell.Save()"
+    ]
+}


### PR DESCRIPTION
This proved to be a bit tricky to implement in scoop, and I'm not sure if my approach is the most viable one.

Due to self-installer that by itself is dependent on java, it ended up being more complex that I would have liked.

With my approach, scoop will wait until jdownloader downloads icon file in `pre_install` phase, then it proceeds with installation, creates dummy shortcut (so that scoop can track and remove in case of uninstall), and then manually modify icon and target of the shortcut in `post_install` phase.

Given the nature of this manifest, whether you want to merge this or not, is up for your consideration. I just thought I'd share my manifests that I built over the past few months, maybe some folks using brilliant scoop would find this handy.