### PR TITLE
etcher and etcher-cli: Update to 1.4.7 and adjust to renamings

### DIFF
--- a/etcher-cli.json
+++ b/etcher-cli.json
@@ -29,9 +29,9 @@
             "32bit": {
                 "url": "https://github.com/balena-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x86.zip"
             }
+        },
+        "hash": {
+            "url": "https://github.com/balena-io/etcher/releases/download/v$version/SHASUMS256-CLI.txt"
         }
-    },
-    "hash": {
-        "url": "https://github.com/balena-io/etcher/releases/download/v$version/SHASUMS256-CLI.txt"
     }
 }

--- a/etcher-cli.json
+++ b/etcher-cli.json
@@ -12,15 +12,10 @@
             "hash": "90a3bcec437c0cc3a955aa5a8dd1d30e9806259faa00e65d55eaffea433766d3"
         }
     },
-    "note": "Alias 'etcher' is still provided for backward compatibility.",
     "bin": [
         [
-            "balenaEtcher.exe",
+            "balena-etcher.exe",
             "etcher"
-        ],
-        [
-            "balenaEtcher.exe",
-            "balenaEtcher"
         ]
     ],
     "checkver": {

--- a/etcher-cli.json
+++ b/etcher-cli.json
@@ -4,11 +4,11 @@
     "version": "1.4.7",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x64.zip",
+            "url": "https://github.com/balena-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x64.zip",
             "hash": "7d67130ffa20200dd4fac2aa26e4c93e8de28d5c97f961616188de7ed8eb45a5"
         },
         "32bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x86.zip",
+            "url": "https://github.com/balena-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x86.zip",
             "hash": "90a3bcec437c0cc3a955aa5a8dd1d30e9806259faa00e65d55eaffea433766d3"
         }
     },
@@ -24,15 +24,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/resin-io/etcher"
+        "github": "https://github.com/balena-io/etcher"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x64.zip"
+                "url": "https://github.com/balena-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x86.zip"
+                "url": "https://github.com/balena-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x86.zip"
             }
         }
     }

--- a/etcher-cli.json
+++ b/etcher-cli.json
@@ -1,28 +1,38 @@
 {
     "homepage": "https://etcher.io/cli",
     "license": "Apache-2.0",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.6/etcher-cli-1.4.6-windows-x64.zip",
-            "hash": "8cc28b1cff774de7e76ef7a29c93e756bda56c216918be06970151397eb4837e"
+            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x64.zip",
+            "hash": "7d67130ffa20200dd4fac2aa26e4c93e8de28d5c97f961616188de7ed8eb45a5"
         },
         "32bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.6/etcher-cli-1.4.6-windows-x86.zip",
-            "hash": "ce0ba00e4b0a930ef8e5de44c27e57d196058d60c0bcba2f13807306d5147976"
+            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.7/balena-etcher-cli-1.4.7-windows-x86.zip",
+            "hash": "90a3bcec437c0cc3a955aa5a8dd1d30e9806259faa00e65d55eaffea433766d3"
         }
     },
-    "bin": "etcher.exe",
+    "note": "Alias 'etcher' is still provided for backward compatibility.",
+    "bin": [
+        [
+            "balenaEtcher.exe",
+            "etcher"
+        ],
+        [
+            "balenaEtcher.exe",
+            "balenaEtcher"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/resin-io/etcher"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/etcher-cli-$version-windows-x64.zip"
+                "url": "https://github.com/resin-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/etcher-cli-$version-windows-x86.zip"
+                "url": "https://github.com/resin-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x86.zip"
             }
         }
     }

--- a/etcher-cli.json
+++ b/etcher-cli.json
@@ -35,5 +35,8 @@
                 "url": "https://github.com/balena-io/etcher/releases/download/v$version/balena-etcher-cli-$version-windows-x86.zip"
             }
         }
+    },
+    "hash": {
+        "url": "https://github.com/balena-io/etcher/releases/download/v$version/SHASUMS256-CLI.txt"
     }
 }

--- a/etcher.json
+++ b/etcher.json
@@ -1,21 +1,21 @@
 {
     "homepage": "https://etcher.io/",
     "license": "Apache-2.0",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.6/Etcher-Setup-1.4.6-x64.exe#/dl.7z",
-            "hash": "3a8fc81c35e4d1d76716930ed91791fd4ba96c63edbbe22674dc8e39896bf245"
+            "url": "https://github.com/balena-io/etcher/releases/download/v1.4.7/balenaEtcher-Setup-1.4.7-x64.exe#/dl.7z",
+            "hash": "26ce9c13fa57c96570c385ddc5b323c9c5a9fa255168bfa4d91a93a9a1a42d99"
         },
         "32bit": {
-            "url": "https://github.com/resin-io/etcher/releases/download/v1.4.6/Etcher-Setup-1.4.6-x86.exe#/dl.7z",
-            "hash": "1bd33e28566b1c969a29699d61f4b8a9d145412a1e19ead1e828babb9bd8dfc4"
+            "url": "https://github.com/balena-io/etcher/releases/download/v1.4.7/balenaEtcher-Setup-1.4.7-x86.exe#/dl.7z",
+            "hash": "166c80092471a6db86fbc96c2885f8cb2e5b5613aefe3a33d551df35ae4627d0"
         }
     },
     "shortcuts": [
         [
-            "Etcher.exe",
-            "Etcher"
+            "balenaEtcher.exe",
+            "balenaEtcher"
         ]
     ],
     "checkver": {
@@ -25,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/Etcher-Setup-$version-x64.exe#/dl.7z"
+                "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-Setup-$version-x64.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://github.com/resin-io/etcher/releases/download/v$version/Etcher-Setup-$version-x86.exe#/dl.7z"
+                "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-Setup-$version-x86.exe#/dl.7z"
             }
         }
     }

--- a/etcher.json
+++ b/etcher.json
@@ -30,6 +30,9 @@
             "32bit": {
                 "url": "https://github.com/balena-io/etcher/releases/download/v$version/balenaEtcher-Setup-$version-x86.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "https://github.com/balena-io/etcher/releases/download/v$version/SHASUMS256.txt"
         }
     }
 }

--- a/etcher.json
+++ b/etcher.json
@@ -19,7 +19,7 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/resin-io/etcher"
+        "github": "https://github.com/balena-io/etcher"
     },
     "pre_install": "extract_7zip \"$dir\\`$PLUGINSDIR\\app-*.7z\" \"$dir\"",
     "autoupdate": {


### PR DESCRIPTION
Adjust to changes on etcher-side:

- `resin-io` was renamed to `balena-io`
- `etcher` was renamed to `balenaEtcher`
- `etcher-cli` was renamed to `balena-etcher`

and added hash urls.