### PR TITLE
XX-Net: fix shortcuts

### DIFF
--- a/xx-net.json
+++ b/xx-net.json
@@ -14,15 +14,18 @@
     ],
     "shortcuts": [
         [
-            "%SystemRoot%\\System32\\wscript.exe",
+            "start.bat",
             "XX-Net",
-            "$dir\\start.vbs",
+            "",
             "code\\default\\launcher\\web_ui\\favicon.ico"
         ]
     ],
     "persist": [
         "data"
     ],
+    "post_install": [
+        
+    ]
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/XX-net/XX-Net/releases/download/$version/XX-Net-$version.7z",

--- a/xx-net.json
+++ b/xx-net.json
@@ -23,9 +23,6 @@
     "persist": [
         "data"
     ],
-    "post_install": [
-        
-    ]
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/XX-net/XX-Net/releases/download/$version/XX-Net-$version.7z",


### PR DESCRIPTION
Due to shortcuts limit, only able to set target inside `$dir`, unable to call `wscript.exe`