### PR TITLE
aida64extreme: Updated to 5.99 and fixed autoupdate url

### DIFF
--- a/aida64extreme.json
+++ b/aida64extreme.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://www.aida64.com",
     "description": "AIDA64 is a system information, diagnostics, and auditing application.",
-    "version": "5.98",
+    "version": "5.99",
     "license": "Shareware",
-    "url": "http://download.aida64.com/aida64extreme598.zip",
-    "hash": "2d276d8e9ad5499acf52c306b35b8796c6c154a44f8de8976cf774b798cfd703",
+    "url": "http://download.aida64.com/aida64extreme599.zip",
+    "hash": "1f99e46d3ec9fe8df7f7d7e654560656fc32d34b30b11fec7dc316d3ebaab22f",
     "installer": {
         "script": [
             "$FILE = 'aida64.ini'",
@@ -35,6 +35,6 @@
         "re": "AIDA64 Extreme v([\\d\\.]*)"
     },
     "autoupdate": {
-        "url": "http://download.aida64.com/aida64extreme$match2$match3.zip"
+        "url": "http://download.aida64.com/aida64extreme$cleanVersion.zip"
     }
 }


### PR DESCRIPTION
Fix autoupdate url by changing `$match2$match3` (they were not working) to `$cleanVersion`