### PR TITLE
Add coursier (an artifact downloader like Ivy)

### DIFF
--- a/bucket/coursier.json
+++ b/bucket/coursier.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/coursier/coursier",
+    "description": "Pure Scala Artifact Fetching",
+    "license": "Apache-2.0",
+    "version": "1.1.0-M13-1",
+    "url": [
+        "https://github.com/coursier/coursier/releases/download/v1.1.0-M13-1/coursier",
+        "https://github.com/coursier/coursier/releases/download/v1.1.0-M13-1/coursier.bat"
+    ],
+    "hash": [
+        "c82f560b6aa851d06a431e266522f75b3e2e3fca0e913a3c85c9944bee027d69",
+        "994b15a95cefeaac5a6054bdcb807596b46188a92b6ea7b23c809c97cbf22a2b"
+    ],
+    "bin": "coursier.bat",
+    "checkver": {
+        "url": "https://github.com/coursier/coursier/releases",
+        "re": "v(?<version>\\d\\.\\d\\.\\d-[\\d\\w-]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/coursier/coursier/releases/download/v$version/coursier"
+    }
+}

--- a/bucket/coursier.json
+++ b/bucket/coursier.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/coursier/coursier",
+    "homepage": "https://get-coursier.io/",
     "description": "Pure Scala Artifact Fetching",
     "license": "Apache-2.0",
     "version": "1.1.0-M13-1",


### PR DESCRIPTION
I haven't found an example where multiple `autoupdate` `url`s are used, so I'm assuming I have to hard-code the link to the second file?