### PR TITLE
Inno Script Studio: Fix manifest

### DIFF
--- a/bucket/inno-script-studio.json
+++ b/bucket/inno-script-studio.json
@@ -5,13 +5,21 @@
     "license": "Freeware",
     "url": "https://www.kymoto.org/downloads/ISStudio_Latest.exe",
     "hash": "3e453334a89edcf6e50439e3296ec84913f6bb0c2b3efcb469c11ec8965d10bb",
-    "depends": "innosetup",
+    "depends": "inno-setup",
     "innosetup": true,
     "post_install": [
         "$regpath = \"HKCU:\\Software\\Kymoto Solutions\\Inno Script Studio 2\\Options\\Compiler\"",
         "New-Item -Path $regpath -Type Directory -Force | Out-Null",
-        "New-ItemProperty -Path $regpath -Name \"InnoCompilerPath\" -Value (versiondir 'innosetup' 'current') | Out-Null"
+        "New-ItemProperty -Path $regpath -Name \"InnoCompilerPath\" -Value (versiondir 'inno-setup' 'current') | Out-Null"
     ],
+    "uninstaller": {
+        "script": [
+            "Remove-Item \"HKCU:\\Software\\Kymoto Solutions\\Inno Script Studio 2\" -Recurse -Force",
+            "if ($null -eq (Get-ChildItem \"HKCU:\\Software\\Kymoto Solutions\")) {",
+            "   Remove-Item \"HKCU:\\Software\\Kymoto Solutions\" -Force",
+            "}"
+        ]
+    },
     "shortcuts": [
         [
             "ISStudio.exe",


### PR DESCRIPTION
- Forget to change `innosetup` to `inno-setup` in https://github.com/lukesampson/scoop-extras/pull/1901
- Delete added registry item during uninstall