### PR TITLE
add wslgit 0.6.0

### DIFF
--- a/wslgit.json
+++ b/wslgit.json
@@ -1,0 +1,28 @@
+{
+    "description": "A small executable that forwards all arguments to git running inside Bash on Windows/Windows Subsystem for Linux (WSL)",
+    "version": "0.6.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/andy-5/wslgit/releases/download/v0.6.0/wslgit.exe",
+            "hash": "acd220702cfc6d2dd23b0aac8e52abc2318c5efdf6367ce93979d16c4cfd174c"
+        }
+    },
+    "depends": ["extras/vcredist2017"],
+    "homepage": "https://github.com/andy-5/wslgit",
+    "bin": "wslgit.exe",
+    "checkver": {
+        "url": "https://github.com/andy-5/wslgit/releases/latest",
+        "re": "/releases/tag/v([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/andy-5/wslgit/releases/download/v$version/wslgit.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/wslgit.json
+++ b/wslgit.json
@@ -8,13 +8,12 @@
             "hash": "acd220702cfc6d2dd23b0aac8e52abc2318c5efdf6367ce93979d16c4cfd174c"
         }
     },
-    "depends": ["extras/vcredist2017"],
+    "suggest": {
+        "vcredist": "extras/vcredist2017"
+    },
     "homepage": "https://github.com/andy-5/wslgit",
     "bin": "wslgit.exe",
-    "checkver": {
-        "url": "https://github.com/andy-5/wslgit/releases/latest",
-        "re": "/releases/tag/v([\\d\\.]+)"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/wslgit.json
+++ b/wslgit.json
@@ -20,9 +20,6 @@
             "64bit": {
                 "url": "https://github.com/andy-5/wslgit/releases/download/v$version/wslgit.exe"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
This is a small executable that forwards all arguments to git running inside Bash on Windows/Windows Subsystem for Linux (WSL)