### PR TITLE
boostnote: Move to arch.64, change to nupkg and add hash extract

### DIFF
--- a/bucket/boostnote.json
+++ b/bucket/boostnote.json
@@ -1,22 +1,33 @@
 {
     "homepage": "https://boostnote.io/",
+    "description": "A markdown editor for developers.",
     "license": "GPL-3.0-or-later",
     "version": "0.11.13",
-    "url": "https://github.com/BoostIO/boost-releases/releases/download/v0.11.13/BoostnoteSetup.exe#/dl.7z",
-    "hash": "d18a4f859a78cda46566eae7aa56db4686effb870d67851575082d20e92089d4",
-    "pre_install": "extract_7zip \"$dir\\boost-*.nupkg\" \"$dir\"",
-    "bin": "lib\\net45\\Boostnote.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/BoostIO/boost-releases/releases/download/v0.11.13/boost-0.11.13-full.nupkg",
+            "hash": "sha1:241cfb2c01c79443033b8bb365da3626f289a791",
+            "extract_dir": "lib\\net45"
+        }
+    },
+    "bin": "Boostnote.exe",
     "shortcuts": [
         [
-            "lib\\net45\\Boostnote.exe",
+            "Boostnote.exe",
             "Boostnote"
         ]
     ],
-    "post_install": "Remove-Item \"$dir\\boost-*.nupkg\"",
     "checkver": {
         "github": "https://github.com/BoostIO/boost-releases"
     },
     "autoupdate": {
-        "url": "https://github.com/BoostIO/boost-releases/releases/download/v$version/BoostnoteSetup.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/BoostIO/boost-releases/releases/download/v$version/boost-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Move to `arch.64bit`
- Change setup to nupkg so as to simplify installation and have a native hash extraction