### PR TITLE
Add Zeal pre-install script to create zeal.ini file

### DIFF
--- a/bucket/zeal.json
+++ b/bucket/zeal.json
@@ -15,6 +15,9 @@
         }
     },
     "bin": "zeal.exe",
+    "pre_install": [
+        "if (!(test-path \"$dir\\zeal.ini\")) { new-item -force \"$dir\\zeal.ini\" -itemtype file | out-null }",
+    ],
     "persist": [
         "zeal.ini",
         "cache",

--- a/bucket/zeal.json
+++ b/bucket/zeal.json
@@ -16,7 +16,7 @@
     },
     "bin": "zeal.exe",
     "pre_install": [
-        "if (!(test-path \"$dir\\zeal.ini\")) { new-item -force \"$dir\\zeal.ini\" -itemtype file | out-null }",
+        "if (!(test-path \"$dir\\zeal.ini\")) { new-item -force \"$dir\\zeal.ini\" -itemtype file | out-null }"
     ],
     "persist": [
         "zeal.ini",


### PR DESCRIPTION
The scoop install process currently creates a directory for Zeal's preferences file. This PR adds a "pre_install" script to the Zeal recipe to create an empty preferences file, for the install process to link to.

This should fully close  #1481