### PR TITLE
MEGAsync: Update to 4.0.2

### DIFF
--- a/bucket/megasync.json
+++ b/bucket/megasync.json
@@ -5,7 +5,7 @@
         "identifier": "Freeware",
         "url": "https://mega.nz/terms"
     },
-    "version": "4.0.1.0",
+    "version": "4.0.2.0",
     "url": "https://mega.nz/MEGAsyncSetup.exe#dl.7z",
     "hash": "b420a01befcc6a34098556ab54a290f08620c2a51e2c84d155ce13f6f39e4c53",
     "bin": "MEGAsync.exe",


### PR DESCRIPTION
When megasync's hash changes, one should check if its version number has changed... MEGAsync's sourcecode in github may change after its binary changes.