### PR TITLE
Fix for love extract_dir

### DIFF
--- a/love.json
+++ b/love.json
@@ -5,12 +5,12 @@
         "64bit": {
             "url": "https://bitbucket.org/rude/love/downloads/love-11.2-win64.zip",
             "hash": "6b42739d70d3a29e29e593d46482c333523acc87ff062cb3ca8ccb4667d6c564",
-            "extract_dir": "love-11.2-win64"
+            "extract_dir": "love-11.2.0-win64"
         },
         "32bit": {
             "url": "https://bitbucket.org/rude/love/downloads/love-11.2-win32.zip",
             "hash": "816fc2c11f23c0a023081172c1dcec2f1dbc8f46c17258dd795bd18ee731d2dd",
-            "extract_dir": "love-11.2-win32"
+            "extract_dir": "love-11.2.0-win32"
         }
     },
     "bin": [


### PR DESCRIPTION
Love devs still use `11.x` as version in a zip name and `11.x.0` for a directory.