### PR TITLE
XX-Net: fix shortcut icon

### DIFF
--- a/xx-net.json
+++ b/xx-net.json
@@ -17,7 +17,7 @@
             "start.bat",
             "XX-Net",
             "",
-            "$dir\\code\\default\\launcher\\web_ui\\favicon.ico"
+            "code\\default\\launcher\\web_ui\\favicon.ico"
         ]
     ],
     "persist": [


### PR DESCRIPTION
```powershell
❯ scoop install xx-net --global
Installing 'xx-net' (3.12.11) [64bit]
XX-Net-3.12.11.7z (9.3 MB) [===============================================================================] 100%
Checking hash of XX-Net-3.12.11.7z ... ok.
Extracting XX-Net-3.12.11.7z ... done.
Linking C:\ProgramData\scoop\apps\xx-net\current => C:\ProgramData\scoop\apps\xx-net\3.12.11
Creating shim for 'XX-Net'.
Creating shortcut for XX-Net (start.bat) failed: Couldn't find icon C:\ProgramData\scoop\apps\xx-net\current\$dir\code\default\launcher\web_ui\favicon.ico
Persisting data
'xx-net' (3.12.11) was installed successfully!
```