### PR TITLE
Add KeePassSequencer version 0.1.1 (KeePass 2.x plugin)

### DIFF
--- a/bucket/keepass-plugin-sequencer.json
+++ b/bucket/keepass-plugin-sequencer.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://github.com/fireout/keepasssequencer",
+    "description": "Custom password generator algorithm plugin for KeePass 2.x to generate word sequences.",
+    "notes": "Default options located in \"$dir\\options.xml\".",
+    "version": "0.1.1",
+    "url": [
+        "https://github.com/fireout/keepasssequencer/releases/download/release%2F0.1.1/Sequencer.dll",
+        "https://github.com/fireout/keepasssequencer/releases/download/release%2F0.1.1/Sequencer.dll.config",
+        "https://github.com/fireout/keepasssequencer/releases/download/release%2F0.1.1/options.xml"
+    ],
+    "hash": [
+        "507cc90aa1c47cf213775c7fdb2eb39c8f4d34e9edab98d524dd2d9493b79661",
+        "46935a8e2f420c629001fb6fb2850e3dd35c0ab430a5e506d159dcab1090ca0a",
+        "80142a27be9faed4c8f3dad99bc77d2c196af07e6b8d57f7ccc1d831b971164d"
+    ],
+    "depends": "extras/keepass",
+    "installer": {
+        "script": [
+            "$pluginDir = New-Item -ItemType Directory \"$(appdir keepass)\\current\\Plugins\\Sequencer\"",
+            "Copy-Item \"$dir\\Sequencer.dll\" \"$pluginDir\"",
+            "Copy-Item \"$dir\\Sequencer.dll.config\" \"$pluginDir\""
+        ]
+    },
+    "uninstaller": {
+        "script": "Remove-Item -Recurse \"$(appdir keepass)\\current\\Plugins\\Sequencer\""
+    }
+}


### PR DESCRIPTION
https://github.com/fireout/keepasssequencer

One and only version of this plugin. As there is no other versions since 2016, I don't think it needs **autoupdate** section.

As it's not `.plgx` plugin, so I create directory on install to collect all the files needed to run it.