### PR TITLE
Add pandoc-citeproc to PATH when installing pandoc

### DIFF
--- a/pandoc.json
+++ b/pandoc.json
@@ -14,7 +14,10 @@
             "extract_dir": "pandoc-2.3.1-windows-i386"
         }
     },
-    "bin": "pandoc.exe",
+    "bin": [
+        "pandoc.exe",
+        "pandoc-citeproc.exe"
+    ],
     "checkver": {
         "github": "https://github.com/jgm/pandoc"
     },


### PR DESCRIPTION
This change would add pandoc-citeproc (the citation-processor-filter for pandoc) to the system PATH so it can be easily used as a pandoc filter