### PR TITLE
Update weasel-pageant 1.3

### DIFF
--- a/bucket/weasel-pageant.json
+++ b/bucket/weasel-pageant.json
@@ -2,15 +2,15 @@
     "homepage": "https://github.com/vuori/weasel-pageant",
     "description": "weasel-pageant allows you to use SSH keys held by PuTTY's Pageant in WSL",
     "license": "GNU GPL v3",
-    "version": "1.2",
-    "url": "https://github.com/vuori/weasel-pageant/releases/download/v1.2/weasel-pageant-1.2.zip",
-    "extract_dir": "weasel-pageant-1.2",
-    "hash": "f4965a80e8aeb425f432173c8377bfb31f62b2c061a3ca2f578b5c2b8e7f7e07",
+    "version": "1.3",
+    "url": "https://github.com/vuori/weasel-pageant/releases/download/v1.3/weasel-pageant-1.3.zip",
+    "extract_dir": "weasel-pageant-1.3",
+    "hash": "1f8ed0448cd2e7559f5d9bab860713c1f4c82518cdb2000b5d511cecb9dcbf06",
     "checkver": {
         "github": "https://github.com/vuori/weasel-pageant"
     },
     "autoupdate": {
-        "url": "https://github.com/vuori/weasel-pageant/archive/weasel-pageant-$version.zip",
+        "url": "https://github.com/vuori/weasel-pageant/releases/download/v$version/weasel-pageant-$version.zip",
         "extract_dir": "weasel-pageant-$version"
     },
     "notes": [

--- a/bucket/weasel-pageant.json
+++ b/bucket/weasel-pageant.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/vuori/weasel-pageant",
     "description": "weasel-pageant allows you to use SSH keys held by PuTTY's Pageant in WSL",
-    "license": "GNU GPL v3",
+    "license": "GPL-3.0-or-later",
     "version": "1.3",
     "url": "https://github.com/vuori/weasel-pageant/releases/download/v1.3/weasel-pageant-1.3.zip",
     "extract_dir": "weasel-pageant-1.3",


### PR DESCRIPTION
Since the autoupdate url didn't seem to work I updated the url and now the autoupdate feature should work as intended.

```PS1
# .\bin\checkver.ps1 weasel-pageant -u
weasel-pageant: 1.3 (scoop version is 1.2) autoupdate available
Autoupdating weasel-pageant
Downloading weasel-pageant-1.3.zip to compute hashes!
weasel-pageant-1.3.zip (98,2 KB) [===============================================] 100%
Computed hash: 1f8ed0448cd2e7559f5d9bab860713c1f4c82518cdb2000b5d511cecb9dcbf06
Writing updated weasel-pageant manifest
```

Has the github release url schema been changed in the past? :S