### PR TITLE
Fix missing path in Miniconda3

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -52,7 +52,10 @@
         ]
     ],
     "persist": "envs",
-    "env_add_path": "scripts",
+    "env_add_path": [
+        "scripts",
+        "Library/bin"
+    ],
     "notes": [
         "Currently conda envs activate and deactivate doesn't work on PowerShell,",
         "for more information, see: https://github.com/conda/conda/issues/626,",


### PR DESCRIPTION
Conda will complain about SSL errors if you do not have `Library/bin` in the path. There is an upstream issue here (link directly to working solution):

https://github.com/conda/conda/issues/6064#issuecomment-453147166

The maintainers write it should be fixed in a future Python build, but when testing the build linked it still doesn't work so this workaround is clean and works well.