### PR TITLE
Wavebox: Bumped to 4.5.0

### DIFF
--- a/wavebox.json
+++ b/wavebox.json
@@ -1,16 +1,12 @@
 {
-    "version": "4.4.0",
+    "version": "4.5.0",
     "description": "Bring all your web communication tools together for faster, smarter working.",
     "homepage": "https://wavebox.io/",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://wavebox.pro/dl/client/4_4_0/Wavebox_4_4_0_windows_x86_64/wavebox-4.4.0-full.nupkg#/dl.7z",
-            "hash": "sha1:1b3cec50f8edc0aec15f03a40bd950b4cfae167c"
-        },
-        "32bit": {
-            "url": "https://wavebox.pro/dl/client/4_4_0/Wavebox_4_4_0_windows_ia32/wavebox-4.4.0-full.nupkg#/dl.7z",
-            "hash": "sha1:e796ad4723826281b7ea7fd9c5e73e57a579af07"
+            "url": "https://wavebox.pro/dl/client/4_5_0/Wavebox_4_5_0_windows_x86_64/wavebox-4.5.0-full.nupkg",
+            "hash": "sha1:a85f540a8dd0c44cf35c6fe7fd6fd5b731961df2"
         }
     },
     "extract_dir": "lib\\net45",
@@ -29,10 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://wavebox.pro/dl/client/$underscoreVersion/Wavebox_$underscoreVersion_windows_x86_64/wavebox-$version-full.nupkg#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://wavebox.pro/dl/client/$underscoreVersion/Wavebox_$underscoreVersion_windows_ia32/wavebox-$version-full.nupkg#/dl.7z"
+                "url": "https://wavebox.pro/dl/client/$underscoreVersion/Wavebox_$underscoreVersion_windows_x86_64/wavebox-$version-full.nupkg"
             }
         },
         "hash": {


### PR DESCRIPTION
- Removed 32bit version
- No need to change filename since, nupkg is extracted automatically after lukesampson/scoop@2224da82f8a786b8ae9c203c67924b4c6ef2c652

> We're hoping to move over to just 64-bit having seen quite a big drop in 32-bit users over the last year.