### PR TITLE
Add cloud directory to npp persist

### DIFF
--- a/notepadplusplus.json
+++ b/notepadplusplus.json
@@ -17,6 +17,7 @@
     "bin": "notepad++.exe",
     "persist": [
         "backup",
+        "cloud",
         "plugins",
         "themes",
         "config.xml",


### PR DESCRIPTION
Npp can save config to cloud folder, like Dropbox or Google Drive, this setting should be persisted as well.