### PR TITLE
Access exe of inno-setup from command line

### DIFF
--- a/bucket/inno-setup.json
+++ b/bucket/inno-setup.json
@@ -6,7 +6,7 @@
     "url": "http://www.jrsoftware.org/download.php/is-unicode.exe",
     "hash": "27d49e9bc769e9d1b214c153011978db90dc01c2acd1ddcd9ed7b3fe3b96b538",
     "innosetup": true,
-    "env_add_path": ".\\",
+    "bin": "iscc.exe",
     "post_install": [
         "Invoke-WebRequest -Uri 'http://www.jrsoftware.org/download.php/iscrypt.dll' -OutFile \"$dir\\ISCrypt.dll\""
     ],

--- a/bucket/inno-setup.json
+++ b/bucket/inno-setup.json
@@ -6,6 +6,7 @@
     "url": "http://www.jrsoftware.org/download.php/is-unicode.exe",
     "hash": "27d49e9bc769e9d1b214c153011978db90dc01c2acd1ddcd9ed7b3fe3b96b538",
     "innosetup": true,
+    "env_add_path": ".\\",
     "post_install": [
         "Invoke-WebRequest -Uri 'http://www.jrsoftware.org/download.php/iscrypt.dll' -OutFile \"$dir\\ISCrypt.dll\""
     ],


### PR DESCRIPTION
Add `env_add_path` option to allow for access to `iscc.exe` from the command line.