### PR TITLE
Add typora v0.9.9.60

### DIFF
--- a/typora.json
+++ b/typora.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.9.9.60",
+    "description": "A decent markdown editor finally available on Windows",
+    "homepage": "https://typora.io",
+    "license": {
+        "identifier": "Commercial",
+        "url": "https://support.typora.io/Privacy-Policy/"
+    },
+    "notes": "Free during beta.",
+    "architecture": {
+        "64bit": {
+            "url": "https://typora.io/windows/typora-setup-x64.exe",
+            "hash": "0afcb283e30dba4722fbbaa96395c671e2af97a55246e2bfad91e6c2c0ad3d0f"
+        },
+        "32bit": {
+            "url": "https://typora.io/windows/typora-setup-ia32.exe",
+            "hash": "cda2e384980800f7e86c1a7b98d0c362f71c2f3102c63a01b0f98c5a8e02ba09"
+        }
+    },
+    "innosetup": true,
+    "bin": "bin\\typora.exe",
+    "shortcuts": [
+        [
+            "Typora.exe",
+            "Typora"
+        ]
+    ],
+    "checkver": {
+        "url": "https://typora.io/windows/dev_release.html",
+        "regex": "<h4>([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://typora.io/windows/typora-setup-x64.exe"
+            },
+            "32bit": {
+                "url": "https://typora.io/windows/typora-setup-ia32.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Typora v0.9.9.60, a truly minimal markdown editor.

- Name: Typora
- Description: A powerful wysiwyg markdown editor.
- Version: 0.9.9.60
- Homepage: https://typora.io
- Note: typora.io built Typora as a Commercial software. FREE during beta.