### PR TITLE
mpc-be: Tweaks

### DIFF
--- a/mpc-be.json
+++ b/mpc-be.json
@@ -1,12 +1,11 @@
 {
     "homepage": "https://sourceforge.net/projects/mpcbe/",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/1.5.1/MPC-BE.1.5.1.x64.7z",
-            "hash": "b66b63fb0da8bc1a8cd20ff8a239b7d814d3e5870cc99be017593e993ac465de",
-            "extract_dir": "MPC-BE.1.5.1.2985.x64",
+            "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/1.5.2/MPC-BE.1.5.2.x64.7z",
+            "hash": "sha1:711e665c9ded1d555e4a6e3fd41eab5d9fe92b21",
             "bin": [
                 "mpc-be64.exe",
                 [
@@ -22,12 +21,9 @@
             ]
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/1.5.1/MPC-BE.1.5.1.x86.7z",
-            "hash": "48698e8b8a8af1ff487bc086325d3f511295ac094039a8771f5e1b9632523120",
-            "extract_dir": "MPC-BE.1.5.1.2985.x86",
-            "bin": [
-                "mpc-be.exe"
-            ],
+            "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/1.5.2/MPC-BE.1.5.2.x86.7z",
+            "hash": "sha1:d643756829d83dcf22b70e7d3c0cd8e51c45d599",
+            "bin": "mpc-be.exe",
             "shortcuts": [
                 [
                     "mpc-be.exe",
@@ -36,8 +32,23 @@
             ]
         }
     },
+    "pre_install": [
+        "$fold = (Get-ChildItem \"$dir\" 'MPC-BE*')[0]",
+        "Move-Item \"$dir\\$fold\\*\" $dir",
+        "Remove-Item \"$dir\\$fold\" -Force -Recurse"
+    ],
     "checkver": {
         "url": "https://sourceforge.net/projects/mpcbe/files/MPC-BE/Release%20builds/",
-        "re": "title=\"([\\d.]+)\"\\sclass=\"folder"
+        "regex": "title=\"([\\d\\.]+)\"\\s+class=\"folder"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/$version/MPC-BE.$version.x64.7z"
+            },
+            "32bit": {
+                "url": "https://downloads.sourceforge.net/project/mpcbe/MPC-BE/Release%20builds/$version/MPC-BE.$version.x86.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
- Bumped to 1.5.2
- Add autoupdate
- Remove `extract_dir`
    - Simulate it in `post_install` (=> Able to update using Excavator without errors)