### PR TITLE
LOVE: Fix shortcut and checkver

### DIFF
--- a/bucket/love.json
+++ b/bucket/love.json
@@ -20,12 +20,15 @@
     "shortcuts": [
         [
             "love.exe",
-            "LÖVE"
+            "LOVE"
         ]
     ],
     "license": "Zlib",
     "notes": "Alternate versions of the LÖVE engine included in versions bucket.",
-    "checkver": "Download LÖVE ([\\d.]+)",
+    "checkver": {
+        "url": "https://bitbucket.org/rude/love/downloads/",
+        "regex": "love-([0-9.]+)-w"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
- Fix shortcut to "LOVE" to avoid shortcut creating error
- Change checkver to download page to ensure windows version is released