### PR TITLE
JDownloader: ensure config directory exists at install time

### DIFF
--- a/jdownloader.json
+++ b/jdownloader.json
@@ -11,7 +11,10 @@
     },
     "persist": "cfg",
     "bin": "JDownloader.bat",
-    "pre_install": "Set-Content \"$dir\\JDownloader.bat\" (@('@echo off', 'start javaw.exe -jar JDownloader.jar') -join \"`r`n\") -Encoding Ascii",
+    "pre_install": [
+        "Set-Content \"$dir\\JDownloader.bat\" (@('@echo off', 'start javaw.exe -jar JDownloader.jar') -join \"`r`n\") -Encoding Ascii",
+        "New-Item \"$dir\\cfg\" -Type Directory -ErrorAction SilentlyContinue | Out-Null"
+    ],
     "shortcuts": [
         [
             "JDownloader.bat",


### PR DESCRIPTION
On clean installation, the configuration directory did not get created, which resulted in persistence not working.