### PR TITLE
Eclipse 2018-12

### DIFF
--- a/eclipse-committers.json
+++ b/eclipse-committers.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-committers.json
+++ b/eclipse-committers.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-committers-2018-12-win32-x86_64.zip",
-            "hash": "d0495e44568fcfad92eb9724e74babc9d823848d66d3296efd8c0e9613f64924"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-committers-2018-12-win32.zip",
-            "hash": "b28faf47a568afdb2123977ede4c8ac88ce7dc6c4d3a91f4d45404a62d0206d0"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-committers-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:67c772f73a354e554ab6d26e6431b1aa4ad664a3d2a36d50b96b39ed8780c869561c14d5316c8084f17ca2f9d9e2d1ca4d98db6867c05c2bcf0799111e9aa84c"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-cpp.json
+++ b/eclipse-cpp.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-cpp.json
+++ b/eclipse-cpp.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-cpp-2018-12-win32-x86_64.zip",
-            "hash": "f6dd79634066e8ff28c279ad7463b085b9e1084c9524034f61326d51bf1cad31"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-cpp-2018-12-win32.zip",
-            "hash": "2239cbd4ec9a0566620c4d399d51542f719971e770024d9204ca04ec5af1a2e3"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-cpp-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:7d89d0ec0f92f61b29e4fd93698d685e1749253e79718a8a6671aa8ece1cfe4d3c030e42db98a393ef0798292d1bfa7e7630ba47dad4b3c7eec5ea47ce7c0b09"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-dsl.json
+++ b/eclipse-dsl.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-dsl.json
+++ b/eclipse-dsl.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-dsl-2018-12-win32-x86_64.zip",
-            "hash": "8aee9a06f970743cf042a1a6f56cecf5cd687906667510b7ea32874424048677"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-dsl-2018-12-win32.zip",
-            "hash": "d685eaad46eb6f4b3d0a86484dac61027393ab1db2f7801c6d14fe7c5d5365be"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-dsl-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:7ac97a53fca16207a388c831c69f8ba86736b646ea4b263954f10f55a0af10cbacb1d876d03d20acc28f0925e9526cae7abb8ddad975fe2eaaf3a62d109bb675"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-java.json
+++ b/eclipse-java.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-java.json
+++ b/eclipse-java.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-java-2018-12-win32-x86_64.zip",
-            "hash": "9dd7039d81e6f554d0b0da0f0930365ce2cdf3482461b7c49e14afbb53cb8764"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-java-2018-12-win32.zip",
-            "hash": "141f16312779200ad02b7af005b5de92efacba55a7ec4bd3cf70c7f458bb1244"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-java-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:b27dc010eea4c805e90c95d44823ff45832c7c55eff1dc19211ac5ba58aaba06762bfd7e3d517139ab638f7b11149c5690c3a42c25cb62afe39f3b2133c421b0"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-javascript.json
+++ b/eclipse-javascript.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-javascript-2018-12-win32-x86_64.zip",
-            "hash": "7daaf4361852bb15c02727d574090744df41cf09a1825b108d4f262bb3cb3220"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-javascript-2018-12-win32.zip",
-            "hash": "005ee2d9e4ee4be3591eecb6346986eda5d20878d84123e40606934ad23430be"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-javascript-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:e959a1175ed8f5d541ef6521d17b1ce1de2249182c947e55932571ea387564423f7fc6e99c3b5ca1a4e67230ceb99dc849e602f058cab960f8f76ed2892cda70"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-javascript.json
+++ b/eclipse-javascript.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-jee.json
+++ b/eclipse-jee.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-jee.json
+++ b/eclipse-jee.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-jee-2018-12-win32-x86_64.zip",
-            "hash": "0b01b291b23bf406531a7dc8cb08e5ce61233aba0942e4fbc67f5ff2114eed29"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-jee-2018-12-win32.zip",
-            "hash": "589ce1342a8b58e66c982288d2ac89c14db5e7b49c79f8b3f7c5ca141b8fd806"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-jee-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:9157728d6f951f8fedb196fd0204e2dbd61a170a7ed096c1b71454ea4c25c8cff513656909c0ab8d97c95cd6fdcf2cbaa7a6d5fc728a9593568d917cd92d3cd9"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-modeling.json
+++ b/eclipse-modeling.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-modeling-2018-12-win32-x86_64.zip",
-            "hash": "38c71eaef13e6943874e410a07de42a0bac37556bf7930192d3aaef7ae0cdfc2"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-modeling-2018-12-win32.zip",
-            "hash": "1a72be58e0b1b993518f62e6f359bde166e67dacf44c50d05d305f1c2b85e4db"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-modeling-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:f956142a5fe2a0bf3720aced73243a4f0d6659b1a4d07f72a5bbf680c207b4ba02ac0ab84ab08979283c98730a80409c02d9b64202b96d06a7254ea968942e5f"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-modeling.json
+++ b/eclipse-modeling.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-parallel.json
+++ b/eclipse-parallel.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-parallel.json
+++ b/eclipse-parallel.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-parallel-2018-12-win32-x86_64.zip",
-            "hash": "223ee4f007296f518539d41a3850e16b461ea908a3d5515bf7048674d8fd3ac0"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-parallel-2018-12-win32.zip",
-            "hash": "8172726b5c05dae3ad68d7f6776ef2fd10d6aa82e63fbc74f774257df53f6e58"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-parallel-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:7477a950df262df7a0c05cd9097f7e1f532213116230490194088360fe5b1b86098d32ca177e5dfee531bba9070ad5b18200c3d294a07380dc238857f9742f2a"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-php.json
+++ b/eclipse-php.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-php-2018-12-win32-x86_64.zip",
-            "hash": "4b6f670c1025c4d4021af796a1d694f5d4352ff071ba501be17787b47d800a78"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-php-2018-12-win32.zip",
-            "hash": "35085c74bbbd1bbfdf5a9c9fc63933b1a54c65d1b485d4d2546b50c5a5390e8a"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-php-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:ede88ae3f2d8878725d25f9fb5abd24fddbdd0ce1e4640ac76f1247a6db09728d12d674a36cae8a298b87f2f757d73c195cd912e0b6351609935c3df34a991de"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-php.json
+++ b/eclipse-php.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-platform.json
+++ b/eclipse-platform.json
@@ -26,7 +26,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-platform-$matchRelease-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-platform-$matchRelease-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-platform-$matchRelease-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-platform.json
+++ b/eclipse-platform.json
@@ -6,10 +6,6 @@
         "64bit": {
             "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-platform-4.10-win32-x86_64.zip",
             "hash": "sha512:b54c2532d62a9c47e662f96926feeea77735809139c5adc03d9c1fa27782159614f5f1ea14e235b072edb7d8049759cd670995587029c9a4c388e3c806964501"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-platform-4.10-win32.zip",
-            "hash": "f6eb4ca38fe8c14c2966f998a9391898e3efc739d7a8a55c0325a8e4d53f6abb"
         }
     },
     "extract_dir": "eclipse",
@@ -31,13 +27,6 @@
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-platform-$matchRelease-win32-x86_64.zip",
                 "hash": {
                     "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-platform-$matchRelease-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-platform-$matchRelease-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-platform-$matchRelease-win32.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-rcp.json
+++ b/eclipse-rcp.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-rcp-2018-12-win32-x86_64.zip",
-            "hash": "fe171cbfde7dd032bce9b7ec16d7b31020099f090f4243610a23051275781687"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-rcp-2018-12-win32.zip",
-            "hash": "fbf4452ef05c5897ffc2e207411a85179206e9ebbdccb6b8d4594cb1ebf4381d"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-rcp-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:6de687d94f91680a008840c428987c140d9b9bc8330bbaf566d99d7bcb659b73eba4ed99c960150455af2cb8c87cc1cfbc7623caec2db0781dc63cf9dff551b5"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-rcp.json
+++ b/eclipse-rcp.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-reporting.json
+++ b/eclipse-reporting.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-reporting.json
+++ b/eclipse-reporting.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-reporting-2018-12-win32-x86_64.zip",
-            "hash": "ef2a04872ed385f0e48768f4a232e4509fea7ef1eb88eed5c429da3f28b8ca4e"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-reporting-2018-12-win32.zip",
-            "hash": "6fce9cd29c0c4df724f5973c97cd788e73d38905f7dcdb57295049864d1fdc75"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-reporting-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:72a8c8ac18e7059db684046e5e02bdd19008fd4ca107ad2e510467e49d8db8a1ae627e304e79aef7fd24b0200765041efe1d27e48b15af55db875b3cb15c3730"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-rust.json
+++ b/eclipse-rust.json
@@ -12,7 +12,7 @@
     "shortcuts": [
         [
             "eclipse.exe",
-            "Eclipse for Testers"
+            "Eclipse for Rust Developers"
         ]
     ],
     "checkver": {

--- a/eclipse-rust.json
+++ b/eclipse-rust.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://www.eclipse.org",
+    "license": "EPL-1.0",
+    "version": "2018-12",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-rust-2018-12-R-incubation-win32-x86_64.zip",
+            "hash": "sha512:068f389622bee9f7cad881714b89d667364fe5a73214acc32d241c2d35a0b64d344589049b5eb4ea4b6630544257323e9427b5a841e01047e0b5679c60f2b72f"
+        }
+    },
+    "extract_dir": "eclipse",
+    "shortcuts": [
+        [
+            "eclipse.exe",
+            "Eclipse for Testers"
+        ]
+    ],
+    "checkver": {
+        "url": "http://download.eclipse.org/technology/epp/downloads/release/release.xml",
+        "re": "\\<present\\>([\\d]{4}-[\\d]{2})\\/(?<r>[\\w]+)\\<\\/present\\>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip",
+                "hash": {
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip.sha512",
+                    "find": "([a-fA-F0-9]{128})"
+                }
+            }
+        }
+    }
+}

--- a/eclipse-rust.json
+++ b/eclipse-rust.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-scout.json
+++ b/eclipse-scout.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-scout.json
+++ b/eclipse-scout.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-scout-2018-12-win32-x86_64.zip",
-            "hash": "ec01bc86756e911b13ea78c8438b39137b983febde0a7232ee997cd68dd26b47"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-scout-2018-12-win32.zip",
-            "hash": "bcacf969d977688ea72b3b91dafe592d9bdef60a7e7d27adefe8c2d9b8ff48d6"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-scout-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:3d6236b879902ccdd7c98f91ce03550e4022bfe8dea0b6931b77b1139c19cd9a56dc2f6a4f65a4e6b80de7cb1edd96b407bb7cc749edc04b75f546a8c3d111db"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-sdk.json
+++ b/eclipse-sdk.json
@@ -25,7 +25,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-SDK-$matchRelease-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-SDK-$matchRelease-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-SDK-$matchRelease-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-sdk.json
+++ b/eclipse-sdk.json
@@ -6,10 +6,6 @@
         "64bit": {
             "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-win32-x86_64.zip",
             "hash": "sha512:892409bc7bb19fec6ef76c65aa2aa51822df7a6868d1a1eb10a7407aab6621116c5f6da7dc3ff4ed96228b461a33c7a0d80f5f9334124a48918cbae0ab4194a0"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-win32.zip",
-            "hash": "34b89a3363519419d3350d9d028633fa1a43ea9c555f84a470b0a7143a813e0a"
         }
     },
     "extract_dir": "eclipse",
@@ -30,13 +26,6 @@
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-SDK-$matchRelease-win32-x86_64.zip",
                 "hash": {
                     "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-SDK-$matchRelease-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-SDK-$matchRelease-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-SDK-$matchRelease-win32.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-testing.json
+++ b/eclipse-testing.json
@@ -4,12 +4,8 @@
     "version": "2018-12",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-testing-2018-12-win32-x86_64.zip",
-            "hash": "6e34d5c75106b5123f843e8561799d26123e20dc663035015b39f1a2a1a59749"
-        },
-        "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-testing-2018-12-win32.zip",
-            "hash": "c31f84dbff7fe0d389917026e39907850f0059fbf6978a05ab9b49cdfb1224a8"
+            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2018-12/R/eclipse-testing-2018-12-R-win32-x86_64.zip",
+            "hash": "sha512:356b54e6ec536cc1ea6a44eaf6087e90a678b12fee731737fa3f3cba1c9dd2e57a4bc3781d45e03571e4d53502b1f22e8c8b2edd13bf8499bcf51755695b86c9"
         }
     },
     "extract_dir": "eclipse",
@@ -26,16 +22,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-win32-x86_64.zip",
+                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-win32-x86_64.zip.sha512",
-                    "find": "([a-fA-F0-9]{128})"
-                }
-            },
-            "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-win32.zip",
-                "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-win32.zip.sha512",
+                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }

--- a/eclipse-testing.json
+++ b/eclipse-testing.json
@@ -24,7 +24,7 @@
             "64bit": {
                 "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip",
                 "hash": {
-                    "url": "http://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip.sha512",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             }


### PR DESCRIPTION
- Fixed download and hash url
- Removed 32-bit
- Added eclipse-rust

Closes #1544 
Also closes #1548, fixes #1549 and resolves #1550.