### PR TITLE
Create portable_settings.txt before install to persist as file, not dir

### DIFF
--- a/bucket/heidisql.json
+++ b/bucket/heidisql.json
@@ -19,6 +19,7 @@
             "HeidiSQL"
         ]
     ],
+    "pre_install": "New-Item \"$dir/portable_settings.txt\" > $null",
     "persist": "portable_settings.txt",
     "checkver": {
         "url": "https://www.heidisql.com/download.php",


### PR DESCRIPTION
Currently if you install heidisql, the persist happens as a dir and it causes errors in the app (it will crash trying to write to portable_settings.txt).