### PR TITLE
Rambox: tweaks

### DIFF
--- a/rambox.json
+++ b/rambox.json
@@ -1,36 +1,35 @@
 {
-    "version": "0.5.17",
+    "version": "0.6.1",
+    "description": "Free and Open Source messaging and emailing app that combines common web applications into one.",
     "homepage": "http://rambox.pro/",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/saenzramiro/rambox/releases/download/0.5.17/Rambox-0.5.17-x64-win.zip",
-            "hash": "a2d58f3afe295f97c2a740087c9ee95b8e186bf946e6cf0b6591aa651074fadf"
+            "url": "https://github.com/ramboxapp/community-edition/releases/download/0.6.1/Rambox-0.6.1-win-x64.zip",
+            "hash": "57b1753d01e3f278fe51c5541374c3b4deaf481d295e446c838bb939fa26719e"
         },
         "32bit": {
-            "url": "https://github.com/saenzramiro/rambox/releases/download/0.5.17/Rambox-0.5.17-ia32-win.zip",
-            "hash": "c2d739bdb048edf14dfb93dce1d0fac34afb19ac45b8db896a73c61077d5a95d"
+            "url": "https://github.com/ramboxapp/community-edition/releases/download/0.6.1/Rambox-0.6.1-win-ia32.zip",
+            "hash": "a2fada3956b79d6dd410658b7f5bbb8cb1bdafc37dd1e36681de9b20e5820dcb"
         }
     },
-    "bin": [
-        "Rambox.exe"
-    ],
+    "bin": "Rambox.exe",
     "shortcuts": [
         [
             "Rambox.exe",
-            "Rambox"
+            "Rambox Community Edition"
         ]
     ],
     "checkver": {
-        "github": "https://github.com/saenzramiro/rambox"
+        "github": "https://github.com/ramboxapp/community-edition/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/saenzramiro/rambox/releases/download/$version/Rambox-$version-x64-win.zip"
+                "url": "https://github.com/ramboxapp/community-edition/releases/download/$version/Rambox-$version-win-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/saenzramiro/rambox/releases/download/$version/Rambox-$version-ia32-win.zip"
+                "url": "https://github.com/ramboxapp/community-edition/releases/download/$version/Rambox-$version-win-ia32.zip"
             }
         }
     }

--- a/rambox.json
+++ b/rambox.json
@@ -2,15 +2,18 @@
     "version": "0.6.1",
     "description": "Free and Open Source messaging and emailing app that combines common web applications into one.",
     "homepage": "http://rambox.pro/",
-    "license": "GPL-3.0-only",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/ramboxapp/community-edition/blob/master/LICENSE"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/ramboxapp/community-edition/releases/download/0.6.1/Rambox-0.6.1-win-x64.zip",
-            "hash": "57b1753d01e3f278fe51c5541374c3b4deaf481d295e446c838bb939fa26719e"
+            "hash": "a7e8099621f4bbd01a4952fa1de1cc884c7b5bbecd29cd01bf2dd4dd45a418d0"
         },
         "32bit": {
             "url": "https://github.com/ramboxapp/community-edition/releases/download/0.6.1/Rambox-0.6.1-win-ia32.zip",
-            "hash": "a2fada3956b79d6dd410658b7f5bbb8cb1bdafc37dd1e36681de9b20e5820dcb"
+            "hash": "afbe0a02042f63b5d3222157775ed26e6ef4d9ab4d3f5a5c9a641fdb5d94e208"
         }
     },
     "bin": "Rambox.exe",


### PR DESCRIPTION
- Respec repository URL change
- Change download file
- Bump to 0.6.1 version
- Add description

WIP: Since ramiro changed it's version number last minute, and there are no non windows binaries yet.
UPDATE: Version 0.6.1 was taken down and it's only draft until all packages are up.

As we changed builder from squirell to NSIS, installation could be changed to something like:

```json
    "url": "https://github.com/ramboxapp/community-edition/releases/download/0.5.18/Rambox-0.5.18-win.exe"
    "extract_dir": "\\$PLUGINSDIR",
    "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z', 'app-32.7z' | Remove-Item -Force -Recurse",
    "architecture": {
        "64bit": {
            "installer": {
                "script": "extract_7zip \"$dir\\app-64.7z\" \"$dir\""
            }
        },
        "32bit": {
            "installer": {
                "script": "extract_7zip \"$dir\\app-32.7z\" \"$dir\""
            }
        }
    },
    "post_install": "Remove-Item \"$dir\\app-64.7z\", \"$dir\\app-32.7z\"",
```

Then file named `latest.yml` could be used for autoupdate hash extraction (possible after: lukesampson/scoop@04c9ddeb6d3b99496c39543ad468d34f4f1adeff)

```json
"url": "https://github.com/ramboxapp/community-edition/releases/download/$version/Rambox-$version-win.exe",
"hash": {
    "url": "https://github.com/ramboxapp/community-edition/releases/download/$version/latest.yml",
    "find": "$basename\\s+sha512:\\s(.*)\\s"
```