### PR TITLE
Add manifest to install Archi

### DIFF
--- a/archi.json
+++ b/archi.json
@@ -41,10 +41,5 @@
             "Archi"
         ]
     ],
-    "bin": [
-        [
-            "archi.exe",
-            "archi"
-        ]
-    ]
+    "bin": "archi.exe"
 }

--- a/archi.json
+++ b/archi.json
@@ -32,7 +32,7 @@
         },
         "hash": {
             "url": "$url.MD5",
-            "find": "MD5\\s+\\(.*\\)\\s+=\\s+([a-fA-F0-9]{32})"
+            "find": "MD5 \\($basename\\) = ([A-Fa-f\\d]{32})"
         }
     },
     "shortcuts": [

--- a/archi.json
+++ b/archi.json
@@ -1,0 +1,50 @@
+{
+    "homepage": "https://www.archimatetool.com/",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/archimatetool/archi/blob/master/License.txt"
+    },
+    "description": "Archi® is a free, open source, cross-platform tool and editor to create ArchiMate models.",
+    "version": "4.3",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.archimatetool.com/downloads/root43/Archi-Win64-4.3.zip",
+            "hash": "md5:6cd67ca7494becdf4a09abc0f868a9ba"
+        },
+        "32bit": {
+            "url": "https://www.archimatetool.com/downloads/root43/Archi-Win32-4.3.zip",
+            "hash": "md5:3ea6ecb37bc8f0f1f08bbe2c51bdc3be"
+        }
+    },
+    "checkver": {
+        "url": "https://www.archimatetool.com/download/",
+        "re": "Archi ([\\d.]+),"
+    },
+    "extract_dir": "Archi",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.archimatetool.com/downloads/root$cleanVersion/Archi-Win64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://www.archimatetool.com/downloads/root$cleanVersion/Archi-Win32-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.MD5",
+            "find": "MD5\\s+\\(.*\\)\\s+=\\s+([a-fA-F0-9]{32})"
+        }
+    },
+    "shortcuts": [
+        [
+            "archi.exe",
+            "Archi"
+        ]
+    ],
+    "bin": [
+        [
+            "archi.exe",
+            "archi"
+        ]
+    ]
+}


### PR DESCRIPTION
Archi is an archimate enterprise architecture tool that can be
downloaded from www.archimatetool.com.