### PR TITLE
Add Meow v0.2019.01.31

### DIFF
--- a/bucket/meow.json
+++ b/bucket/meow.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/kiedtl/meow",
+    "version": "0.2019.01.31",
+    "url": "https://github.com/kiedtl/meow/archive/827f02ff36bb3d6c6e9e86669b53354c46eef605.zip",
+    "extract_dir": "meow-827f02ff36bb3d6c6e9e86669b53354c46eef605",
+    "hash": "f174da19efa4c08e1f2c2be74d1e31b130683d7f203d05628a91a5a586c39664",
+    "bin": "bin\\meow.ps1",
+    "checkver": {
+        "url": "https://github.com/kiedtl/meow",
+        "re": "datetime=\"(\\d+)-(\\d+)-(\\d+)[\\S\\s]*?(?<sha>[0-9a-f]{40})\"",
+        "replace": "0.${1}.${2}.${3}"
+    },
+    "autoupdate": {
+        "url": "https://github.com/kiedtl/meow/archive/$matchSha.zip",
+        "extract_dir": "meow-$matchSha"
+    }
+}


### PR DESCRIPTION
Add [Meow](https://github.com/kiedtl/meow), a `lolcat` clone for Windows.
**NOTE**: The screenshot found on the README is outdated.