### PR TITLE
Updates based on how Alacritty is published

### DIFF
--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -2,12 +2,10 @@
     "homepage": "https://github.com/jwilm/alacritty",
     "description": "A cross-platform, GPU-accelerated terminal emulator",
     "license": "Apache-2.0",
-    "version": "0.2.7",
-    "url": "https://github.com/jwilm/alacritty/releases/download/v0.2.7/Alacritty-v0.2.7.exe#/alacritty.exe",
-    "hash": "8772c128b20c59dbea4c4f9051157da5c8587c8fa4e9a9d7e8cb80e033b9f5a9",
-    "depends": "extras/winpty",
+    "version": "0.2.9",
+    "url": "https://github.com/jwilm/alacritty/releases/download/v0.2.9/Alacritty-v0.2.9-windows.zip",
+    "hash": "7edceed0ab442d746addf161a8310342c265d5ec95c23a689b13e4039f473359",
     "bin": "alacritty.exe",
-    "post_install": "Copy-Item \"$(appdir winpty)\\current\\x64\\bin\\winpty-agent.exe\" \"$dir\\winpty-agent.exe\"",
     "shortcuts": [
         [
             "alacritty.exe",
@@ -17,7 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/jwilm/alacritty/releases/download/v$version/Alacritty-v$version.exe#/alacritty.exe"
+        "url": "https://github.com/jwilm/alacritty/releases/download/v$version/Alacritty-v$version-windows.zip"
     },
     "suggest": {
         "vcredist": "extras/vcredist2017"


### PR DESCRIPTION
Alacritty is now published in a different way, bundled in a zip file along with the `winpyt-agent` binary, which was before installed as a dependency and copied over into the working directory.

Now, scoop only needs to extract the zip archive and apply the shortcut.