### PR TITLE
wsltty: move to dir, before run install.bat.

### DIFF
--- a/wsltty.json
+++ b/wsltty.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install.exe#/dl.7z"
     },
     "installer": {
-        "file": "install.bat",
+        "script": ["pushd \"$dir\"", ".\\install.bat", "popd"],
         "keep": true
     },
     "uninstaller": {


### PR DESCRIPTION
Installing wsltty was failed in my environment without any error message.
 ( Win 10 Pro 1809 17763.55 64-bit, scoop 83cff3bb )
I think someone may have same problem.
Downloading and extraction was OK, but any files weren't copied to "user\AppData" folder.
Moreover, it couldn't add the start menu entry in "uesr\AppData\Roaming\Microsoft\Windows\Start Menu\Programs" .
If this is intended behavior, please reject PR.

To fix this problem, it needs to move into the folder including extracted files and other scripts making start menu entries, before executing install.bat.
