### PR TITLE
Updated download path for IrfanView Plugins

### DIFF
--- a/irfanview.json
+++ b/irfanview.json
@@ -9,7 +9,7 @@
         "64bit": {
             "url": [
                 "http://irfanview.info/files/iview451_x64.zip",
-                "https://www.fosshub.com/IrfanView.html/iview451_plugins_x64.zip"
+                "https://www.fosshub.com/IrfanView.html?dwl=iview451_plugins_x64.zip"
             ],
             "hash": [
                 "8112213E9A8AA406712E326523A5A8090D6A827EE5FBAF9EF055EB69E7E8D859",
@@ -25,7 +25,7 @@
         "32bit": {
             "url": [
                 "http://irfanview.info/files/iview451.zip",
-                "https://www.fosshub.com/IrfanView.html/iview451_plugins.zip"
+                "https://www.fosshub.com/IrfanView.html?dwl=iview451_plugins.zip"
             ],
             "hash": [
                 "79AB64955C1B877AD8C383E1C7B730E446580D56698C029FA65679613002A56B",


### PR DESCRIPTION
They've changed parameters from [path] to [query] in the download link.