### PR TITLE
Motrix: Add manifest v1.1.3

### DIFF
--- a/bucket/motrix.json
+++ b/bucket/motrix.json
@@ -1,0 +1,38 @@
+{
+    "homepage": "https://motrix.app",
+    "description": "A full-featured download manager.",
+    "version": "1.1.3",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/agalwood/Motrix/releases/download/v1.1.3/Motrix-Setup-1.1.3.exe#/dl.7z",
+            "hash": "sha512:4aaa2eec13d17cc40b0d996ce0d5ae224c7e0c2ebc488cf5909fea9ae86d3ba0c6ed2ac5ef1a1a9c93b0ab96ca64d10ef009949546a943efeefe5aa811251af5",
+            "installer": {
+                "script": [
+                    "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "shortcuts": [
+        [
+            "Motrix.exe",
+            "Motrix"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/agalwood/Motrix"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/agalwood/Motrix/releases/download/v$version/Motrix-Setup-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "find": "sha512:\\s+(.*)"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Name: Motrix
- Description: A full-featured download manager.
- Homepage: https://motrix.app
- Version: 1.1.3
- License: MIT