### PR TITLE
KiTTY: Update to version 0.70.0.6

### DIFF
--- a/kitty.json
+++ b/kitty.json
@@ -1,9 +1,10 @@
 {
     "homepage": "http://kitty.9bis.net",
     "license": "MIT",
-    "version": "0.70.0.5",
-    "url": "https://www.fosshub.com/KiTTY.html/kitty_portable.exe",
-    "hash": "7872424693ce23fac1d47f01c0cf09ddde98435de2997e64015ae15143fe9cef",
+    "version": "0.70.0.6",
+    "url": "https://downloads.sourceforge.net/project/portableapps/KiTTY%20Portable/KiTTYPortable_0.70.0.6_English.paf.exe#/dl.7z",
+    "hash": "md5:bb8b410f19dea64009e3aaaa05309a24",
+    "extract_dir": "App\\KiTTY",
     "bin": [
         [
             "kitty_portable.exe",
@@ -31,6 +32,10 @@
         "re": "The last version is ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/KiTTY.html/kitty_portable.exe"
+        "url": "https://downloads.sourceforge.net/project/portableapps/KiTTY%20Portable/KiTTYPortable_$version_English.paf.exe#/dl.7z",
+        "hash": {
+            "url": "https://portableapps.com/apps/internet/kitty-portable",
+            "find": "([0-9a-fA-F]{32})"
+        }
     }
 }


### PR DESCRIPTION
Update KiTTY to version 0.70.0.6, change download source to sourceforge.net portableapp's version.