### PR TITLE
Add rxrepl

### DIFF
--- a/rxrepl.json
+++ b/rxrepl.json
@@ -9,7 +9,7 @@
     "url": "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0",
     "bin": "rxrepl.exe",
     "hash": "c0d8523addafa2fb5e89440e9b5262ce80c84fa9e87ca82d7b3cc23ad10c1e1b",
-    "checkver": "(?:Version )(.*?)(?:</h3>)",
+    "checkver": "Version ([\\d\\.]+)",
     "autoupdate": {
         "url": "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0"
     }

--- a/rxrepl.json
+++ b/rxrepl.json
@@ -1,0 +1,16 @@
+{
+    "description": "A command line tool to search and replace text in text files using Perl compatible regular expressions (PCRE).",
+    "homepage": "https://sites.google.com/site/regexreplace/",
+    "version": "1.5",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://hastebin.com/raw/adajilisey"
+    },
+    "url": "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0",
+    "bin": "rxrepl.exe",
+    "hash": "c0d8523addafa2fb5e89440e9b5262ce80c84fa9e87ca82d7b3cc23ad10c1e1b",
+    "checkver": "(?:Version )(.*?)(?:</h3>)",
+    "autoupdate": {
+        "url": "https://sites.google.com/site/regexreplace/home/rxrepl.zip?attredirects=0"
+    }
+}


### PR DESCRIPTION
This PR adds [rxrepl](https://sites.google.com/site/regexreplace/), a windows tool similar to `sed -i` or `perl -pi`.

I'm honestly not sure about the license with this one. I couldn't find an online version, so i had to upload it to hastebin. Please advise.