### PR TITLE
Fix clingo.json for v5.3.0

### DIFF
--- a/bucket/clingo.json
+++ b/bucket/clingo.json
@@ -10,15 +10,9 @@
         }
     },
     "bin": [
-        [
-            "clingo-python.exe",
-            "clingo"
-        ],
+        "clingo.exe",
         "clasp.exe",
-        [
-            "gringo-python.exe",
-            "gringo"
-        ],
+        "gringo.exe",
         "reify.exe",
         "lpconvert.exe"
     ],


### PR DESCRIPTION
Since [clingo](https://github.com/potassco/clingo/releases) v5.2.3, `clingo-python.exe` and `gringo-python.exe` are no longer included in its binary releases.