### PR TITLE
Add DebugView++

### DIFF
--- a/debugviewpp.json
+++ b/debugviewpp.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://github.com/CobaltFusion/DebugViewPP",
+    "description": "DebugView++, collect, view and filter your application logs",
+    "license": "BSL-1.0",
+    "version": "1.8.0.34",
+    "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.34/DebugView++.zip",
+    "hash": "677389538cd593e10b79c12c113cbda4038a9ca1ea205454c30ebd64d815072d",
+    "bin": [
+        "DebugView++.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version/DebugView++.zip"
+    }
+}

--- a/debugviewpp.json
+++ b/debugviewpp.json
@@ -3,13 +3,34 @@
     "description": "DebugView++, collect, view and filter your application logs",
     "license": "BSL-1.0",
     "version": "1.8.0.34",
-    "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.34/DebugView++.zip",
-    "hash": "677389538cd593e10b79c12c113cbda4038a9ca1ea205454c30ebd64d815072d",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.34-x64/DebugView++.zip",
+            "hash": "ff1078c4dc5fb7d9b73cf2edca28e511758980720b4e01aa5fbe23df7c88c14d"
+        },
+        "32bit": {
+            "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v1.8.0.34/DebugView++.zip",
+            "hash": "677389538cd593e10b79c12c113cbda4038a9ca1ea205454c30ebd64d815072d"
+        }
+    },
     "bin": [
-        "DebugView++.exe"
+        "DebugView++.exe",
+        [
+            "DebugView++.exe",
+            "DebugView"
+        ],
+        "DebugViewConsole.exe"
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version/DebugView++.zip"
-    }
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version-x64/DebugView++.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/CobaltFusion/DebugViewPP/releases/download/v$version/DebugView++.zip"
+            }
+        }
+    },
+    "notes": "The 'OutputForwarderVSIX.vsix' is located at '$dir'."
 }


### PR DESCRIPTION
This PR adds an app manifest for [`debugview++`](https://github.com/CobaltFusion/DebugViewPP).

- Releases from GitHub
- Binaries: `DebugView++.exe`, `DebugViewConsole.exe`

Moved from lukesampson/scoop#2697, thanks @r15ch13.