### PR TITLE
Archive from vscode is zip not 7z.

### DIFF
--- a/vscode-insiders-portable.json
+++ b/vscode-insiders-portable.json
@@ -43,14 +43,14 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.7z",
+                "https://vscode-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ]
         },
         "32bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/latest/win32-archive/insider#/dl.7z",
+                "https://vscode-update.azurewebsites.net/latest/win32-archive/insider#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ]

--- a/vscode-insiders.json
+++ b/vscode-insiders.json
@@ -37,14 +37,14 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.7z",
+                "https://vscode-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ]
         },
         "32bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/latest/win32-archive/insider#/dl.7z",
+                "https://vscode-update.azurewebsites.net/latest/win32-archive/insider#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ]

--- a/vscode-portable.json
+++ b/vscode-portable.json
@@ -41,7 +41,7 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/1.28.2/win32-x64-archive/stable#/dl.7z",
+                "https://vscode-update.azurewebsites.net/1.28.2/win32-x64-archive/stable#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ],
@@ -53,7 +53,7 @@
         },
         "32bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/1.28.2/win32-archive/stable#/dl.7z",
+                "https://vscode-update.azurewebsites.net/1.28.2/win32-archive/stable#/dl.zip",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.github.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ],
@@ -67,14 +67,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://vscode-update.azurewebsites.net/$version/win32-x64-archive/stable#/dl.7z",
+                "url": "https://vscode-update.azurewebsites.net/$version/win32-x64-archive/stable#/dl.zip",
                 "hash": {
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jp": "$.products[?(@.platform.os == 'win32-x64-archive')].sha256hash"
                 }
             },
             "32bit": {
-                "url": "https://vscode-update.azurewebsites.net/$version/win32-archive/stable#/dl.7z",
+                "url": "https://vscode-update.azurewebsites.net/$version/win32-archive/stable#/dl.zip",
                 "hash": {
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jp": "$.products[?(@.platform.os == 'win32-archive')].sha256hash"

--- a/vscode.json
+++ b/vscode.json
@@ -35,7 +35,7 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/1.28.2/win32-x64-archive/stable#/dl.7z",
+                "https://vscode-update.azurewebsites.net/1.28.2/win32-x64-archive/stable#/dl.zip",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ],
@@ -47,7 +47,7 @@
         },
         "32bit": {
             "url": [
-                "https://vscode-update.azurewebsites.net/1.28.2/win32-archive/stable#/dl.7z",
+                "https://vscode-update.azurewebsites.net/1.28.2/win32-archive/stable#/dl.zip",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/vscode-install-context.reg",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/vscode-uninstall-context.reg"
             ],
@@ -61,14 +61,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://vscode-update.azurewebsites.net/$version/win32-x64-archive/stable#/dl.7z",
+                "url": "https://vscode-update.azurewebsites.net/$version/win32-x64-archive/stable#/dl.zip",
                 "hash": {
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jp": "$.products[?(@.platform.os == 'win32-x64-archive')].sha256hash"
                 }
             },
             "32bit": {
-                "url": "https://vscode-update.azurewebsites.net/$version/win32-archive/stable#/dl.7z",
+                "url": "https://vscode-update.azurewebsites.net/$version/win32-archive/stable#/dl.zip",
                 "hash": {
                     "url": "https://code.visualstudio.com/sha?build=stable",
                     "jp": "$.products[?(@.platform.os == 'win32-archive')].sha256hash"


### PR DESCRIPTION
Thanks for your great system. Today I discovered it and decided to switch from chocolatey to it. It worked smoothly except this vscode.

I tried to install vscode in both normal and portable mode and the script failed with 
```
λ scoop install vscode-portable
Installing 'vscode-portable' (1.28.2) [64bit]
stable (64.3 MB) [============================================================================================================] 100%
Checking hash of stable ... ok.
vscode-install-context.reg (490 B) [==========================================================================================] 100%
Checking hash of vscode-install-context.reg ... ok.
vscode-uninstall-context.reg (386 B) [========================================================================================] 100%
Checking hash of vscode-uninstall-context.reg ... ok.
Extracting dl.7z ... Exit code was -1.
```