### PR TITLE
Add Joplin

### DIFF
--- a/joplin.json
+++ b/joplin.json
@@ -1,0 +1,35 @@
+{
+    "homepage": "https://joplin.cozic.net/",
+    "license": "MIT",
+    "version": "1.0.114",
+    "url": "https://github.com/laurent22/joplin/releases/download/v1.0.114/Joplin-Setup-1.0.114.exe#/dl.7z",
+    "hash": "069990b0b239cbc20c1dd326ffbd1f80d29d2125e7ee1a325f09a4b3799aa7d3",
+    "extract_dir": "\\$PLUGINSDIR",
+    "pre_install": "Get-ChildItem \"$dir\" -Exclude 'app-64.7z', 'app-32.7z' | Remove-Item -Force -Recurse",
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": "extract_7zip \"$dir\\app-64.7z\" \"$dir\""
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": "extract_7zip \"$dir\\app-32.7z\" \"$dir\""
+            }
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\app-64.7z\", \"$dir\\app-32.7z\"",
+    "bin": "Joplin.exe",
+    "shortcuts": [
+        [
+            "Joplin.exe",
+            "Joplin"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/laurent22/joplin"
+    },
+    "autoupdate": {
+        "url": "https://github.com/laurent22/joplin/releases/download/v$version/Joplin-Setup-$version.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
Adds manifest for the open source multi-platform note-taking app Joplin. 

Configuration and content are stored at $env:userprofile\\.config\\joplin-desktop, so no persistence needed.
