### PR TITLE
Update snipaste's checkver.

### DIFF
--- a/snipaste.json
+++ b/snipaste.json
@@ -23,10 +23,7 @@
             "Snipaste"
         ]
     ],
-    "checkver": {
-        "url": "https://www.snipaste.com/download.html",
-        "re": "<b>v([\\d.]+)</b>"
-    },
+    "checkver": "Desktop ([\\.0-9]+)",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
snipaste now has two version: one for Desktop and another for Windows Store. I change checkver's regex to only check Desktop version.

Before:

```PowerShell
scoop-extras master % = $ .\bin\checkver.ps1 snipaste
snipaste: 2.1.3 (scoop version is 1.16.2) autoupdate available
```

After:

```PowerShell
scoop-extras master *% = $ .\bin\checkver.ps1 snipaste
snipaste: 1.16.2
```
