### PR TITLE
XX-Net: Improve shim and shortcut

### DIFF
--- a/xx-net.json
+++ b/xx-net.json
@@ -8,15 +8,15 @@
     "extract_dir": "XX-Net-3.12.11",
     "bin": [
         [
-            "start.bat",
+            "start.vbs",
             "XX-Net"
         ]
     ],
     "shortcuts": [
         [
-            "start.bat",
+            "%SystemRoot%\\System32\\wscript.exe",
             "XX-Net",
-            "",
+            "$dir\\start.vbs",
             "code\\default\\launcher\\web_ui\\favicon.ico"
         ]
     ],


### PR DESCRIPTION
`start.bat` is for convenience to create shortcut on desktop, with ability to "Run as Administrator" from context menu. Use `start.vbs` instead, which is actually run by `start.bat`