### PR TITLE
Add lightbulb@1.6.4

### DIFF
--- a/lightbulb.json
+++ b/lightbulb.json
@@ -14,17 +14,22 @@
     "url": "https://github.com/Tyrrrz/LightBulb/releases/download/1.6.4/LightBulb-Portable.zip",
     "hash": "847053924ab64a872e01d70070d2a6ece816fe0e276003038ba9148c69d9896c",
     "pre_install": [
-        "   #Create placeholder file",
+        "#Create placeholder file",
         "function CreateFile([String] $file, [String] $content = $null) {",
         "    if(!(Test-Path \"$persist_dir\\$file\")) {",
-        "        Write-Host \"Create placeholder for shadowsocksr-csharp: $file\"",
+        "        Write-Host \"Create placeholder for $file\"",
         "        New-Item -Force -Path \"$persist_dir\\$file\" -ItemType file -Value $content | Out-Null",
         "    }",
         "}",
         "CreateFile 'Configuration.dat' '{}'"
     ],
     "persist": "Configuration.dat",
-    "bin": "LightBulb.exe",
+    "bin": [
+        [
+            "LightBulb_Portable.bat",
+            "LightBulb"
+        ]
+    ],
     "shortcuts": [
         [
             "LightBulb_Portable.bat",

--- a/lightbulb.json
+++ b/lightbulb.json
@@ -6,7 +6,11 @@
         "identifier": "GPL-3.0-only",
         "url": "https://github.com/Tyrrrz/LightBulb/blob/master/License.txt"
     },
-    "notes": ".NET Framework version 4.5.2 or higher is required to run this program. If the gamma doesn't change under 6600K, run the Manual_Gamma_Registry_Fix.reg registry key in the program's directory (scoop/apps/lightbulb/current). Don't run LightBulb.exe when you're in that folder. Use the file LightBulb_Portable.bat or the created shortcut to run this program.",
+    "notes": [
+        ".NET Framework version 4.5.2 or higher is required to run this program.",
+        "If the gamma doesn't change under 6600K, run the Manual_Gamma_Registry_Fix.reg registry key in the program's directory (scoop/apps/lightbulb/current).",
+        "Don't run LightBulb.exe when you're in that folder. Use the file LightBulb_Portable.bat or the created shortcut to run this program."
+    ],
     "url": "https://github.com/Tyrrrz/LightBulb/releases/download/1.6.4/LightBulb-Portable.zip",
     "hash": "847053924ab64a872e01d70070d2a6ece816fe0e276003038ba9148c69d9896c",
     "pre_install": [
@@ -19,12 +23,8 @@
         "}",
         "CreateFile 'Configuration.dat' '{}'"
     ],
-    "persist": [
-        "Configuration.dat"
-    ],
-    "bin": [
-        "LightBulb.exe"
-    ],
+    "persist": "Configuration.dat",
+    "bin": "LightBulb.exe",
     "shortcuts": [
         [
             "LightBulb_Portable.bat",

--- a/lightbulb.json
+++ b/lightbulb.json
@@ -1,0 +1,40 @@
+{
+    "version": "1.6.4",
+    "description": "A program that reduces eyestrain produced by staring at a computer screen when working late hours",
+    "homepage": "https://github.com/Tyrrrz/LightBulb",
+    "license": {
+        "identifier": "GPL-3.0-only",
+        "url": "https://github.com/Tyrrrz/LightBulb/blob/master/License.txt"
+    },
+    "notes": ".NET Framework version 4.5.2 or higher is required to run this program. If the gamma doesn't change under 6600K, run the Manual_Gamma_Registry_Fix.reg registry key in the program's directory (scoop/apps/lightbulb/current). Don't run LightBulb.exe when you're in that folder. Use the file LightBulb_Portable.bat or the created shortcut to run this program.",
+    "url": "https://github.com/Tyrrrz/LightBulb/releases/download/1.6.4/LightBulb-Portable.zip",
+    "hash": "847053924ab64a872e01d70070d2a6ece816fe0e276003038ba9148c69d9896c",
+    "pre_install": [
+        "   #Create placeholder file",
+        "function CreateFile([String] $file, [String] $content = $null) {",
+        "    if(!(Test-Path \"$persist_dir\\$file\")) {",
+        "        Write-Host \"Create placeholder for shadowsocksr-csharp: $file\"",
+        "        New-Item -Force -Path \"$persist_dir\\$file\" -ItemType file -Value $content | Out-Null",
+        "    }",
+        "}",
+        "CreateFile 'Configuration.dat' '{}'"
+    ],
+    "persist": [
+        "Configuration.dat"
+    ],
+    "bin": [
+        "LightBulb.exe"
+    ],
+    "shortcuts": [
+        [
+            "LightBulb_Portable.bat",
+            "LightBulb",
+            "",
+            "LightBulb.exe"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/Tyrrrz/LightBulb/releases/download/$version/LightBulb-Portable.zip"
+    }
+}


### PR DESCRIPTION
LightBulb is an opensource alternative to f.lux. It's a bit more customizable than f.lux and should also be more "gaming-friendly" as the author of the program explains it here: https://old.reddit.com/r/osugame/comments/5rpq1q/lightbulb_gamingfriendly_flux_alternative/

The app manifest is based on the portable version of the progam. I've added notes that the program needs .Net framework, Run a registry key if changing the gamma doesnt work correctly (the readme file advises to run it at least once) and that you need to run the bat file inside the folder of the program to enable portable mode, which the created shortcut already does.

I'm not sure if the notes can be shorter or anything can be removed from it. Otherwise the app manifest works perfectly for me. It also allows to install older versions of the program.

Please leave feedback if necessary.