### PR TITLE
Add PhpStorm version 2018.2.1

### DIFF
--- a/phpstorm.json
+++ b/phpstorm.json
@@ -1,0 +1,46 @@
+{
+    "version": "2018.2.1",
+    "homepage": "https://www.jetbrains.com/phpstorm/",
+    "url": "https://download.jetbrains.com/webide/PhpStorm-2018.2.1.exe#/dl.7z",
+    "hash": "290bce7e8cf9511c68e951744f152a79db386ef57a7f2ff377a4be67b1b120c0",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "bin\\phpstorm64.exe",
+                    "phpstorm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "bin\\phpstorm64.exe",
+                    "JetBrains PhpStorm"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "bin\\phpstorm.exe",
+                    "phpstorm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "bin\\phpstorm.exe",
+                    "JetBrains PhpStorm"
+                ]
+            ]
+        }
+    },
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release",
+        "jp": "$..version"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/webide/PhpStorm-$version.exe#/dl.7z",
+        "hash": {
+            "url": "https://download.jetbrains.com/webide/PhpStorm-$version.exe.sha256"
+        }
+    }
+}


### PR DESCRIPTION
PhpStorm is a perfect PHP IDE for working with Symfony, Drupal, WordPress, Zend Framework, Laravel, Magento, Joomla!, CakePHP, Yii, and other.