### PR TITLE
Add ungoogled-chromium

### DIFF
--- a/ungoogled-chromium.json
+++ b/ungoogled-chromium.json
@@ -1,0 +1,43 @@
+{
+    "version": "67.0.3396.87-3",
+    "description": "Modifications to Google Chromium for removing Google integration and enhancing privacy, control, and transparency.",
+    "homepage": "https://github.com/Eloston/ungoogled-chromium",
+    "license": {
+        "identifier": "BSD-3-Clause",
+        "url": "https://github.com/Eloston/ungoogled-chromium/blob/master/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Wyse-/ungoogled-chromium-binaries/releases/download/67.0.3396.87-3/ungoogled-chromium_67.0.3396.87-3_windows.zip",
+            "hash": "bab1f622f9a966baffa07838c305e586715979db884cd7369df96bb08c092f8a",
+            "extract_dir": "ungoogled-chromium_67.0.3396.87-3_windows"
+        },
+        "32bit": {
+            "url": "https://github.com/Eloston/ungoogled-chromium/releases/download/55.0.2883.87-1/ungoogled-chromium_55.0.2883.87-1_windows_x86.zip",
+            "hash": "38eef153c7a34d8e858859f159bcccb3745ebe99428b00464a7e32426e50cd53"
+        }
+    },
+    "bin": "chrome.exe",
+    "shortcuts": [
+        [
+            "chrome.exe",
+            "Ungoogled Chromium"
+        ]
+    ],
+    "checkver": {
+        "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/64bit/",
+        "re": ">([\\.\\d-]+)</a></li>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Wyse-/ungoogled-chromium-binaries/releases/download/67.0.3396.87-3/ungoogled-chromium_$version_windows.zip",
+                "hash": {
+                    "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/64bit/$version",
+                    "find": "<li>SHA256:\\s+<code>([A-Fa-f\\d+]{64})</code></li>"
+                },
+                "extract_dir": "ungoogled-chromium_$version_windows"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Closes #1284

Autoupdate for 32bit is disabled due to unavailable binaries.
There is  problem, that binaries are deployed to different github accounts.
There are 2 steps needed for acquiring everything needed. Get version (as in manifest) and then go to that relase page and find user (not possible now; basicly same as hash)