### PR TITLE
notepadplusplus: Removed plugin manager suggestion

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -27,9 +27,6 @@
         "Add-Content \"$dir/config.xml\" $null",
         "Add-Content \"$dir/session.xml\" $null"
     ],
-    "suggest": {
-        "Notepad++ Plugin Manager": "extras/notepadplusplus-pm"
-    },
     "shortcuts": [
         [
             "notepad++.exe",


### PR DESCRIPTION
Removed `notepadplusplus-pm` suggestion.

Related to #1695.