### PR TITLE
Fix libreoffice fresh.

### DIFF
--- a/libreoffice-fresh.json
+++ b/libreoffice-fresh.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://libreoffice.org/",
     "license": "MPL-2.0",
-    "version": "6.1.1.2",
+    "version": "6.1.1",
     "architecture": {
         "64bit": {
-            "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/6.1.1.2/win/x86_64/LibreOffice_6.1.1.2_Win_x64.msi",
+            "url": "http://download.documentfoundation.org/libreoffice/stable/6.1.1/win/x86_64/LibreOffice_6.1.1_Win_x64.msi",
             "hash": "05b7cd7d55dc5feb2f5da401c3676f0c091ad7db820424cca2aff77f8a300cb5"
         },
         "32bit": {
-            "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/6.1.1.2/win/x86/LibreOffice_6.1.1.2_Win_x86.msi",
+            "url": "http://download.documentfoundation.org/libreoffice/stable/6.1.1/win/x86/LibreOffice_6.1.1_Win_x86.msi",
             "hash": "a35240ae3e7d7310d943389cab0acebf4cb91b20f4ac9cf3ce9342cea7a1144b"
         }
     },
@@ -40,15 +40,15 @@
     ],
     "checkver": {
         "url": "https://www.libreoffice.org/download/download/",
-        "re": "libreoffice-([\\d.]+).tar.xz"
+        "re": "LibreOffice_(\\d(\\.\\d){2,3})_Win_x64_sdk\\.msi"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/$version/win/x86_64/LibreOffice_$version_Win_x64.msi"
+                "url": "http://download.documentfoundation.org/libreoffice/stable/$version/win/x86_64/LibreOffice_$version_Win_x64.msi"
             },
             "32bit": {
-                "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/$version/win/x86/LibreOffice_$version_Win_x86.msi"
+                "url": "http://download.documentfoundation.org/libreoffice/stable/$version/win/x86/LibreOffice_$version_Win_x86.msi"
             }
         },
         "hash": {


### PR DESCRIPTION
version urls has changed.

also changed checkver regex. there is a libreoffice-6.1.1.2.tar.xz but no corresponding 6.1.1.2.msi file