### PR TITLE
Add weasel-pageant 1.2

### DIFF
--- a/weasel-pageant.json
+++ b/weasel-pageant.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://github.com/vuori/weasel-pageant",
+    "description": "weasel-pageant allows you to use SSH keys held by PuTTY's Pageant in WSL",
+    "license": "GNU GPL v3",
+    "version": "1.2",
+    "url": "https://github.com/vuori/weasel-pageant/releases/download/v1.2/weasel-pageant-1.2.zip",
+    "extract_dir": "weasel-pageant-1.2",
+    "hash": "f4965a80e8aeb425f432173c8377bfb31f62b2c061a3ca2f578b5c2b8e7f7e07",
+    "checkver": {
+        "github": "https://github.com/vuori/weasel-pageant"
+    },
+    "autoupdate": {
+        "url": "https://github.com/vuori/weasel-pageant/archive/weasel-pageant-$version.zip",
+        "extract_dir": "weasel-pageant-$version"
+    },
+    "notes": [
+        "Add 'eval $(/mnt/c/Users/$USER/scoop/apps/weasel-pageant/current/weasel-pageant -r)' to your WSL ~/.bashrc",
+        "More information about setup can be read on https://github.com/vuori/weasel-pageant/blob/master/README.md"
+    ]
+}


### PR DESCRIPTION
Hey,

I added the tool weasel-pageant which allows you to use your ssh keys from pageant in WSL directly. I already tested the installation once. You don't need any environment variables or something, but you have to add the following command to your personal .bashrc / .bash_profile:

`eval $(/mnt/c/Users/$USER/scoop/apps/weasel-pageant/current/weasel-pageant -r)`

Kind regards