### PR TITLE
pandoc: Fixed extract_dir (#1238)

### DIFF
--- a/pandoc.json
+++ b/pandoc.json
@@ -5,14 +5,15 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.3/pandoc-2.3-windows-x86_64.zip",
-            "hash": "0a89a63b7df49aa2f7f92aa6cbcdfee35a2400b90ebd8b3ad431384cbc3bef1d"
+            "hash": "0a89a63b7df49aa2f7f92aa6cbcdfee35a2400b90ebd8b3ad431384cbc3bef1d",
+            "extract_dir": "pandoc-2.3-windows-x86_64"
         },
         "32bit": {
             "url": "https://github.com/jgm/pandoc/releases/download/2.3/pandoc-2.3-windows-i386.zip",
-            "hash": "4588826e1ca6dce55f000f22f06ddb9de5ae9a5d3611d439a2b5941c7cd04a0b"
+            "hash": "4588826e1ca6dce55f000f22f06ddb9de5ae9a5d3611d439a2b5941c7cd04a0b",
+            "extract_dir": "pandoc-2.3-windows-i386"
         }
     },
-    "extract_dir": "pandoc-2.3",
     "bin": "pandoc.exe",
     "checkver": {
         "github": "https://github.com/jgm/pandoc"


### PR DESCRIPTION
The extraction directory in Pandoc's pre-built zip-files has changed and is now architecture dependent.

This addresses issue #1238.