### PR TITLE
Fix stunnel

### DIFF
--- a/bucket/stunnel.json
+++ b/bucket/stunnel.json
@@ -3,19 +3,37 @@
     "version": "5.50",
     "license": "GPL-2.0-only",
     "description": "A multiplatform GNU/GPL-licensed proxy encrypting arbitrary TCP connections with SSL/TLS",
-    "url": "https://www.stunnel.org/downloads/archive/5.x/stunnel-5.50-win64-installer.exe#/dl.7z",
-    "hash": "e855d58a05dca0943a5da8d030b5904630ee9cff47c3d747d326e151724f3bc8",
-    "bin": "bin\\stunnel.exe",
-    "persist": "config",
-    "checkver": {
-        "url": "https://www.stunnel.org/downloads.html",
-        "re": "stunnel-([\\d.]+[\\d]+)-win64-installer.exe"
-    },
-    "autoupdate": {
-        "url": "https://www.stunnel.org/downloads/archive/$majorVersion.x/stunnel-$version-win64-installer.exe#/dl.7z",
-        "hash": {
-            "url": "$url.sha256"
+    "architecture": {
+        "64bit": {
+            "url": "https://www.stunnel.org/downloads/archive/5.x/stunnel-5.50-win64-installer.exe#/dl.7z",
+            "hash": "e855d58a05dca0943a5da8d030b5904630ee9cff47c3d747d326e151724f3bc8"
         }
     },
-    "notes": "Run \"stunnel -install\" in the directory where a configured stunnel.conf is located (eg C:\\ProgramData\\scoop\\persist\\stunnel\\config) to create a native Windows service. Please note that as of version 5.50 Stunnel is a 64 bit application."
+    "bin": "bin\\stunnel.exe",
+    "persist": "config",
+    "uninstaller": {
+        "script": [
+            "stunnel -stop -quiet",
+            "stunnel -uninstall -quiet",
+            "stunnel -exit -quiet"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.stunnel.org/downloads.html",
+        "re": "stunnel-(.+?)-win64-installer.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.stunnel.org/downloads/archive/$majorVersion.x/stunnel-$version-win64-installer.exe#/dl.7z",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    },
+    "notes": [
+        "For Windows 32bit, use \"stunnel549\" instead",
+        "Run \"stunnel -install\" in the directory where a configured stunnel.conf is located (eg C:\\ProgramData\\scoop\\persist\\stunnel\\config) to create a native Windows service. Please note that as of version 5.50 Stunnel is a 64 bit application."
+    ]
 }

--- a/bucket/stunnel.json
+++ b/bucket/stunnel.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.stunnel.org",
     "version": "5.50",
-    "license": "GPL-2.0-only",
+    "license": "GPL-2.0-or-later",
     "description": "A multiplatform GNU/GPL-licensed proxy encrypting arbitrary TCP connections with SSL/TLS",
     "architecture": {
         "64bit": {
@@ -20,7 +20,7 @@
     },
     "checkver": {
         "url": "https://www.stunnel.org/downloads.html",
-        "re": "stunnel-(.+?)-win64-installer.exe"
+        "re": "stunnel-(.+?)-win64"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- move to `arch.64bit`
- add `uninstaller.script`
- add `notes` that `stunnel549` is the latest version that support win32