### PR TITLE
Add KeePassRPC version 1.8.0 (plugin for KeePass 2.x)

### DIFF
--- a/bucket/keepass-plugin-keepassrpc.json
+++ b/bucket/keepass-plugin-keepassrpc.json
@@ -12,5 +12,9 @@
     "autoupdate": {
         "url": "https://github.com/kee-org/keepassrpc/releases/download/v$version/KeePassRPC.plgx"
     },
-    "post_install": "Copy-Item \"$dir\\KeePassRPC.plgx\" \"$(appdir keepass)\\current\\Plugins\""
+    "installer": {
+        "script": [
+            "Copy-Item \"$dir\\KeePassRPC.plgx\" \"$(appdir keepass)\\current\\Plugins\""
+        ]
+    }
 }

--- a/bucket/keepass-plugin-keepassrpc.json
+++ b/bucket/keepass-plugin-keepassrpc.json
@@ -1,0 +1,16 @@
+{
+    "homepage": "https://www.kee.pm/",
+    "description": "Kee is a Firefox and Chrome add-on for linking browsers to KeePass, using the KeePassRPC KeePass plugin contained within this repository.",
+    "license": "GPL-2.0-or-later",
+    "version": "1.8.0",
+    "url": "https://github.com/kee-org/keepassrpc/releases/download/v1.8.0/KeePassRPC.plgx",
+    "hash": "8d9d5e390fc4a3b8d6d8f24dd26a712dc032c4ff49708c8ec32c95a2e27594b5",
+    "depends": "extras/keepass",
+    "checkver": {
+        "github": "https://github.com/kee-org/keepassrpc"
+    },
+    "autoupdate": {
+        "url": "https://github.com/kee-org/keepassrpc/releases/download/v$version/KeePassRPC.plgx"
+    },
+    "post_install": "Copy-Item \"$dir\\KeePassRPC.plgx\" \"$(appdir keepass)\\current\\Plugins\""
+}

--- a/bucket/keepass-plugin-keepassrpc.json
+++ b/bucket/keepass-plugin-keepassrpc.json
@@ -16,5 +16,10 @@
         "script": [
             "Copy-Item \"$dir\\KeePassRPC.plgx\" \"$(appdir keepass)\\current\\Plugins\""
         ]
+    },
+    "uninstaller": {
+        "script": [
+            "Remove-Item \"$(appdir keepass)\\current\\Plugins\\KeePassRPC.plgx\""
+        ]
     }
 }


### PR DESCRIPTION
RPC plugin for [Kee](https://addons.mozilla.org/firefox/addon/keefox/) browser extensions.