### PR TITLE
notable: Move to arch.64bit, modify url and autoupdate.hash

### DIFF
--- a/bucket/notable.json
+++ b/bucket/notable.json
@@ -1,18 +1,37 @@
 {
     "homepage": "https://github.com/fabiospampinato/notable",
+    "description": "The markdown-based note-taking app that doesn't suck.",
     "version": "1.2.0",
     "license": "MIT",
-    "url": "https://github.com/fabiospampinato/notable/releases/download/v1.2.0/Notable-1.2.0-win.zip",
-    "hash": "e1f7c3ae8f4f6bcb7f8e9978c3b703f6e6fe87e774cb3199ad6db28a94cdd420",
-    "bin": "notable.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fabiospampinato/notable/releases/download/v1.2.0/Notable.Setup.1.2.0.exe#/dl.7z",
+            "hash": "sha512:33952f14944ce91048cf11f42ac211290a2d7f2d9484db5ea37bbeb707ba08f18dd3c5944b6c4d3a3fcc160ff76c7a5781347c2d8e76a78c34bb07bbe9c11057",
+            "installer": {
+                "script": [
+                    "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "bin": "Notable.exe",
     "shortcuts": [
         [
-            "notable.exe",
+            "Notable.exe",
             "Notable"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/fabiospampinato/notable/releases/download/v$version/Notable-$version-win.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fabiospampinato/notable/releases/download/v$version/Notable.Setup.$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "find": "sha512:\\s+(.*)"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Move to arch.64bit
- Change `.zip` to `.exe` since smaller download size and `latest.yml` hash extraction