### PR TITLE
peerblock: Fix checkver

### DIFF
--- a/peerblock.json
+++ b/peerblock.json
@@ -60,8 +60,8 @@
         "CreateFile 'peerblock.conf.failed'"
     ],
     "checkver": {
-        "url": "https://sourceforge.net/projects/peerblock/files/",
-        "re": "v(?<release>[\\d.]+) Stable Release \\(r(?<build>\\d+)\\)",
+        "url": "http://forums.peerblock.com/feed.php?1,replies=1,type=rss",
+        "re": "PeerBlock\\s+(?<release>[\\d.]+)\\+\\s+\\(r(?<build>\\d+)\\)",
         "replace": "${release}.${build}"
     }
 }


### PR DESCRIPTION
Fix `checkver`:

- to be consistent with homepage
- to match with latest mirror from `scoopinstaller/binary-mirror`