### PR TITLE
Add Sysinternals Process Explorer v16.22

### DIFF
--- a/bucket/procexp.json
+++ b/bucket/procexp.json
@@ -1,0 +1,44 @@
+{
+	"description": "Process Explorer shows you information about which handles and DLLs processes have opened or loaded.",
+	"homepage": "https://technet.microsoft.com/sysinternals/bb896655",
+	"version": "16.22",
+	"hash": "d393f062091c4fcf720ce0cad56520a920ffcc9412cdc7941150e3bb3fc4fefa",
+	"url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
+	"license": {
+		"identifier": "Freeware",
+		"url": "https://docs.microsoft.com/en-us/sysinternals/license-terms"
+	},
+	"checkver": {
+		"url": "https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer",
+		"re": "Process Explorer v([\\d.]+)"
+	},
+	"autoupdate": {
+		"url": "https://download.sysinternals.com/files/ProcessExplorer.zip"
+    },
+    "architecture": {
+        "32bit": {
+            "bin": [
+                "procexp.exe"
+            ],
+            "shortcuts": [
+                [
+                    "procexp.exe",
+                    "SysInternals/ProcessExplorer - Enhanced Task Manager",
+                    "/accepteula"
+                ]
+            ]
+        },
+        "64bit": {
+            "bin": [
+                "procexp64.exe"
+            ],
+            "shortcuts": [
+                [
+                    "procexp64.exe",
+                    "SysInternals/ProcessExplorer - Enhanced Task Manager",
+                    "/accepteula"
+                ]
+            ]
+        }
+    }
+}

--- a/bucket/procexp.json
+++ b/bucket/procexp.json
@@ -1,19 +1,19 @@
 {
-	"description": "Process Explorer shows you information about which handles and DLLs processes have opened or loaded.",
-	"homepage": "https://technet.microsoft.com/sysinternals/bb896655",
-	"version": "16.22",
-	"hash": "d393f062091c4fcf720ce0cad56520a920ffcc9412cdc7941150e3bb3fc4fefa",
-	"url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
-	"license": {
-		"identifier": "Freeware",
-		"url": "https://docs.microsoft.com/en-us/sysinternals/license-terms"
-	},
-	"checkver": {
-		"url": "https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer",
-		"re": "Process Explorer v([\\d.]+)"
-	},
-	"autoupdate": {
-		"url": "https://download.sysinternals.com/files/ProcessExplorer.zip"
+    "description": "Process Explorer shows you information about which handles and DLLs processes have opened or loaded.",
+    "homepage": "https://technet.microsoft.com/sysinternals/bb896655",
+    "version": "16.22",
+    "hash": "d393f062091c4fcf720ce0cad56520a920ffcc9412cdc7941150e3bb3fc4fefa",
+    "url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://docs.microsoft.com/en-us/sysinternals/license-terms"
+    },
+    "checkver": {
+        "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer",
+        "re": "Process Explorer v([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://download.sysinternals.com/files/ProcessExplorer.zip"
     },
     "architecture": {
         "32bit": {


### PR DESCRIPTION
Sophos antivirus software marks pskill and sorts as suspicious software preventing SysinternalsSuite installation.
Thus this separate package.