### PR TITLE
cmake-rc: fix checkver to find the latest rc version

### DIFF
--- a/cmake-rc.json
+++ b/cmake-rc.json
@@ -22,8 +22,9 @@
         "bin/cmake-gui.exe"
     ],
     "checkver": {
-        "re": "Release\\s+Candidate.*\\(([\\d\\w.-]+)\\)",
-        "url": "https://cmake.org/download/"
+        "url": "https://gitlab.kitware.com/cmake/cmake/tags?sort=name_desc&format=atom",
+        "re": "v([\\d\\.]+)-rc([\\d]+)",
+        "replace": "${1}-rc${2}"
     },
     "shortcuts": [
         [


### PR DESCRIPTION
Fixed broken `checkver `to find the latest release candidate version