### PR TITLE
Enonic CLI scoop entry for the extras bucket

### DIFF
--- a/bucket/enonic.json
+++ b/bucket/enonic.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.enonic.com/public/com/enonic/cli/enonic/1.0.0/enonic_1.0.0_Windows_64-bit.zip",
+            "bin": [
+                "enonic.exe"
+            ],
+            "hash": "c180abe98ad42277f2df8a678d29606787b9366cbc404823bd47c2527a50e2b2"
+        }
+    },
+    "homepage": "https://enonic.com/",
+    "license": "GPLv3",
+    "description": "Command-line interface for Enonic XP"
+}


### PR DESCRIPTION
The Enonic CLI allows users to create projects and manage instances for Enonic XP 7 and newer.