### PR TITLE
kitty: Updated to version 0.70.0.6 and replaced fosshub.com with portableapps.com

### DIFF
--- a/kitty.json
+++ b/kitty.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://kitty.9bis.net",
     "license": "MIT",
-    "version": "0.70.0.5",
-    "url": "https://www.fosshub.com/KiTTY.html/kitty_portable.exe",
-    "hash": "7872424693ce23fac1d47f01c0cf09ddde98435de2997e64015ae15143fe9cef",
+    "version": "0.70.0.6",
+    "url": "https://portableapps.com/redirect/?a=KiTTYPortable&s=s&d=pa&f=KiTTYPortable_0.70.0.6_English.paf.exe#/KiTTY_portable.exe",
+    "hash": "b173fb0cbaafc64baf0c60d9656737672a6971994813898745fade1a0b1eefc1",
     "bin": [
         [
             "kitty_portable.exe",
@@ -31,6 +31,6 @@
         "re": "The last version is ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/KiTTY.html/kitty_portable.exe"
+        "url": "https://portableapps.com/redirect/?a=KiTTYPortable&s=s&d=pa&f=KiTTYPortable_$version_English.paf.exe#/KiTTY_portable.exe"
     }
 }


### PR DESCRIPTION
Fixed broken fosshub.com urls by replacing with portableapps.com links and updated version with one move.