### PR TITLE
Veonim: Add version 0.14.0

### DIFF
--- a/bucket/veonim.json
+++ b/bucket/veonim.json
@@ -1,0 +1,32 @@
+{
+    "homepage": "https://github.com/veonim/veonim",
+    "version": "0.14.0",
+    "description": "Simple modal IDE built on neovim.",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/veonim/veonim/releases/download/0.14.0/veonim.0.14.0.exe#/dl.7z",
+            "hash": "30e690e9979e91e26fb177b22f1ee32eb1a5a479dacea699e178dcf2a08cb589",
+            "installer": {
+                "script": [
+                    "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            },
+            "shortcuts": [
+                [
+                    "veonim.exe",
+                    "Veonim"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/veonim/veonim/releases/download/$version/veonim.$version.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
There is `zip` version for Windows, but this `exe` version has smaller file size. (53.9MB vs. 81.8MB)