### PR TITLE
vscode: fix context menu shortcut

### DIFF
--- a/bucket/vscode-portable.json
+++ b/bucket/vscode-portable.json
@@ -45,7 +45,7 @@
             ],
             "hash": [
                 "64db94c15b3b998e0c3a3186af4adf5a812d591b510cc1a72187ce3741a82e04",
-                "3ef2104fba3fa00afd6fd60f9d8432e90ca8f1b456f9a614bfa3c530c9ad4b3e",
+                "73ca2243ce4577a9e0e72664d6d5150d56c1641d1ea4bcd6dd2a37eef1f2587c",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -57,7 +57,7 @@
             ],
             "hash": [
                 "d61bd3e122a8d0872acd346e5fd0fa98a87c0876c34966b31ca2a3004c29d1dc",
-                "3ef2104fba3fa00afd6fd60f9d8432e90ca8f1b456f9a614bfa3c530c9ad4b3e",
+                "73ca2243ce4577a9e0e72664d6d5150d56c1641d1ea4bcd6dd2a37eef1f2587c",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/bucket/vscode.json
+++ b/bucket/vscode.json
@@ -39,7 +39,7 @@
             ],
             "hash": [
                 "64db94c15b3b998e0c3a3186af4adf5a812d591b510cc1a72187ce3741a82e04",
-                "3ef2104fba3fa00afd6fd60f9d8432e90ca8f1b456f9a614bfa3c530c9ad4b3e",
+                "73ca2243ce4577a9e0e72664d6d5150d56c1641d1ea4bcd6dd2a37eef1f2587c",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         },
@@ -51,7 +51,7 @@
             ],
             "hash": [
                 "d61bd3e122a8d0872acd346e5fd0fa98a87c0876c34966b31ca2a3004c29d1dc",
-                "3ef2104fba3fa00afd6fd60f9d8432e90ca8f1b456f9a614bfa3c530c9ad4b3e",
+                "73ca2243ce4577a9e0e72664d6d5150d56c1641d1ea4bcd6dd2a37eef1f2587c",
                 "9b55432e91e8534cc871d8d57f826761649d1ed7a3a5d7cabc3089fe5a6e147f"
             ]
         }

--- a/scripts/vscode-install-context.reg
+++ b/scripts/vscode-install-context.reg
@@ -1,16 +1,19 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_CLASSES_ROOT\*\shell\Open with &Code]
+@="Open with &Code"
 "Icon"="$code"
 [HKEY_CLASSES_ROOT\*\shell\Open with &Code\command]
 @="\"$code\" \"%1\""
 
 [HKEY_CLASSES_ROOT\Directory\shell\Open with &Code]
+@="Open with &Code"
 "Icon"="$code"
 [HKEY_CLASSES_ROOT\Directory\shell\Open with &Code\command]
 @="\"$code\" \"%1\""
 
 [HKEY_CLASSES_ROOT\Directory\Background\shell\Open with &Code]
+@="Open with &Code"
 "Icon"="$code"
 [HKEY_CLASSES_ROOT\Directory\Background\shell\Open with &Code\command]
 @="\"$code\" \"%V\""


### PR DESCRIPTION
Inserting `&` in key name doesn't set shortcut key for menu item, it's only a visual change. To set shortcut, one should set default value.
https://docs.microsoft.com/en-us/windows/desktop/shell/context-menu-handlers