### PR TITLE
Ditto: Fix manifest

### DIFF
--- a/ditto.json
+++ b/ditto.json
@@ -1,5 +1,9 @@
 {
     "version": "3.22.20.0",
+    "description": [
+        "Clipboard Manager that saves each item placed on the clipboard",
+        "allowing you access to any of those items at a later time."
+    ],
     "homepage": "https://ditto-cp.sourceforge.io/",
     "license": "GPL-3.0-only",
     "architecture": {
@@ -33,7 +37,7 @@
         "$file = 'Ditto.Settings'",
         "if (!(Test-Path \"$persist_dir\\$file\")) {",
         "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
-        "    $CONT = @('[Ditto]\r\nDBPath3=Ditto.db')",
+        "    $CONT = @('[Ditto]', 'DBPath3=Ditto.db')",
         "    Set-Content \"$dir\\$file\" ($CONT -join \"`r`n\") -Encoding Ascii",
         "}"
     ],
@@ -50,10 +54,6 @@
             "64bit": {
                 "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoPortable_64bit_$underscoreVersion.zip"
             }
-        },
-        "hash": {
-            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/",
-            "regex": "$basename.+?([A-Fa-f0-9]{40})"
         }
     }
 }

--- a/ditto.json
+++ b/ditto.json
@@ -1,9 +1,6 @@
 {
     "version": "3.22.20.0",
-    "description": [
-        "Clipboard Manager that saves each item placed on the clipboard",
-        "allowing you access to any of those items at a later time."
-    ],
+    "description": "An enhanced clipboard manager.",
     "homepage": "https://ditto-cp.sourceforge.io/",
     "license": "GPL-3.0-only",
     "architecture": {

--- a/ditto.json
+++ b/ditto.json
@@ -1,38 +1,59 @@
 {
     "version": "3.22.20.0",
-    "extract_dir": "Ditto",
+    "homepage": "https://ditto-cp.sourceforge.io/",
+    "license": "GPL-3.0-only",
     "architecture": {
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.22.20.0/DittoSetup_3_22_20_0.exe",
-            "hash": "sha1:1050e5183b81b0138ecbbec49b3dc7e4764870d4"
+            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.22.20.0/DittoPortable_3_22_20_0.zip",
+            "hash": "sha1:5829beb390c2fa189242abb1918cc4ada761877f"
         },
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.22.20.0/DittoSetup_64bit_3_22_20_0.exe",
-            "hash": "sha1:b4c9b296fdc386cf25f28f39233d4c744aa25d17"
+            "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/3.22.20.0/DittoPortable_64bit_3_22_20_0.zip",
+            "hash": "sha1:37cec4a63b6ea38f5c3e797cc7840b88457f939d"
         }
     },
-    "homepage": "http://ditto-cp.sourceforge.net/",
-    "innosetup": true,
+    "extract_dir": "Ditto",
     "bin": "Ditto.exe",
-    "persist": [
-        "Ditto.db",
-        "Ditto.Settings"
-    ],
-    "checkver": "var versionDots=\"([\\d.]+)\"",
     "shortcuts": [
         [
             "Ditto.exe",
             "Ditto"
         ]
     ],
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\Ditto.db\")) {",
+        "    Write-Host 'File Ditto.db does not exists. Creating.' -f Yellow",
+        "    Start-Process -FilePath \"$dir\\Ditto.exe\"",
+        "    while (!(Test-Path \"$dir\\Ditto.db\")) {",
+        "        Start-Sleep -Milliseconds 500",
+        "    }",
+        "    Start-Sleep 1",
+        "    Stop-Process -Name Ditto",
+        "}",
+        "$file = 'Ditto.Settings'",
+        "if (!(Test-Path \"$persist_dir\\$file\")) {",
+        "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
+        "    $CONT = @('[Ditto]\r\nDBPath3=Ditto.db')",
+        "    Set-Content \"$dir\\$file\" ($CONT -join \"`r`n\") -Encoding Ascii",
+        "}"
+    ],
+    "persist": [
+        "Ditto.db",
+        "Ditto.Settings"
+    ],
+    "checkver": "var versionDots=\"([\\d.]+)\"",
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoSetup_$underscoreVersion.exe"
+                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoPortable_$underscoreVersion.zip"
             },
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoSetup_64bit_$underscoreVersion.exe"
+                "url": "https://downloads.sourceforge.net/project/ditto-cp/Ditto/$version/DittoPortable_64bit_$underscoreVersion.zip"
             }
+        },
+        "hash": {
+            "url": "https://sourceforge.net/projects/ditto-cp/files/Ditto/$version/",
+            "regex": "$basename.+?([A-Fa-f0-9]{40})"
         }
     }
 }


### PR DESCRIPTION
Current manifest of Ditto is a broken one, it's not portable and the `persist` is wrong.

The fixes are:

- Change `url` from installer to portable zip
- `homepage` move to new one
- Add `autoupdate.hash`
- Fix `persist` by some slightly complicated hardcode (start ditto.exe, wait until it created ditto.db, kill ditto.exe)

Now it works fine, at least for me.