### PR TITLE
Add dupeGuru 4.0.3

### DIFF
--- a/bucket/dupeguru.json
+++ b/bucket/dupeguru.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://dupeguru.voltaicideas.net/",
+    "description": "dupeGuru is a cross-platform (Linux, OS X, Windows) GUI tool to find duplicate files in a system.",
+    "license": "GPL-3.0-only",
+    "version": "4.0.3-InstallFix",
+    "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.3-InstallFix/dupeGuru_win64_4.0.3.exe#/dl.7z",
+    "hash": "1bfe7fd2e619d39a51db3256692219bd4445a785111fa4a7abcdef8b9879b120",
+    "bin": "dupeguru.exe",
+    "shortcuts": [
+        [
+            "dupeguru.exe",
+            "dupeGuru"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/arsenetar/dupeguru"
+    },
+    "autoupdate": {
+        "url": "https://github.com/arsenetar/dupeguru/releases/download/$version/dupeGuru_win64_$version.exe#/dl.7z"
+    }
+}

--- a/bucket/dupeguru.json
+++ b/bucket/dupeguru.json
@@ -2,7 +2,7 @@
     "homepage": "https://dupeguru.voltaicideas.net/",
     "description": "dupeGuru is a cross-platform (Linux, OS X, Windows) GUI tool to find duplicate files in a system.",
     "license": "GPL-3.0-only",
-    "version": "4.0.3-InstallFix",
+    "version": "4.0.3",
     "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.3-InstallFix/dupeGuru_win64_4.0.3.exe#/dl.7z",
     "hash": "1bfe7fd2e619d39a51db3256692219bd4445a785111fa4a7abcdef8b9879b120",
     "bin": "dupeguru.exe",


### PR DESCRIPTION
I don't know about autoupdate url, because of different version in the file name.
`https://github.com/arsenetar/dupeguru/releases/download/$version/dupeGuru_win64_$version.exe#/dl.7z`
On the second place, it should be `4.0.3` instead of `4.0.3-InstallFix`.