### PR TITLE
Add painter v1.0.0

### DIFF
--- a/painter.json
+++ b/painter.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/lptstr/painter",
+    "version": "1.0.0",
+    "url": "https://github.com/lptstr/painter/releases/download/v1.0.0/painter.exe",
+    "hash": "a4848ac1eedce8f841c441b8c358c7317b7d36e0efe4eb4ff8a9e68f1a9225a6",
+    "bin": "painter.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/lptstr/painter/releases/download/v$version/painter.exe"
+    }
+}

--- a/painter.json
+++ b/painter.json
@@ -1,5 +1,6 @@
 {
     "homepage": "https://github.com/lptstr/painter",
+    "description": "A tool to manage the Windows wallpaper from the terminal.",
     "license": "MIT",
     "version": "1.0.0",
     "url": "https://github.com/lptstr/painter/releases/download/v1.0.0/painter.exe",

--- a/painter.json
+++ b/painter.json
@@ -1,5 +1,6 @@
 {
     "homepage": "https://github.com/lptstr/painter",
+    "license": "MIT",
     "version": "1.0.0",
     "url": "https://github.com/lptstr/painter/releases/download/v1.0.0/painter.exe",
     "hash": "a4848ac1eedce8f841c441b8c358c7317b7d36e0efe4eb4ff8a9e68f1a9225a6",


### PR DESCRIPTION
Add [painter](https://github.com/lptstr/painter), a tool to manage the Windows desktop wallpaper from the terminal.