### PR TITLE
Add autoupdate.hash and change license.identifier

### DIFF
--- a/php-nts-xdebug.json
+++ b/php-nts-xdebug.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://xdebug.org/",
     "license": {
-        "identifier": "PHP-3.0",
+        "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
     "version": "2.6.1-7.2",
@@ -42,6 +42,10 @@
             "32bit": {
                 "url": "https://xdebug.org/files/php_xdebug-$version-vc15-nts.dll#/php_xdebug.dll"
             }
+        },
+        "hash": {
+            "url": "https://xdebug.org/download.php",
+            "regex": "$basename.+?([a-fA-F0-9]{64})"
         }
     }
 }

--- a/php-xdebug.json
+++ b/php-xdebug.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://xdebug.org/",
     "license": {
-        "identifier": "PHP-3.0",
+        "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
     "version": "2.6.1-7.2",
@@ -42,6 +42,10 @@
             "32bit": {
                 "url": "https://xdebug.org/files/php_xdebug-$version-vc15.dll#/php_xdebug.dll"
             }
+        },
+        "hash": {
+            "url": "https://xdebug.org/download.php",
+            "regex": "$basename.+?([a-fA-F0-9]{64})"
         }
     }
 }


### PR DESCRIPTION
- Xdebug has its own license name and edition ([The Xdebug License, version 1.01](https://xdebug.org/license.php)) and is based on ["The PHP License", version 3.0](https://spdx.org/licenses/PHP-3.0.html). Change `license.identifier`.
- Add `autoupdate.hash`