### PR TITLE
musescore@3.0.4.5763 URL change

### DIFF
--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -3,7 +3,7 @@
     "homepage": "https://musescore.org/",
     "version": "3.0.4.5763",
     "license": "GPL-2.0-only",
-    "url": "https://ftp.osuosl.org/pub/musescore/releases/MuseScore-3.0.4/MuseScore-3.0.4.msi",
+    "url": "https://github.com/musescore/MuseScore/releases/download/v3.0.4/MuseScore-3.0.4-x86_64.msi",
     "hash": "3b12fb19fcd2b9bee3febc21df645434f20a0d656c7c9399c6013ccd1b6618e4",
     "extract_dir": "MuseScore 3",
     "pre_install": "Get-ChildItem \"$dir\\bin\\MuseScore?.exe\" | Rename-Item -NewName \"$dir\\bin\\MuseScore.exe\"",

--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -25,7 +25,7 @@
         "regex": "sparkle:version=\"([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://ftp.osuosl.org/pub/musescore/releases/MuseScore-$matchHead/MuseScore-$matchHead.msi",
+        "url": "https://github.com/musescore/MuseScore/releases/download/v$matchHead/MuseScore-$matchHead-x86_64.msi",
         "extract_dir": "MuseScore $majorVersion",
         "hash": {
             "url": "https://musescore.org/en/download/musescore.msi",


### PR DESCRIPTION
https://ftp.osuosl.org/pub/musescore/releases/MuseScore-3.0.4/MuseScore-3.0.4.msi
or
https://ftp.osuosl.org/pub/musescore/releases/MuseScore-3.0.4/
do not exist. MuseScore release manager made the installers available at GitHub