### PR TITLE
Jigsaw: tweaks

### DIFF
--- a/jigsaw.json
+++ b/jigsaw.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.w3.org/Jigsaw",
-    "description": "W3C's HTTP 1.1 server implementation in Java",
+    "description": "W3C's HTTP 1.1 server implementation in Java.",
     "version": "2.2.6",
     "license": "W3C-20150513",
     "url": "https://jigsaw.w3.org/Distrib/jigsaw_2.2.6.zip",
@@ -28,15 +28,16 @@
             "Jigsaw\\Start JigAdmin Client"
         ]
     ],
-    "persist": [
-        "Jigsaw"
-    ],
-    "checkver": "jigsaw_[\\w.]+\\.zip",
+    "persist": "Jigsaw",
+    "checkver": {
+        "url": "https://www.w3.org/Jigsaw/RelNotes.html",
+        "regex": "Jigsaw ([\\d\\.\\w]+)</h2>"
+    },
     "autoupdate": {
         "url": "https://jigsaw.w3.org/Distrib/jigsaw_$version.zip",
         "hash": {
-            "url": "$url",
-            "find": "md5sum:\\s+([a-fA-F\\d]{32})"
+            "url": "https://www.w3.org/Jigsaw",
+            "find": "md5sum:\\s+([A-Fa-f\\d]{32})"
         }
     }
 }


### PR DESCRIPTION
- Fix checkver
- Fix hash extraction

I am not sure why this manifest have shortcuts. It's just scripts, which has no "gui". Just status terminal window.

Maybe move to main bucket?