### PR TITLE
gitextensions: Fix checkver pattern and autoupdate url

### DIFF
--- a/bucket/gitextensions.json
+++ b/bucket/gitextensions.json
@@ -18,9 +18,9 @@
     ],
     "checkver": {
         "github": "https://github.com/gitextensions/gitextensions",
-        "regex": "GitExtensions-Portable-([\\d.]+).zip"
+        "regex": "v(?<version>[\\d.]+)/GitExtensions-Portable-(?<build>[\\d.]+).zip"
     },
     "autoupdate": {
-        "url": "https://github.com/gitextensions/gitextensions/releases/download/v$version/GitExtensions-$version-Mono.zip"
+        "url": "https://github.com/gitextensions/gitextensions/releases/download/v$version/GitExtensions-Portable-$matchBuild.zip"
     }
 }


### PR DESCRIPTION
Download url was changed, but autoupdate url wasn't.

Also pattern in checkver matched wrong version. Official version on github release
page is semver compatible, so it shouldn't include build number.

Fix #1753.