### PR TITLE
Notable: Fix license and change url

### DIFF
--- a/bucket/notable.json
+++ b/bucket/notable.json
@@ -1,11 +1,11 @@
 {
-    "homepage": "https://github.com/fabiospampinato/notable",
+    "homepage": "https://github.com/notable/notable",
     "description": "The markdown-based note-taking app that doesn't suck.",
     "version": "1.4.0",
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/fabiospampinato/notable/releases/download/v1.4.0/Notable.Setup.1.4.0.exe#/dl.7z",
+            "url": "https://github.com/notable/notable/releases/download/v1.4.0/Notable.Setup.1.4.0.exe#/dl.7z",
             "hash": "sha512:f9bc88d2ced9d743338db5420ad83e8aa433fa3856348a37f2bb8603c6100e0f11b19f8bfa6054abb3211c9984b32ec6eeb5ff479593bf3835828e447963822a",
             "installer": {
                 "script": [
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/fabiospampinato/notable/releases/download/v$version/Notable.Setup.$version.exe#/dl.7z",
+                "url": "https://github.com/notable/notable/releases/download/v$version/Notable.Setup.$version.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/latest.yml",
                     "find": "sha512:\\s+(.*)"


### PR DESCRIPTION
- Change license from "MTI" to "AGPL-3.0"
- Change url to "https://github.com/notable/notable"