### PR TITLE
Add ALTools version 1.0

### DIFF
--- a/altools.json
+++ b/altools.json
@@ -1,16 +1,10 @@
 {
     "homepage": "https://www.microsoft.com/en-us/download/details.aspx?id=18465",
-    "description": "Download tools that you can use to troubleshoot account lockouts, as well as add functionality to Active Directory",
+    "description": "Tools that you can use to troubleshoot account lockouts, as well as add functionality to Active Directory",
     "version": "1.0",
     "license": "Freeware",
-    "url": "https://download.microsoft.com/download/1/f/0/1f0e9569-3350-4329-b443-822976f29284/ALTools.exe",
+    "url": "https://download.microsoft.com/download/1/f/0/1f0e9569-3350-4329-b443-822976f29284/ALTools.exe#dl.7z",
     "hash": "716718c095ef5ad5724bc8344cbccc176e14fd773de89c517f6c8514cd3ae260",
-    "installer": {
-        "args": [
-            "/Q",
-            "/T:$dir"
-        ]
-    },
     "bin": [
         "ALoInfo.exe",
         "EventCombMT.exe",

--- a/altools.json
+++ b/altools.json
@@ -1,0 +1,38 @@
+{
+    "homepage": "https://www.microsoft.com/en-us/download/details.aspx?id=18465",
+    "description": "Download tools that you can use to troubleshoot account lockouts, as well as add functionality to Active Directory",
+    "version": "1.0",
+    "license": "Freeware",
+    "url": "https://download.microsoft.com/download/1/f/0/1f0e9569-3350-4329-b443-822976f29284/ALTools.exe",
+    "hash": "716718c095ef5ad5724bc8344cbccc176e14fd773de89c517f6c8514cd3ae260",
+    "installer": {
+        "args": [
+            "/Q",
+            "/T:$dir"
+        ]
+    },
+    "bin": [
+        "ALoInfo.exe",
+        "EventCombMT.exe",
+        "LockoutStatus.exe",
+        "NLParse.exe"
+    ],
+    "shortcuts": [
+        [
+            "ALoInfo.exe",
+            "ALoInfo"
+        ],
+        [
+            "EventCombMT.exe",
+            "EventCombMT"
+        ],
+        [
+            "LockoutStatus.exe",
+            "LockoutStatus"
+        ],
+        [
+            "NLParse.exe",
+            "NLParse"
+        ]
+    ]
+}


### PR DESCRIPTION
Resubmitting the pull request after adding shortcuts, license, and changing to 7-zip extraction over the native installer. These are a small collection of tools from Microsoft that are used for troubleshooting account lockouts. In particular, I use lockoutstatus.exe and nlparse.exe on a daily basis. 