### PR TITLE
CrystalDiskInfo CrystalDiskMark

### DIFF
--- a/crystaldiskinfo.json
+++ b/crystaldiskinfo.json
@@ -1,0 +1,54 @@
+{
+    "homepage": "https://osdn.net/projects/crystaldiskinfo/",
+    "description": "CrystalDiskInfo is a HDD/SSD utility software which supports S.M.A.R.T and a part of USB-HDD.",
+    "version": "7.8.2",
+    "license": "MIT",
+    "url": "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskinfo/70096/CrystalDiskInfo7_8_2.zip",
+    "hash": "md5:d76b0117d17bb7ee556d7b04e3669613",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "DiskInfo64.exe",
+                    "DiskInfo"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "DiskInfo64.exe",
+                    "DiskInfo"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "DiskInfo32.exe",
+                    "DiskInfo"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "DiskInfo32.exe",
+                    "DiskInfo"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "DiskInfo.ini"
+    ],
+    "pre_install": [
+        "if(!(Test-Path \"$dir/DiskInfo.ini\")) { Add-Content \"$dir/DiskInfo.ini\" $null }"
+    ],
+    "checkver": {
+        "re": "<a href=\"/projects/crystaldiskinfo/releases/(?<release>[\\d]*)\">CrystalDiskInfo ([\\d+\\.*]+)</a>"
+    },
+    "autoupdate": {
+        "url": "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskinfo/$matchRelease/CrystalDiskInfo$underscoreVersion.zip",
+        "hash": {
+            "url": "https://osdn.net/projects/crystaldiskinfo/downloads/$matchRelease/CrystalDiskInfo$underscoreVersion.zip/",
+            "regex": "<dt>MD5</dt>\\n[\\t ]*<dd>([0-9a-fA-F]{32})</dd>"
+        }
+    }
+}

--- a/crystaldiskmark.json
+++ b/crystaldiskmark.json
@@ -1,0 +1,56 @@
+{
+    "homepage": "https://osdn.net/projects/crystaldiskmark/",
+    "description": "CrystalDiskMark is a disk benchmark software.",
+    "version": "6.0.2",
+    "license": "BSD-3-Clause",
+    "url": "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/68624/CrystalDiskMark6_0_2.zip",
+    "hash": "md5:a2a6ed95804ed885e1e82d25cb4a5ea2",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "DiskMark64.exe",
+                    "DiskMark"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "DiskMark64.exe",
+                    "DiskMark"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": [
+                [
+                    "DiskMark32.exe",
+                    "DiskMark"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "DiskMark32.exe",
+                    "DiskMark"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "DiskMark32.ini",
+        "DiskMark64.ini"
+    ],
+    "pre_install": [
+        "if(!(Test-Path \"$dir/DiskMark64.ini\")) { Add-Content \"$dir/DiskMark64.ini\" $null }",
+        "if(!(Test-Path \"$dir/DiskMark32.ini\")) { Add-Content \"$dir/DiskMark32.ini\" $null }"
+    ],
+    "checkver": {
+        "re": "<a href=\"/projects/crystaldiskmark/releases/(?<release>[\\d]*)\">CrystalDiskMark ([\\d+\\.*]+)</a>"
+    },
+    "autoupdate": {
+        "url": "https://osdn.net/frs/redir.php?m=dotsrc&f=crystaldiskmark/$matchRelease/CrystalDiskMark$underscoreVersion.zip",
+        "hash": {
+            "url": "https://osdn.net/projects/crystaldiskmark/downloads/$matchRelease/CrystalDiskMark$underscoreVersion.zip/",
+            "regex": "<dt>MD5</dt>\\n[\\t ]*<dd>([0-9a-fA-F]{32})</dd>"
+        }
+    }
+}


### PR DESCRIPTION
CrystalDiskInfo is a HDD/SSD utility software which supports S.M.A.R.T and a part of USB-HDD.
CrystalDiskMark is a disk benchmark software.