### PR TITLE
Meld: Update download URL and version

### DIFF
--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -21,6 +21,9 @@
         "url": "http://meldmerge.org/"
     },
     "autoupdate": {
-        "url": "https://download.gnome.org/binaries/win32/meld/$majorVersion.$minorVersion/Meld-$version-mingw.msi"
+        "url": "https://download.gnome.org/binaries/win32/meld/$majorVersion.$minorVersion/Meld-$version-mingw.msi",
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -1,8 +1,8 @@
 {
     "homepage": "http://meldmerge.org/",
-    "version": "3.18.3",
-    "url": "https://download.gnome.org/binaries/win32/meld/3.18/Meld-3.18.3-win32.msi",
-    "hash": "196ab263e5425407609addc8e8de6eeba8ebfca8d53902b7ff43f169bdb8564c",
+    "version": "3.20.0",
+    "url": "https://download.gnome.org/binaries/win32/meld/3.20/Meld-3.20.0-mingw.msi",
+    "hash": "9f36ac1bba647eb53ae20864c02c2f8b17467973fc71e1700abd9b18272bc8cf",
     "bin": [
         [
             "Meld.exe",
@@ -20,6 +20,6 @@
         "url": "http://meldmerge.org/"
     },
     "autoupdate": {
-        "url": "https://download.gnome.org/binaries/win32/meld/$majorVersion.$minorVersion/Meld-$version-win32.msi"
+        "url": "https://download.gnome.org/binaries/win32/meld/$majorVersion.$minorVersion/Meld-$version-mingw.msi"
     }
 }

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -4,7 +4,7 @@
     "version": "3.20.0",
     "url": "https://download.gnome.org/binaries/win32/meld/3.20/Meld-3.20.0-mingw.msi",
     "hash": "9f36ac1bba647eb53ae20864c02c2f8b17467973fc71e1700abd9b18272bc8cf",
-    "bin": [
+    "bin": "Meld.exe",
         [
             "Meld.exe",
             "meld"

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -5,11 +5,6 @@
     "url": "https://download.gnome.org/binaries/win32/meld/3.20/Meld-3.20.0-mingw.msi",
     "hash": "9f36ac1bba647eb53ae20864c02c2f8b17467973fc71e1700abd9b18272bc8cf",
     "bin": "Meld.exe",
-        [
-            "Meld.exe",
-            "meld"
-        ]
-    ],
     "shortcuts": [
         [
             "Meld.exe",

--- a/bucket/meld.json
+++ b/bucket/meld.json
@@ -1,5 +1,6 @@
 {
     "homepage": "http://meldmerge.org/",
+    "description": "A visual diff and merge tool",
     "version": "3.20.0",
     "url": "https://download.gnome.org/binaries/win32/meld/3.20/Meld-3.20.0-mingw.msi",
     "hash": "9f36ac1bba647eb53ae20864c02c2f8b17467973fc71e1700abd9b18272bc8cf",


### PR DESCRIPTION
The download URL has changed with the latest version [(`3.20.0`)](https://download.gnome.org/binaries/win32/meld/3.20/Meld-3.20.0-mingw.msi) and it's been updated to the correct one.