### PR TITLE
sts: Update to 4.1.2

### DIFF
--- a/bucket/sts.json
+++ b/bucket/sts.json
@@ -1,40 +1,35 @@
 {
     "homepage": "https://spring.io/tools/sts",
-    "version": "3.9.6",
+    "version": "4.1.2",
     "architecture": {
         "64bit": {
-            "url": "http://download.springsource.com/release/STS/3.9.6.RELEASE/dist/e4.9/spring-tool-suite-3.9.6.RELEASE-e4.9.0-win32-x86_64.zip",
-            "hash": "sha1:59de36dcbd94c56ce544c7551c324b4be295e8a3"
-        },
-        "32bit": {
-            "url": "http://download.springsource.com/release/STS/3.9.6.RELEASE/dist/e4.9/spring-tool-suite-3.9.6.RELEASE-e4.9.0-win32.zip",
-            "hash": "sha1:1f136696cf2982cdd089e89bf997d1b2472e7297"
+            "url": "https://download.springsource.com/release/STS4/4.1.2.RELEASE/dist/e4.10/spring-tool-suite-4-4.1.2.RELEASE-e4.10.0-win32.win32.x86_64.zip",
+            "hash": "sha1:93aba7298bd006d20d34c9eaef1f242ec93482d3"
         }
     },
-    "extract_dir": "sts-bundle",
-    "pre_install": "mv \"$dir\\sts-$version.RELEASE\" \"$dir\\sts\"",
+    "extract_dir": "sts-4.1.2.RELEASE",
     "shortcuts": [
         [
-            "sts\\STS.exe",
+            "SpringToolSuite4.exe",
             "Spring Tool Suite"
         ]
     ],
-    "bin": "sts\\STS.exe",
     "checkver": {
-        "url": "https://spring.io/tools/sts/all",
-        "re": "spring-tool-suite-(?<version>[\\d.]+).RELEASE-e(?<eclipse>(?<short>[\\d.]+).[\\d]+\\w?)-win32.zip"
+        "url": "https://spring.io/tools",
+        "re": "spring-tool-suite-4-([\\d.]+).RELEASE-e(?<eclipse>(?<short>[\\d.]+).[\\d]+\\w?)-win32"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.springsource.com/release/STS/$matchVersion.RELEASE/dist/e$matchShort/spring-tool-suite-$version.RELEASE-e$matchEclipse-win32-x86_64.zip"
-            },
-            "32bit": {
-                "url": "http://download.springsource.com/release/STS/$matchVersion.RELEASE/dist/e$matchShort/spring-tool-suite-$version.RELEASE-e$matchEclipse-win32.zip"
+                "url": "https://download.springsource.com/release/STS4/$version.RELEASE/dist/e$matchShort/spring-tool-suite-4-$version.RELEASE-e$matchEclipse-win32.win32.x86_64.zip",
+                "hash": {
+                    "url": "$url.sha1"
+                }
             }
         },
-        "hash": {
-            "url": "$url.sha1"
-        }
-    }
+        "extract_dir": "sts-$version.RELEASE"
+    },
+    "notes": [
+        "For Windows 32bit, please use \"sts396\" in versions bucket."
+    ]
 }


### PR DESCRIPTION
Close #1782 
Version 4 is only 64bit, for latest 32bit, see versions/sts396 (https://github.com/scoopinstaller/versions/pull/121) (v3.9.7 is 64bit only too).