### PR TITLE
database.net: fix hash

### DIFF
--- a/bucket/database.net.json
+++ b/bucket/database.net.json
@@ -6,7 +6,7 @@
         "url": "https://fishcodelib.com/EULA.htm"
     },
     "version": "27.3.7023.1",
-    "hash": "f2c90e2d34e796c3be45d79e0e1fd903ff75e4fc6c7e606e24d2d1532253c90e",
+    "hash": "d3c912c8ada355b45e8c865ef4b8c3b62ff2861dbc0e94a2eae59a3fd7935e28",
     "url": "https://fishcodelib.com/files/DatabaseNet4.zip",
     "shortcuts": [
         [
@@ -17,13 +17,9 @@
     "persist": "Database_Files",
     "checkver": {
         "url": "https://fishcodelib.com/version.xml",
-        "re": "<ver name=\"database4\" md5=\"[a-zA-Z0-9]+\" ver=\"([\\d.]+)\""
+        "re": "database4.*?ver=\"([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://fishcodelib.com/files/DatabaseNet4.zip",
-        "hash": {
-            "url": "https://fishcodelib.com/version.xml",
-            "regex": "database4\"\\s*md5=\"([A-Za-z\\d]{32})\""
-        }
+        "url": "https://fishcodelib.com/files/DatabaseNet4.zip"
     }
 }

--- a/bucket/database.net.json
+++ b/bucket/database.net.json
@@ -11,7 +11,7 @@
     "shortcuts": [
         [
             "Database4.exe",
-            "Database.NET"
+            "Database .NET"
         ]
     ],
     "persist": "Database_Files",


### PR DESCRIPTION
Close #1917

`md5` in `https://fishcodelib.com/version.xml` is not a md5 hash string, it's 29bit or 31bit, need further conversion.