### PR TITLE
Update IrfanView to v4.52

### DIFF
--- a/bucket/irfanview.json
+++ b/bucket/irfanview.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.51",
+    "version": "4.52",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.irfanview.com/eula.htm"
@@ -8,8 +8,8 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://www.irfanview.info/files/iview451_x64.zip",
-                "https://www.irfanview.info/files/iview451_plugins_x64.zip"
+                "https://www.irfanview.info/files/iview452_x64.zip",
+                "https://www.irfanview.info/files/iview452_plugins_x64.zip"
             ],
             "hash": [
                 "8112213E9A8AA406712E326523A5A8090D6A827EE5FBAF9EF055EB69E7E8D859",
@@ -30,8 +30,8 @@
         },
         "32bit": {
             "url": [
-                "https://www.irfanview.info/files/iview451.zip",
-                "https://www.irfanview.info/files/iview451_plugins.zip"
+                "https://www.irfanview.info/files/iview452.zip",
+                "https://www.irfanview.info/files/iview452_plugins.zip"
             ],
             "hash": [
                 "79AB64955C1B877AD8C383E1C7B730E446580D56698C029FA65679613002A56B",


### PR DESCRIPTION
The 4.51 URL doesn't exist anymore and thus fails on installation.

I also have an autoupdate for IrfanView ready, once lukesampson/scoop#2803 is merged.