### PR TITLE
dbeaver.json has invalid hash

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -4,7 +4,7 @@
     "architecture": {
         "64bit": {
             "url": "https://dbeaver.io/files/5.3.5/dbeaver-ce-5.3.5-win32.win32.x86_64.zip",
-            "hash": "955a68184003ce6cdbf9dedb5fbc9d7b30c34af9e3a31d6a3548fcb5175e8b32"
+            "hash": "8dbef4ef88e1117100adbef763b76f8efabb7c64a09e15bd00c469ea4dfdcb27"
         },
         "32bit": {
             "url": "https://dbeaver.io/files/5.3.5/dbeaver-ce-5.3.5-win32.win32.x86.zip",


### PR DESCRIPTION
URL:         https://dbeaver.io/files/5.3.5/dbeaver-ce-5.3.5-win32.win32.x86_64.zip
First bytes: 50 4B 03 04 0A 00 00 00
Expected:    955a68184003ce6cdbf9dedb5fbc9d7b30c34af9e3a31d6a3548fcb5175e8b32
Actual:      8dbef4ef88e1117100adbef763b76f8efabb7c64a09e15bd00c469ea4dfdcb27