### PR TITLE
Sysinternals - Specify extract dir

### DIFF
--- a/sysinternals.json
+++ b/sysinternals.json
@@ -7,13 +7,15 @@
     "version": "December.13.2018",
     "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
     "hash": "41deb4af2d9b6dbac25927de168cf9eeb9535892bb213cc295c9acca93584563",
+    "extract_dir": "SysinternalsSuite",
     "checkver": {
         "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/sysinternals-suite",
         "re": "\\bUpdated:\\s*(\\w+)\\s+(\\d+),\\s+(\\d+)\\b",
         "replace": "${1}.${2}.${3}"
     },
     "autoupdate": {
-        "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip"
+        "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
+        "extract_dir": "SysinternalsSuite"
     },
     "architecture": {
         "32bit": {


### PR DESCRIPTION
Installing `sysinternals` returns the following error.

```
Installing 'sysinternals' (December.13.2018) [64bit]
Loading SysinternalsSuite.zip from cache
Checking hash of SysinternalsSuite.zip ... ok.
Extracting SysinternalsSuite.zip ... done.
Linking ~\scoop\apps\sysinternals\current => ~\scoop\apps\sysinternals\December.13.2018
Creating shim for 'accesschk'.
Can't shim 'accesschk64.exe': File doesn't exist.
```