### PR TITLE
spytify: Update to version 1.2.0

### DIFF
--- a/bucket/spytify.json
+++ b/bucket/spytify.json
@@ -1,13 +1,16 @@
 {
     "description": "Records Spotify while it plays without ads.",
     "homepage": "https://github.com/jwallet/spy-spotify",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "license": "MIT",
-    "url": "https://github.com/jwallet/spy-spotify/releases/download/1.1.4/Spytify-v1.1.4.zip",
+    "url": "https://github.com/jwallet/spy-spotify/releases/download/1.2.0/Spytify-v1.2.zip",
     "bin": "Spytify.exe",
-    "hash": "85595849706f83a6229757a71485bd1087da1107a78279aa956a64b45f8f7511",
-    "checkver": "github",
+    "hash": "0d9e4ab3d0017dbd0f404d1c467cbaa07aeea3c59fb1e7140531982f28d5b048",
+    "checkver": {
+        "github": "https://github.com/jwallet/spy-spotify",
+        "regex": "\\/releases\\/tag\\/(?:v|V)?((?<number>[\\d.]+\\.[1-9])(?:\\.0)?)"
+    },
     "autoupdate": {
-        "url": "https://github.com/jwallet/spy-spotify/releases/download/$version/Spytify-v$version.zip"
+        "url": "https://github.com/jwallet/spy-spotify/releases/download/$version/Spytify-v$matchNumber.zip"
     }
 }


### PR DESCRIPTION
And fixed regex to discard the zero number in version
Example:
1.1.4 -> Spytify-v1.1.4.zip
1.2.0 -> Spytify-v1.2.zip
1.2.1 -> Spytify-v1.2.1.zip