### PR TITLE
conemu: Remove plugins from persisted data

### DIFF
--- a/bucket/conemu.json
+++ b/bucket/conemu.json
@@ -33,8 +33,7 @@
         ]
     ],
     "persist": [
-        "ConEmu\\ConEmu.xml",
-        "plugins"
+        "ConEmu\\ConEmu.xml"
     ],
     "checkver": {
         "github": "https://github.com/Maximus5/ConEmu"


### PR DESCRIPTION
According to https://conemu.github.io/en/ConEmuFolders.html, plugins directory
is needed for Far Manager only. It's added as plugins source when Far is run from
ConEmu, therefore it should be updated with ConEmu and shouldn't be persisted.