### PR TITLE
miniconda3: install with no registry edits

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -36,6 +36,7 @@
             "/InstallationType=JustMe",
             "/RegisterPython=0",
             "/AddToPath=0",
+            "/NoRegistry=1",
             "/D=$dir"
         ]
     },


### PR DESCRIPTION
To have a proper portable and more CI-orientend installation it would be best to add the installer argument `/NoRegistry=1` , which basically prevents registry modification as well as displaying miniconda among the installed programs in the control panel. Tested on my system, working as intended.

FYI, this is also mentioned in conda/conda#1977. Apparently, this option is documented in the help message (when running the installer with `/?`) but not in the official documentation.

EDIT: I take the chance to ask: since miniconda meets all the [criteria ](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket)to be included in the main bucket, shoul it be moved there? It could be redundant to have yet another Python distribution, but it's actually more than that (e.g. [conda-forge](https://conda-forge.org/)), and it's very well-known and widely used, particularly among data analysts.