### PR TITLE
Add Franz version 5.0.0-beta.18

### DIFF
--- a/franz.json
+++ b/franz.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "http://meetfranz.com",
+    "version": "5.0.0-beta.18",
+    "license": {
+        "identifier": "Apache-2.0"
+    },
+    "url": "https://github.com/meetfranz/franz/releases/download/v5.0.0-beta.18/franz-setup-5.0.0-beta.18.exe#/dl.7z",
+    "hash": "bb975d60c923cf42b900adf7fcf5c79e6bd937759ab3717ad988c0a9c16bfc7a",
+    "bin": "Franz.exe",
+    "pre_install": "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
+    "shortcuts": [
+        [
+            "Franz.exe",
+            "Franz"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/meetfranz/franz",
+        "re": "/releases/tag/v(5[\\d.]+(-(alpha|beta)\\.\\d+)?)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/meetfranz/franz/releases/download/v$version/franz-setup-$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}


### PR DESCRIPTION
Franz is a free messaging app for services like WhatsApp, Slack, Messenger and many more. Similar to Station and Rambox.