### PR TITLE
everything: Move ini to a folder to prevent app from breaking hardlinks

### DIFF
--- a/everything.json
+++ b/everything.json
@@ -12,15 +12,25 @@
             "hash": "8d3d85888ccd01612993f89a9d79df11edb2f06de78972fa71656f74920ce342"
         }
     },
-    "bin": "Everything.exe",
+    "bin": [
+        [
+            "Everything.exe",
+            "everything",
+            "-config data/Everything.ini"
+        ]
+    ],
     "checkver": "Download Everything ([\\d.]+)",
     "persist": [
-        "Everything.ini",
-        "Everything.db"
+        "data"
     ],
     "pre_install": [
-        "if(!(test-path \"$dir\\Everything.ini\")) { & \"$dir\\Everything.exe\" -install-config null }",
-        "if(!(test-path \"$dir\\Everything.db\")) { Add-Content \"$dir\\Everything.db\" $null }"
+        "$data_dir = \"$dir\\data\"",
+        "if(!(Test-Path \"$data_dir\")) {",
+        "    New-Item \"$data_dir\" -ItemType Directory | Out-Null",
+        "}",
+        "if(!(test-path \"$persist_dir\\data\\Everything.ini\")) { ",
+        "   & \"$dir\\Everything.exe\" -config \"$data_dir\\Everything.ini\" -install-config null",
+        "}"
     ],
     "autoupdate": {
         "architecture": {
@@ -38,7 +48,8 @@
     "shortcuts": [
         [
             "Everything.exe",
-            "Everything"
+            "Everything",
+            "-config data/Everything.ini"
         ]
     ]
 }


### PR DESCRIPTION
#1312 
There is two file to persist:
- Everything.ini : it contains the actual settings
- Everything.db : it contains an index of the filesystem

I had the idea to move them to a directory, so the app won't break the hardlinks by recreating the files. And it works, but I had to tell everything.exe to use ones from the directory.
As you can see [here](https://www.voidtools.com/support/everything/command_line_options/#-config), there is a command line option to pass the .ini path at startup. [There's one](https://www.voidtools.com/support/everything/command_line_options/#-db) for the .db as well, but it works in read-only mode only.
So I saw two options: to save data to user/appdata or save just .ini and ignore the index db.

I chose to not to persist db, because I think it's not a big deal after an update to re-index the filesystem. I takes max 4 seconds on my average pc, and the [doc](https://www.voidtools.com/support/everything/using_everything/) also claims it's just a few second.