### PR TITLE
PeerBlock: fix version

### DIFF
--- a/peerblock.json
+++ b/peerblock.json
@@ -5,11 +5,11 @@
     "license": "zlib-acknowledgement",
     "architecture": {
         "64bit": {
-            "url": "https://jaist.dl.sourceforge.net/project/peerblock/PeerBlock_r518_x64_Release.zip",
+            "url": "https://jaist.dl.sourceforge.net/project/peerblock/PeerBlock_r518__x64_Release.zip",
             "hash": "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
         },
         "32bit": {
-            "url": "https://nchc.dl.sourceforge.net/project/peerblock/PeerBlock_r518_Win32_Release.zip",
+            "url": "https://nchc.dl.sourceforge.net/project/peerblock/PeerBlock_r518__Win32_Release.zip",
             "hash": "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
         }
     },

--- a/peerblock.json
+++ b/peerblock.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://forums.peerblock.com/",
     "description": "An IP filter for Windows 7/10, forked from PeerGuardian 2",
-    "version": "1.",
+    "version": "518",
     "license": "zlib-acknowledgement",
     "architecture": {
         "64bit": {
-            "url": "https://jaist.dl.sourceforge.net/project/peerblock/PeerBlock_1.__x64_Release.zip",
+            "url": "https://jaist.dl.sourceforge.net/project/peerblock/PeerBlock_r518_x64_Release.zip",
             "hash": "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
         },
         "32bit": {
-            "url": "https://nchc.dl.sourceforge.net/project/peerblock/PeerBlock_1.__Win32_Release.zip",
+            "url": "https://nchc.dl.sourceforge.net/project/peerblock/PeerBlock_r518_Win32_Release.zip",
             "hash": "251a85b3bac687974f360d3796048c20ded3bf0bd69e0d1cfd1db23d013f89ed"
         }
     },


### PR DESCRIPTION
Previous wrong `checkver` regrex had autoupdater modified `version` by error.