### PR TITLE
Add Ocenaudio

### DIFF
--- a/ocenaudio.json
+++ b/ocenaudio.json
@@ -3,11 +3,11 @@
     "version": "3.4.5",
     "architecture": {
         "64bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip",
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.4.5",
             "hash": "2bc002a29b6a3c4fbc9ec0a6d839b121a1a2e6682a67125a2211455495f747c5"
         },
         "32bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip",
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.4.5",
             "hash": "21d345c77d376fc258256eec53735daedd16485740c9d44a390d764223c31d37"
         }
     },
@@ -25,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip"
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version"
             },
             "32bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip"
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version"
             }
         }
     }

--- a/ocenaudio.json
+++ b/ocenaudio.json
@@ -1,0 +1,35 @@
+{
+    "homepage": "https://www.ocenaudio.com/",
+    "version": "3.4.5",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip",
+            "hash": "2bc002a29b6a3c4fbc9ec0a6d839b121a1a2e6682a67125a2211455495f747c5"
+        },
+        "32bit": {
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip",
+            "hash": "21d345c77d376fc258256eec53735daedd16485740c9d44a390d764223c31d37"
+        }
+    },
+    "bin": "ocenaudio.exe",
+    "shortcuts": [
+        [
+            "ocenaudio.exe",
+            "Ocenaudio"
+        ]
+    ],
+    "persist": "settings",
+    "checkver": {
+    	"re": "ocenaudio ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip"
+            },
+            "32bit": {
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip"
+            }
+        }
+    }
+}

--- a/ocenaudio.json
+++ b/ocenaudio.json
@@ -20,7 +20,7 @@
     ],
     "persist": "settings",
     "checkver": {
-    	"re": "ocenaudio ([\\d.]+)"
+	    "re": "ocenaudio ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/ocenaudio.json
+++ b/ocenaudio.json
@@ -20,7 +20,7 @@
     ],
     "persist": "settings",
     "checkver": {
-	    "re": "ocenaudio ([\\d.]+)"
+        "re": "ocenaudio ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This pull request adds Ocenaudio into the scoop-extras bucket. It's a free single-track audio editor where you can record and edit audio or just view the waveform of an audio track. There's also a spectrum viewer so you can analyze if a lossless audio file is truely lossless.

I use this program frequently so i want this program in the bucket so i don't have to update manually from time to time.

This is also my first app manifesto. I've tested the auto-update feature which works. It also install and uninstall the application without any errors.