### PR TITLE
Fix apps based on Electron (add description, move to 64bit, etc.)

### DIFF
--- a/bucket/github.json
+++ b/bucket/github.json
@@ -1,9 +1,14 @@
 {
     "homepage": "https://desktop.github.com/",
+    "description": "Extend your GitHub workflow beyond your browser.",
     "version": "1.6.1",
     "license": "MIT",
-    "url": "https://central.github.com/deployments/desktop/desktop/latest/GitHubDesktop-1.6.1-full.nupkg#/dl.7z",
-    "hash": "sha1:f46a9b3c5bd54cc3236a75c20f06303289ee7d3b",
+    "architecture": {
+        "64bit": {
+            "url": "https://central.github.com/deployments/desktop/desktop/latest/GitHubDesktop-1.6.1-full.nupkg",
+            "hash": "sha1:f46a9b3c5bd54cc3236a75c20f06303289ee7d3b"
+        }
+    },
     "extract_dir": "lib\\net45",
     "bin": "GitHubDesktop.exe",
     "shortcuts": [
@@ -13,14 +18,18 @@
         ]
     ],
     "checkver": {
-        "url": "https://central.github.com/api/deployments/desktop/desktop/latest/RELEASES?env=production&id=GitHubDesktop&arch=amd64",
-        "re": "GitHubDesktop-([\\d.]+)-full.nupkg",
+        "url": "https://central.github.com/api/deployments/desktop/desktop/latest/RELEASES",
+        "regex": "GitHubDesktop-([\\d.]+)-full.nupkg",
         "reverse": true
     },
     "autoupdate": {
-        "url": "https://central.github.com/deployments/desktop/desktop/latest/GitHubDesktop-$version-full.nupkg#/dl.7z",
-        "hash": {
-            "url": "https://central.github.com/api/deployments/desktop/desktop/latest/RELEASES?env=production&id=GitHubDesktop&arch=amd64"
+        "architecture": {
+            "64bit": {
+                "url": "https://central.github.com/deployments/desktop/desktop/latest/GitHubDesktop-$version-full.nupkg",
+                "hash": {
+                    "url": "https://central.github.com/api/deployments/desktop/desktop/latest/RELEASES"
+                }
+            }
         }
     }
 }

--- a/bucket/gitkraken.json
+++ b/bucket/gitkraken.json
@@ -1,5 +1,6 @@
 {
     "homepage": "https://www.gitkraken.com/",
+    "description": "A Git client which helps you track and manage changes to your code.",
     "version": "4.2.2",
     "license": {
         "identifier": "Freeware",
@@ -7,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://release.gitkraken.com/win64/gitkraken-4.2.2-full.nupkg#/dl.7z",
+            "url": "https://release.gitkraken.com/win64/gitkraken-4.2.2-full.nupkg",
             "hash": "d4d95a3cb7d69092825c32f7aa1bc298382ae1082213204284d0c1911945301c"
         },
         "32bit": {
-            "url": "https://release.gitkraken.com/win32/gitkraken-4.2.2-full.nupkg#/dl.7z",
+            "url": "https://release.gitkraken.com/win32/gitkraken-4.2.2-full.nupkg",
             "hash": "665fec321b289687cf95fcc8184c18a582a7f6f743de9914f782342667558209"
         }
     },
@@ -31,10 +32,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://release.gitkraken.com/win64/gitkraken-$version-full.nupkg#/dl.7z"
+                "url": "https://release.gitkraken.com/win64/gitkraken-$version-full.nupkg"
             },
             "32bit": {
-                "url": "https://release.gitkraken.com/win32/gitkraken-$version-full.nupkg#/dl.7z"
+                "url": "https://release.gitkraken.com/win32/gitkraken-$version-full.nupkg"
             }
         },
         "hash": {

--- a/bucket/hyper.json
+++ b/bucket/hyper.json
@@ -1,9 +1,14 @@
 {
     "homepage": "https://hyper.is",
+    "description": "A terminal built on web technologies.",
     "version": "2.1.2",
     "license": "MIT",
-    "url": "https://github.com/zeit/hyper/releases/download/2.1.2/hyper-2.1.2-full.nupkg#/dl.7z",
-    "hash": "sha1:a448a107e0588b655061fe1672f7a49374a77577",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zeit/hyper/releases/download/2.1.2/hyper-2.1.2-full.nupkg",
+            "hash": "sha1:a448a107e0588b655061fe1672f7a49374a77577"
+        }
+    },
     "extract_dir": "lib\\net45",
     "bin": "resources\\bin\\hyper.cmd",
     "shortcuts": [
@@ -16,9 +21,13 @@
         "github": "https://github.com/zeit/hyper"
     },
     "autoupdate": {
-        "url": "https://github.com/zeit/hyper/releases/download/$version/hyper-$version-full.nupkg#/dl.7z",
-        "hash": {
-            "url": "$baseurl/RELEASES"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zeit/hyper/releases/download/$version/hyper-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
+            }
         }
     }
 }

--- a/bucket/insomnia.json
+++ b/bucket/insomnia.json
@@ -1,9 +1,14 @@
 {
+    "homepage": "https://insomnia.rest",
+    "description": "A REST client you'll love.",
     "version": "6.3.2",
     "license": "MIT",
-    "url": "https://github.com/getinsomnia/insomnia/releases/download/v6.3.2/insomnia-6.3.2-full.nupkg#/dl.7z",
-    "homepage": "https://insomnia.rest",
-    "hash": "551581989638c52e68180b9360226a6e9eeaa87dc8bae87a5f0efcb36281bac1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/getinsomnia/insomnia/releases/download/v6.3.2/insomnia-6.3.2-full.nupkg",
+            "hash": "sha1:c6056cd515baecf5ba7679136831386eb507600c"
+        }
+    },
     "extract_dir": "lib\\net45",
     "shortcuts": [
         [
@@ -15,7 +20,13 @@
         "github": "https://github.com/getinsomnia/insomnia"
     },
     "autoupdate": {
-        "url": "https://github.com/getinsomnia/insomnia/releases/download/v$version/insomnia-$version-full.nupkg#/dl.7z",
-        "extract_dir": "lib\\net45"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/getinsomnia/insomnia/releases/download/v$version/insomnia-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
+            }
+        }
     }
 }

--- a/bucket/netron.json
+++ b/bucket/netron.json
@@ -3,23 +3,35 @@
     "description": "Visualizer for deep learning and machine learning models.",
     "version": "2.8.7",
     "license": "MIT",
-    "url": "https://github.com/lutzroeder/netron/releases/download/v2.8.7/Netron-Setup-2.8.7.exe/#dl.7z",
-    "hash": "sha512:46f3212d5f3e4396d59be320b82afe7770372842a34ebef08d8357c389d31b6f8103430fcfdd86d07b66740bd8da5db460f12f71f7d6784a6d7165db0c1397b1",
-    "pre_install": "extract_7zip \"$dir\\`$PLUGINSDIR\\app-*.7z\" \"$dir\"",
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
-    "bin": "netron.exe",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lutzroeder/netron/releases/download/v2.8.7/Netron-Setup-2.8.7.exe#/dl.7z",
+            "hash": "sha512:46f3212d5f3e4396d59be320b82afe7770372842a34ebef08d8357c389d31b6f8103430fcfdd86d07b66740bd8da5db460f12f71f7d6784a6d7165db0c1397b1",
+            "installer": {
+                "script": [
+                    "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "bin": "Netron.exe",
     "shortcuts": [
         [
-            "netron.exe",
+            "Netron.exe",
             "Netron"
         ]
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/lutzroeder/netron/releases/download/v$version/Netron-Setup-$version.exe/#dl.7z",
-        "hash": {
-            "url": "$baseurl/latest.yml",
-            "find": "sha512:\\s+(.*)"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lutzroeder/netron/releases/download/v$version/Netron-Setup-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "find": "sha512:\\s+(.*)"
+                }
+            }
         }
     }
 }

--- a/bucket/sourcetree.json
+++ b/bucket/sourcetree.json
@@ -1,23 +1,24 @@
 {
     "homepage": "https://www.sourcetreeapp.com/",
+    "description": "Simplicity and power in a beautiful Git GUI.",
     "version": "3.0.17",
-    "url": "https://www.sourcetreeapp.com/update/windows/ga/SourceTree-3.0.17-full.nupkg#/dl.7z",
+    "url": "https://www.sourcetreeapp.com/update/windows/ga/SourceTree-3.0.17-full.nupkg",
     "hash": "sha1:56d642548d18de2edfe5574f0f6b23291fba3f3a",
-    "bin": "lib\\net45\\sourcetree.exe",
+    "extract_dir": "lib\\net45",
+    "bin": "sourcetree.exe",
     "shortcuts": [
         [
-            "lib\\net45\\sourcetree.exe",
+            "sourcetree.exe",
             "Atlassian SourceTree"
         ]
     ],
     "checkver": {
-        "url": "https://www.sourcetreeapp.com/update/windows/ga/RELEASES?id=SourceTree&localVersion=0&arch=amd64",
-        "re": "SourceTree-([\\d.]+)-full.nupkg",
+        "url": "https://www.sourcetreeapp.com/update/windows/ga/RELEASES",
+        "regex": "SourceTree-([\\d.]+)-full.nupkg",
         "reverse": true
     },
-    "post_install": "New-Item -ItemType file -Path \"$dir\\lib\\Update.exe\" -force | out-null",
     "autoupdate": {
-        "url": "https://www.sourcetreeapp.com/update/windows/ga/SourceTree-$version-full.nupkg#/dl.7z",
+        "url": "https://www.sourcetreeapp.com/update/windows/ga/SourceTree-$version-full.nupkg",
         "hash": {
             "url": "$baseurl/RELEASES"
         }

--- a/bucket/terminus.json
+++ b/bucket/terminus.json
@@ -1,9 +1,14 @@
 {
     "homepage": "https://eugeny.github.io/terminus/",
+    "description": "A terminal for a more modern age.",
     "version": "1.0.70",
     "license": "MIT",
-    "url": "https://github.com/Eugeny/terminus/releases/download/v1.0.70/terminus-1.0.70-full.nupkg#/dl.7z",
-    "hash": "2e5e0b25e29891a6713dd0026982f86641fe47d14e62c8e75bff756e4ea63285",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Eugeny/terminus/releases/download/v1.0.70/terminus-1.0.70-full.nupkg",
+            "hash": "2e5e0b25e29891a6713dd0026982f86641fe47d14e62c8e75bff756e4ea63285"
+        }
+    },
     "extract_dir": "lib\\net45",
     "bin": "Terminus.exe",
     "shortcuts": [
@@ -16,6 +21,10 @@
         "github": "https://github.com/Eugeny/terminus"
     },
     "autoupdate": {
-        "url": "https://github.com/Eugeny/terminus/releases/download/v$version/terminus-$version-full.nupkg#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Eugeny/terminus/releases/download/v$version/terminus-$version-full.nupkg"
+            }
+        }
     }
 }


### PR DESCRIPTION
- github: Add `description`, move to `arch.64bit`, simplify `checkver` and `au.hash` url
- gitkraken: Add `description`, simplify `url`
- hyper: Add `description`, move to `arch.64bit`
- insomnia: Add `description`, move to `arch.64bit`
- netron: Move to `arch.64bit`, mod `installer.script`
- sourcetree: Add `description`, `extract_dir`
- terminus: Add `description`, move to `arch.64bit`