### PR TITLE
Use $majorVersion in autoupdate URL

### DIFF
--- a/nsis.json
+++ b/nsis.json
@@ -17,7 +17,7 @@
         "re": "\\/rn\\/v([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/nsis/NSIS%203/$version/nsis-$version.zip",
+        "url": "https://downloads.sourceforge.net/project/nsis/NSIS%20$majorVersion/$version/nsis-$version.zip",
         "extract_dir": "nsis-$version"
     },
     "persist": [


### PR DESCRIPTION
The URL is currently static. However, this will (still) not work with major updates. But I guess it's by design that automatic updates are limited to minor updates.