### PR TITLE
hwmonitor: hash fix (closes #1344)

### DIFF
--- a/hwmonitor.json
+++ b/hwmonitor.json
@@ -3,7 +3,7 @@
     "architecture": {
         "32bit": {
             "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.37.zip",
-            "hash": "fb347ae66c25c6de8a22e443ff9d0307d956144aec55210703a61c2b852326f7",
+            "hash": "ddca58cee48591d754b19aba722e846003288ef6c5cfc0619fae3d3b943cc2d1",
             "bin": [
                 [
                     "hwmonitor_x32.exe",
@@ -19,7 +19,7 @@
         },
         "64bit": {
             "url": "http://download.cpuid.com/hwmonitor/hwmonitor_1.37.zip",
-            "hash": "fb347ae66c25c6de8a22e443ff9d0307d956144aec55210703a61c2b852326f7",
+            "hash": "ddca58cee48591d754b19aba722e846003288ef6c5cfc0619fae3d3b943cc2d1",
             "bin": [
                 [
                     "hwmonitor_x64.exe",


### PR DESCRIPTION
Confirmed correct URL and version, downloaded zip manually, and manually confirmed different hash.