### PR TITLE
fix kid3 bin and shim paths

### DIFF
--- a/kid3.json
+++ b/kid3.json
@@ -5,10 +5,10 @@
     "version": "3.6.2",
     "url": "https://downloads.sourceforge.net/project/kid3/kid3/3.6.2/kid3-3.6.2-win32.zip",
     "hash": "sha1:37743ea924b1d4d60216867c17107fabed570a6a",
-    "bin": "kid3-cli.exe",
+    "bin": "kid3-3.6.2-win32/kid3-cli.exe",
     "shortcuts": [
         [
-            "kid3.exe",
+            "kid3-3.6.2-win32/kid3.exe",
             "Kid3"
         ]
     ],

--- a/kid3.json
+++ b/kid3.json
@@ -5,10 +5,11 @@
     "version": "3.6.2",
     "url": "https://downloads.sourceforge.net/project/kid3/kid3/3.6.2/kid3-3.6.2-win32.zip",
     "hash": "sha1:37743ea924b1d4d60216867c17107fabed570a6a",
-    "bin": "kid3-3.6.2-win32/kid3-cli.exe",
+    "bin": "kid3-cli.exe",
+    "extract_dir": "kid3-3.6.2-win32",
     "shortcuts": [
         [
-            "kid3-3.6.2-win32/kid3.exe",
+            "kid3.exe",
             "Kid3"
         ]
     ],
@@ -16,6 +17,7 @@
         "re": "kid3-([\\d.]+)-win32.zip"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/kid3/kid3/$version/kid3-$version-win32.zip"
+        "url": "https://downloads.sourceforge.net/project/kid3/kid3/$version/kid3-$version-win32.zip",
+        "extract_dir": "kid3-$version-win32"
     }
 }


### PR DESCRIPTION
Don't know if there is a better way to fix this or not (such as removing the extra folder).