### PR TITLE
Fix extract_dir for auto updates

### DIFF
--- a/knime.json
+++ b/knime.json
@@ -9,14 +9,15 @@
     "architecture": {
         "64bit": {
             "url": "https://download.knime.org/analytics-platform/win/knime_3.6.1.win32.win32.x86_64.zip",
-            "hash": "eaed81880c6552385c75a14e5550b92588758386904b091fab41aa8e467da690"
+            "hash": "eaed81880c6552385c75a14e5550b92588758386904b091fab41aa8e467da690",
+            "extract_dir": "knime_3.6.1"
         },
         "32bit": {
             "url": "https://download.knime.org/analytics-platform/win/knime_3.6.1.win32.win32.x86.zip",
             "hash": "ebf7ddcdac8838e9985ef5e39e1b15c2d8e0ff331e77709f73292694140ddf62"
+            "extract_dir": "knime_3.6.1"
         }
     },
-    "extract_dir": "knime_3.6.0",
     "bin": [
         [
             "knime.exe",

--- a/knime.json
+++ b/knime.json
@@ -9,15 +9,14 @@
     "architecture": {
         "64bit": {
             "url": "https://download.knime.org/analytics-platform/win/knime_3.6.1.win32.win32.x86_64.zip",
-            "hash": "eaed81880c6552385c75a14e5550b92588758386904b091fab41aa8e467da690",
-            "extract_dir": "knime_3.6.1"
+            "hash": "eaed81880c6552385c75a14e5550b92588758386904b091fab41aa8e467da690"
         },
         "32bit": {
             "url": "https://download.knime.org/analytics-platform/win/knime_3.6.1.win32.win32.x86.zip",
-            "hash": "ebf7ddcdac8838e9985ef5e39e1b15c2d8e0ff331e77709f73292694140ddf62",
-            "extract_dir": "knime_3.6.1"
+            "hash": "ebf7ddcdac8838e9985ef5e39e1b15c2d8e0ff331e77709f73292694140ddf62"
         }
     },
+    "extract_dir": "knime_3.6.1",
     "bin": [
         [
             "knime.exe",
@@ -31,14 +30,13 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.knime.org/analytics-platform/win/knime_$version.win32.win32.x86_64.zip",
-                "extract_dir": "knime_$version"
+                "url": "https://download.knime.org/analytics-platform/win/knime_$version.win32.win32.x86_64.zip"
             },
             "32bit": {
-                "url": "https://download.knime.org/analytics-platform/win/knime_$version.win32.win32.x86.zip",
-                "extract_dir": "knime_$version"
+                "url": "https://download.knime.org/analytics-platform/win/knime_$version.win32.win32.x86.zip"
             }
-        }
+        },
+        "extract_dir": "knime_$version"
     },
     "shortcuts": [
         [

--- a/knime.json
+++ b/knime.json
@@ -14,7 +14,7 @@
         },
         "32bit": {
             "url": "https://download.knime.org/analytics-platform/win/knime_3.6.1.win32.win32.x86.zip",
-            "hash": "ebf7ddcdac8838e9985ef5e39e1b15c2d8e0ff331e77709f73292694140ddf62"
+            "hash": "ebf7ddcdac8838e9985ef5e39e1b15c2d8e0ff331e77709f73292694140ddf62",
             "extract_dir": "knime_3.6.1"
         }
     },


### PR DESCRIPTION
extract_dir was at the root level rather than inside the respective architecture elements, and was therefore not being updated to the correct value upon a checkver update, preventing the installation from completing successfully