### PR TITLE
Add RBTray version 4.8

### DIFF
--- a/bucket/rbtray.json
+++ b/bucket/rbtray.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://rbtray.sourceforge.net/",
+    "description": "Background program making any application minimizable to the system tray by right-clicking its Minimize button",
+    "license": "GPL-2.0-or-later",
+    "version": "4.8",
+    "url": "https://github.com/benbuck/rbtray/archive/v4.8.zip",
+    "hash": "23ca18069c22f3f3655ffa24e2587a271644e6600139f0ba03bf234ad6a0d9eb",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "rbtray-4.8\\x64"
+        },
+        "32bit": {
+            "extract_dir": "rbtray-4.8\\x86"
+        }
+    },
+    "shortcuts": [
+        [
+            "RBTray.exe",
+            "RBTray"
+        ]
+    ]
+}


### PR DESCRIPTION
[RBTray](https://github.com/benbuck/rbtray) is a background application making it possible to minimize any window by right-clicking its Minimize button (there are other shortcuts available too). This manifest refers to an updated fork which supports modern Windows versions better.

As stated in [Installing](https://github.com/benbuck/rbtray#installing), we should document how to run it when the user logs in (as the application itself can't do that). What should we write in the `notes` section?