### PR TITLE
Add Streamlink portable

### DIFF
--- a/bucket/streamlink-portable.json
+++ b/bucket/streamlink-portable.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0",
+    "description": "Command-line utility that pipes video streams from various services into a video player.",
+    "homepage": "https://streamlink.github.io/",
+    "license": "BSD-2-Clause",
+    "suggest": {
+        "FFmpeg": [
+            "ffmpeg",
+            "ffmpeg-nightly"
+        ]
+    },
+    "url": "https://github.com/streamlink/streamlink-portable/releases/download/Stable_v1.0.0/Streamlink_for_Windows_Portable_v1.0.0.zip",
+    "hash": "88c7c4c8bf39f361fde535fc2c3ed0c53d337f20cec3c61da2a10f3877208173",
+    "persist": "streamlinkrc",
+    "bin": "Streamlink.exe",
+    "checkver": {
+        "github": "https://github.com/streamlink/streamlink-portable/",
+        "regex": "tag/Stable_v([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/streamlink/streamlink-portable/releases/download/Stable_v$version/Streamlink_for_Windows_Portable_v$version.zip"
+    }
+}


### PR DESCRIPTION
No need for manually build exe files as in #1680

Sidenote: Should not be streamlinks moved into main bucket? It's only command line tools, which spawn player