### PR TITLE
Use double quotes for the registry file in VS Code notes

### DIFF
--- a/vscode-insiders-portable.json
+++ b/vscode-insiders-portable.json
@@ -6,10 +6,10 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "VSCode now supports Portable Mode! Please move the following directories:",
+        "Visual Studio Code now supports Portable Mode! Please move the following directories:",
         "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders\\data\\extensions\"",
         "From \"$env:APPDATA\\Code - Insiders\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders\\data\\user-data\"",
-        "Add VSCode as a context menu option by running: '$dir\\vscode-install-context.reg'"
+        "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\""
     ],
     "bin": [
         [

--- a/vscode-insiders.json
+++ b/vscode-insiders.json
@@ -6,7 +6,7 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "Add VSCode as a context menu option by running: '$dir\\vscode-install-context.reg'"
+        "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\""
     ],
     "bin": [
         [

--- a/vscode-portable.json
+++ b/vscode-portable.json
@@ -6,10 +6,10 @@
         "url": "https://code.visualstudio.com/License/"
     },
     "notes": [
-        "VSCode now supports Portable Mode! Please move the following directories:",
+        "Visual Studio Code now supports Portable Mode! Please move the following directories:",
         "From \"$env:USERPROFILE\\.vscode\\extensions\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-portable\\data\\extensions\"",
         "From \"$env:APPDATA\\Code\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-portable\\data\\user-data\"",
-        "Add VSCode as a context menu option by running: '$dir\\vscode-install-context.reg'"
+        "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\""
     ],
     "bin": [
         [

--- a/vscode.json
+++ b/vscode.json
@@ -5,7 +5,7 @@
         "identifier": "Freeware",
         "url": "https://code.visualstudio.com/License/"
     },
-    "notes": "Add VSCode as a context menu option by running: '$dir\\vscode-install-context.reg'",
+    "notes": "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\"",
     "bin": [
         [
             "bin\\code.cmd",


### PR DESCRIPTION
This makes it possible to select the whole path by double-clicking it, then run it by pasting the path as-is in cmd.exe or PowerShell.

The official name for Visual Studio Code is also now used.