### PR TITLE
Fix Paint.net package; resolves #1397

### DIFF
--- a/paint.net.json
+++ b/paint.net.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.3",
+    "version": "4.1.4",
     "description": "Image and photo editing software.",
     "homepage": "https://www.getpaint.net/",
     "license": {
@@ -7,8 +7,8 @@
         "url": "https://www.getpaint.net/license.html"
     },
     "notes": ".NET 4.7.1 is required https://www.microsoft.com/en-us/download/details.aspx?id=56115",
-    "url": "https://www.dotpdn.com/files/paint.net.4.1.3.install.zip",
-    "hash": "0fcef83e822121ba9f64f12544ce4bc74d7059f6a62e86d7990cbb38761f5591",
+    "url": "https://www.dotpdn.com/files/paint.net.4.1.4.install.zip",
+    "hash": "b8e06fb2629dc08858247f12778ea47167a28f4187cf27b73354ce900f70e7c2",
     "pre_install": [
         "extract_7zip \"$dir\\paint.net.$version.install.exe\" \"$dir\\tmp\" $true",
         "Set-Content \"$dir\\PaintDotNet.AppSettings.json\" '{}' -Encoding Ascii"


### PR DESCRIPTION
Paint.net is actually on version 4.1.4, not 4.1.3, but when you download 4.1.3 from the URL, it actually downloads 4.1.4. I have updated the version, URL, and hash after manually verifying the package. Closes [#1397](https://github.com/lukesampson/scoop-extras/issues/1397).