### PR TITLE
Add XMR-Stak

### DIFF
--- a/xmr-stak.json
+++ b/xmr-stak.json
@@ -1,0 +1,52 @@
+{
+  "homepage": "https://github.com/fireice-uk/xmr-stak",
+  "description": "Unified All-in-one Monero miner",
+  "version": "2.4.7",
+  "license": "GPL-3.0-only",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.7/xmr-stak-win64.zip",
+      "hash": "sha1:7a36ed2819dd20ebb5b915bf62fb355a023f88b0"
+    }
+  },
+  "extract_dir": "xmr-stak-win64",
+  "bin": [
+    [
+        "xmr-stak.exe"
+    ]
+  ],
+  "shortcuts": [
+    [
+        "xmr-stak.exe",
+        "Monero\\XMR-Stak"
+    ]
+  ],
+  "pre_install": [
+    "Add-Content \"amd.txt\" $null",
+    "Add-Content \"config.txt\" $null",
+    "Add-Content \"cpu.txt\" $null",
+    "Add-Content \"nvidia.txt\" $null",
+    "Add-Content \"pools.txt\" $null"
+  ],
+  "persist": [
+    "amd.txt",
+    "config.txt",
+    "cpu.txt",
+    "nvidia.txt",
+    "pools.txt"
+  ],
+  "checkver": {
+    "github": "https://github.com/fireice-uk/xmr-stak/releases"
+  },
+  "autoupdate": {
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fireice-uk/xmr-stak/releases/download/$version/xmr-stak-win64.zip",
+            "hash": {
+                "url": "https://github.com/fireice-uk/xmr-stak/releases/tag/$version",
+                "find": '(?:\$ sha1sum xmr-stak-win64\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\.zip)'
+            }
+        }
+    }
+  }
+}

--- a/xmr-stak.json
+++ b/xmr-stak.json
@@ -1,52 +1,47 @@
 {
-  "homepage": "https://github.com/fireice-uk/xmr-stak",
-  "description": "Unified All-in-one Monero miner",
-  "version": "2.4.7",
-  "license": "GPL-3.0-only",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.7/xmr-stak-win64.zip",
-      "hash": "sha1:7a36ed2819dd20ebb5b915bf62fb355a023f88b0"
-    }
-  },
-  "extract_dir": "xmr-stak-win64",
-  "bin": [
-    [
-        "xmr-stak.exe"
-    ]
-  ],
-  "shortcuts": [
-    [
-        "xmr-stak.exe",
-        "Monero\\XMR-Stak"
-    ]
-  ],
-  "pre_install": [
-    "Add-Content \"amd.txt\" $null",
-    "Add-Content \"config.txt\" $null",
-    "Add-Content \"cpu.txt\" $null",
-    "Add-Content \"nvidia.txt\" $null",
-    "Add-Content \"pools.txt\" $null"
-  ],
-  "persist": [
-    "amd.txt",
-    "config.txt",
-    "cpu.txt",
-    "nvidia.txt",
-    "pools.txt"
-  ],
-  "checkver": {
-    "github": "https://github.com/fireice-uk/xmr-stak/releases"
-  },
-  "autoupdate": {
+    "homepage": "https://github.com/fireice-uk/xmr-stak",
+    "description": "Unified All-in-one Monero miner",
+    "version": "2.4.7",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fireice-uk/xmr-stak/releases/download/$version/xmr-stak-win64.zip",
-            "hash": {
-                "url": "https://github.com/fireice-uk/xmr-stak/releases/tag/$version",
-                "find": '(?:\\$ sha1sum xmr-stak-win64\\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\\.zip)'
+            "url": "https://github.com/fireice-uk/xmr-stak/releases/download/2.4.7/xmr-stak-win64.zip",
+            "hash": "sha1:7a36ed2819dd20ebb5b915bf62fb355a023f88b0"
+        }
+    },
+    "extract_dir": "xmr-stak-win64",
+    "bin": "xmr-stak.exe",
+    "shortcuts": [
+        [
+            "xmr-stak.exe",
+            "Monero\\XMR-Stak"
+        ]
+    ],
+    "pre_install": [
+        "Add-Content \"$dir\\amd.txt\" $null",
+        "Add-Content \"$dir\\config.txt\" $null",
+        "Add-Content \"$dir\\cpu.txt\" $null",
+        "Add-Content \"$dir\\nvidia.txt\" $null",
+        "Add-Content \"$dir\\pools.txt\" $null"
+    ],
+    "persist": [
+        "amd.txt",
+        "config.txt",
+        "cpu.txt",
+        "nvidia.txt",
+        "pools.txt"
+    ],
+    "checkver": {
+        "github": "https://github.com/fireice-uk/xmr-stak"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fireice-uk/xmr-stak/releases/download/$version/xmr-stak-win64.zip",
+                "hash": {
+                    "url": "https://github.com/fireice-uk/xmr-stak/releases/tag/$version"
+                }
             }
         }
     }
-  }
 }

--- a/xmr-stak.json
+++ b/xmr-stak.json
@@ -44,7 +44,7 @@
             "url": "https://github.com/fireice-uk/xmr-stak/releases/download/$version/xmr-stak-win64.zip",
             "hash": {
                 "url": "https://github.com/fireice-uk/xmr-stak/releases/tag/$version",
-                "find": '(?:\\$ sha1sum xmr-stak-win64\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\.zip)'
+                "find": '(?:\\$ sha1sum xmr-stak-win64\\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\\.zip)'
             }
         }
     }

--- a/xmr-stak.json
+++ b/xmr-stak.json
@@ -44,7 +44,7 @@
             "url": "https://github.com/fireice-uk/xmr-stak/releases/download/$version/xmr-stak-win64.zip",
             "hash": {
                 "url": "https://github.com/fireice-uk/xmr-stak/releases/tag/$version",
-                "find": '(?:\$ sha1sum xmr-stak-win64\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\.zip)'
+                "find": '(?:\\$ sha1sum xmr-stak-win64\.zip *\r\n)([a-fA-F0-9]{40})(?:  xmr-stak-win64\.zip)'
             }
         }
     }


### PR DESCRIPTION
[XMR-Stak](https://github.com/fireice-uk/xmr-stak) is a universal Stratum pool miner. This miner supports CPUs, AMD and NVIDIA gpus and can be used to mine the crypto currencys Monero, Aeon and many more Cryptonight coins. Developed by fireice-uk and psychocrypt, licensed under GNU GPLv3.