### PR TITLE
Picotorrent: Tweaks

### DIFF
--- a/picotorrent.json
+++ b/picotorrent.json
@@ -1,7 +1,10 @@
 {
     "homepage": "https://picotorrent.org",
-    "description": "A tiny BitTorrent client with low memory usage, high performance and a native user interface.",
-    "license": "MIT",
+    "description": "A tiny, hackable BitTorrent client with low memory usage, high performance and a native user interface.",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/picotorrent/picotorrent/blob/master/LICENSE"
+    },
     "version": "0.15.0",
     "architecture": {
         "64bit": {
@@ -21,13 +24,13 @@
     ],
     "bin": "PicoTorrent.exe",
     "pre_install": [
-        "if(!(test-path \"$dir\\Session.dat\")) { Add-Content \"$dir\\Session.dat\" '' }",
-        "if(!(test-path \"$dir\\PicoTorrent.json\")) { Add-Content \"$dir\\PicoTorrent.json\" '{}' }"
+        "if (!(Test-Path \"$persist_dir\\Session.dat\")) { Set-Content \"$dir\\Session.dat\" $null -Encoding Ascii }",
+        "if (!(Test-Path \"$persist_dir\\PicoTorrent.json\")) { Set-Content \"$dir\\PicoTorrent.json\" '{}' -Encoding Ascii }"
     ],
     "persist": [
+        "Torrents",
         "Session.dat",
-        "PicoTorrent.json",
-        "\\Torrents"
+        "PicoTorrent.json"
     ],
     "checkver": {
         "github": "https://github.com/picotorrent/picotorrent"


### PR DESCRIPTION
Set encoding to ditch powershells default UTF-16 encoding