### PR TITLE
ilspy: Fix checkver pattern and autoupdate url

### DIFF
--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -7,9 +7,9 @@
     "bin": "ILSpy.exe",
     "checkver": {
         "github": "https://github.com/icsharpcode/ILSpy",
-        "re": "download/v(?<short>[\\d.\\D]+)/ILSpy_binaries_(?<version>[\\d.]+).zip"
+        "re": "download/v(?<version>[\\d.]+)/ILSpy_binaries_(?<build>[\\d.]+).zip"
     },
     "autoupdate": {
-        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$matchShort/ILSpy_binaries_$version.zip"
+        "url": "https://github.com/icsharpcode/ILSpy/releases/download/v$version/ILSpy_binaries_$matchBuild.zip"
     }
 }

--- a/bucket/ilspy.json
+++ b/bucket/ilspy.json
@@ -6,7 +6,7 @@
     "hash": "d1bf46034e334d456b0f7698b6493e21e664e3f3c12b1206fcf6feab8a8c6b5f",
     "bin": "ILSpy.exe",
     "checkver": {
-        "url": "https://github.com/icsharpcode/ILSpy/releases/latest",
+        "github": "https://github.com/icsharpcode/ILSpy",
         "re": "download/v(?<short>[\\d.\\D]+)/ILSpy_binaries_(?<version>[\\d.]+).zip"
     },
     "autoupdate": {


### PR DESCRIPTION
According to [update log](https://scoop.r15.ch/extras/mud-20190221-160001.log) **ilspy** update was failing.

**checkver** pattern was greedy and matched more than it should. It was supposed to
match versions like `3.0-final`, but **ilspy** author doesn't use versions like this for
release anymore.