### PR TITLE
GIMP: Using installer.script instead of original installer

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -2,9 +2,9 @@
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0-only",
     "description": "GNU Image Manipulation Program",
-    "version": "2.10.12-2",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup-2.exe",
-    "hash": "6cd67baf381c7950ec0a46f6ea9b9a6c9191e29fff09a575ce7c7af6d223b613",
+    "version": "2.10.12-3",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup-3.exe",
+    "hash": "90038ea1895b2fe2a63fe6f69fc2115161b9af6a509e96ee08371138260de45e",
     "innosetup": true,
     "installer": {
         "script": [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -1,32 +1,72 @@
 {
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0-only",
+    "description": "GNU Image Manipulation Program",
     "version": "2.10.12",
     "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup.exe",
     "hash": "40bf733beb554e0a5f5ab5b82e75c035eefd715b00cc0eaf1cd57ba8a7e2ab6f",
+    "innosetup": true,
     "installer": {
-        "args": [
-            "/VERYSILENT",
-            "/NORESTART",
-            "/DIR=\"$dir\""
+        "script": [
+            "Push-Location \"$dir\"",
+            "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
+            "if ($architecture -eq '64bit') {",
+            "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
+            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe'",
+            "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
+            "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
+            "   New-Item '32\\etc', '32\\share', 'share\\gimp\\2.0\\fonts' -ItemType 'Directory' | Out-Null",
+            "   Copy-Item 'etc\\fonts', 'etc\\gtk-2.0' '32\\etc' -Recurse",
+            "   Copy-Item 'share\\themes' '32\\share' -Recurse",
+            "   $defpath = \"`nPATH=`${gimp_installation_dir}\\bin;`${gimp_installation_dir}\\32\\bin\"",
+            "} else {",
+            "   Get-ChildItem -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.name -Replace ',1','' }",
+            "   Get-ChildItem -Filter '*,*' -Recurse | Remove-Item",
+            "   movedir \"$dir\\32\" \"$dir\" | Out-Null",
+            "   $defpath = \"`nPATH=`${gimp_installation_dir}\\bin\"",
+            "}",
+            "$defenv = Get-Content 'lib\\gimp\\2.0\\environ\\default.env' -Raw",
+            "$defenv += $defpath",
+            "$defenv += \"PYTHONPATH=`${gimp_installation_dir}\\lib\\gimp\\2.0\\python;`${gimp_plug_in_dir}\\plug-ins\\python-console\"",
+            "$defenv | Set-Content 'lib\\gimp\\2.0\\environ\\default.env'",
+            "$pyenv = Get-Content 'lib\\gimp\\2.0\\environ\\pygimp.env' -Raw",
+            "$pyenv + '__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content 'lib\\gimp\\2.0\\environ\\pygimp.env'",
+            "$pyint = Get-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp' -Raw",
+            "$pyint = ($pyint -Replace '/mingw32', \"$dir\\bin\") -Replace 'py::python2', 'py::python'",
+            "$pyint | Set-Content 'lib\\gimp\\2.0\\interpreters\\pygimp.interp'",
+            "Pop-Location"
         ]
-    },
-    "uninstaller": {
-        "file": "uninst\\unins000.exe",
-        "args": "/VERYSILENT"
     },
     "bin": [
+        "bin\\gimp-console-2.10.exe",
+        [
+            "bin\\gimp-console-2.10.exe",
+            "gimp"
+        ],
+        "bin\\gimptool-2.0.exe",
+        [
+            "bin\\gimptool-2.0.exe",
+            "gimptool"
+        ]
+    ],
+    "shortcuts": [
         [
             "bin\\gimp-2.10.exe",
-            "gimp"
+            "GIMP"
         ]
+    ],
+    "persist": [
+        "etc\\gimp",
+        "lib\\gimp\\2.0\\plug-ins",
+        "share\\gimp"
     ],
     "checkver": {
         "url": "https://www.gimp.org/downloads/",
-        "re": "gimp-(?<version>[\\d.]+)-setup(?<build>-\\d)?.exe"
+        "regex": "gimp-(?<version>[\\d.]+)-setup(?<build>-\\d)?.exe",
+        "replace": "${1}${2}"
     },
     "autoupdate": {
-        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$version-setup$matchBuild.exe",
+        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$matchVersion-setup$matchBuild.exe",
         "hash": {
             "url": "$baseurl/SHA256SUMS"
         }

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -2,9 +2,9 @@
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0-only",
     "description": "GNU Image Manipulation Program",
-    "version": "2.10.12",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup.exe",
-    "hash": "40bf733beb554e0a5f5ab5b82e75c035eefd715b00cc0eaf1cd57ba8a7e2ab6f",
+    "version": "2.10.12-1",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup-1.exe",
+    "hash": "1e624ac9f082ed7fa7dadf67c249a6aa7c208e156a7d92cff63437e63a644bfb",
     "innosetup": true,
     "installer": {
         "script": [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -2,9 +2,9 @@
     "homepage": "https://www.gimp.org/",
     "license": "GPL-3.0-only",
     "description": "GNU Image Manipulation Program",
-    "version": "2.10.12-1",
-    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup-1.exe",
-    "hash": "1e624ac9f082ed7fa7dadf67c249a6aa7c208e156a7d92cff63437e63a644bfb",
+    "version": "2.10.12-2",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.10/windows/gimp-2.10.12-setup-2.exe",
+    "hash": "6cd67baf381c7950ec0a46f6ea9b9a6c9191e29fff09a575ce7c7af6d223b613",
     "innosetup": true,
     "installer": {
         "script": [


### PR DESCRIPTION
Close #1369 

Please consider merging https://github.com/lukesampson/scoop/pull/3204, current `unpack_inno` crashed occasionally (due to `Move-Item` for huge amount of files).