### PR TITLE
Updated CheatEngine 6.8.1 -> 6.8.2

### DIFF
--- a/cheat-engine.json
+++ b/cheat-engine.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://cheatengine.org/index.php",
     "description": "a tool for modifying, debugging, single player games and applications",
-    "version": "6.8.1",
+    "version": "6.8.2",
     "innosetup": true,
-    "url": "https://github.com/cheat-engine/cheat-engine/releases/download/v6.8.1/CheatEngine681.exe",
-    "hash": "6f795f11fa3983b4779426dd6dce8346e279b099f62ad4bab5d246b932e09885",
+    "url": "https://github.com/cheat-engine/cheat-engine/releases/download/6.8.2/CheatEngine682.exe",
+    "hash": "61a35039e8da357e9d6f06642f417dc897ed9a077f6a99e84b46ada1a211d949",
     "architecture": {
         "64bit": {
             "shortcuts": [
@@ -43,6 +43,6 @@
         "github": "https://github.com/cheat-engine/cheat-engine"
     },
     "autoupdate": {
-        "url": "https://github.com/cheat-engine/cheat-engine/releases/download/v$version/CheatEngine$cleanVersion.exe"
+        "url": "https://github.com/cheat-engine/cheat-engine/releases/download/$version/CheatEngine$cleanVersion.exe"
     }
 }


### PR DESCRIPTION
Removed the v prefix in the auto-update key because it only works with `v6.8.1`. See https://github.com/cheat-engine/cheat-engine/issues/477