### PR TITLE
atom: Modify autoupdate.hash

### DIFF
--- a/bucket/atom.json
+++ b/bucket/atom.json
@@ -4,11 +4,11 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-x64-1.34.0-full.nupkg#dl.7z",
+            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-x64-1.34.0-full.nupkg",
             "hash": "sha1:da3569ffb26ba1e8db00553df4ae11f5d69e0b41"
         },
         "32bit": {
-            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-1.34.0-full.nupkg#dl.7z",
+            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-1.34.0-full.nupkg",
             "hash": "sha1:56498b29f7a9929db4b14639d4212bd638171582"
         }
     },
@@ -29,14 +29,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-$version-full.nupkg#dl.7z",
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-$version-full.nupkg",
                 "hash": {
                     "url": "$baseurl/RELEASES-x64",
                     "regex": "([a-fA-F0-9]+)\\s+?(?:atom-$version-full.nupkg)"
                 }
             },
             "32bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-$version-full.nupkg#dl.7z",
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-$version-full.nupkg",
                 "hash": {
                     "url": "$baseurl/RELEASES"
                 }

--- a/bucket/atom.json
+++ b/bucket/atom.json
@@ -4,17 +4,15 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-x64-windows.zip",
-            "hash": "73a241c5b89df1aef2625a021008f3dc08f56bdafb55d72d8447b65b22f2961b",
-            "extract_dir": "Atom x64"
+            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-x64-1.34.0-full.nupkg#dl.7z",
+            "hash": "sha1:da3569ffb26ba1e8db00553df4ae11f5d69e0b41"
         },
         "32bit": {
-            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-windows.zip",
-            "hash": "d6ba569b50ff1e758098fcfd9afd799610c4efab1b36557367165ddaf307d94f",
-            "extract_dir": "Atom"
+            "url": "https://github.com/atom/atom/releases/download/v1.34.0/atom-1.34.0-full.nupkg#dl.7z",
+            "hash": "sha1:56498b29f7a9929db4b14639d4212bd638171582"
         }
     },
-    "extract_dir": "Atom",
+    "extract_dir": "lib\\net45",
     "bin": [
         "\\resources\\cli\\atom.cmd",
         "\\resources\\app\\apm\\bin\\apm.cmd"
@@ -31,12 +29,17 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-windows.zip",
-                "extract_dir": "Atom x64"
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-$version-full.nupkg#dl.7z",
+                "hash": {
+                    "url": "$baseurl/RELEASES-x64",
+                    "regex": "([a-fA-F0-9]+)\\s+?(?:atom-$version-full.nupkg)"
+                }
             },
             "32bit": {
-                "url": "https://github.com/atom/atom/releases/download/v$version/atom-windows.zip",
-                "extract_dir": "Atom"
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-$version-full.nupkg#dl.7z",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
             }
         }
     }


### PR DESCRIPTION
- Using nupkg instead of zip
- Using `$version` in regex to find hash in github `RELEASE` file.(https://github.com/lukesampson/scoop/commit/3a22526554d368edbd4f7aa177540ee749c32e72)