### PR TITLE
telegram: change url to github

### DIFF
--- a/bucket/telegram.json
+++ b/bucket/telegram.json
@@ -2,7 +2,7 @@
     "version": "1.5.11",
     "license": "GPL-3.0-only",
     "extract_dir": "Telegram",
-    "url": "https://updates.tdesktop.com/tsetup/tportable.1.5.11.zip",
+    "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v1.5.11/tportable.1.5.11.zip",
     "homepage": "https://telegram.org/",
     "hash": "f617e94d5b353d0a1eb0f713949c078a0fff0d97e126b296dfdedd35919764f4",
     "bin": "telegram.cmd",
@@ -18,6 +18,6 @@
         "github": "https://github.com/telegramdesktop/tdesktop"
     },
     "autoupdate": {
-        "url": "https://updates.tdesktop.com/tsetup/tportable.$version.zip"
+        "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable.$version.zip"
     }
 }


### PR DESCRIPTION
telegram.com is blocked by some Russian internet providers.
GitHub.com seems to be more appropriate source.