### PR TITLE
winfetch: update dependencies

### DIFF
--- a/bucket/winfetch.json
+++ b/bucket/winfetch.json
@@ -5,7 +5,8 @@
     "version": "1.1.0",
     "depends": [
         "curl",
-        "pwsh"
+        "pwsh",
+        "imagemagick"
     ],
     "url": "https://codeload.github.com/lptstr/winfetch/zip/v1.1.0#/dl.7z",
     "extract_dir": "winfetch-1.1.0",


### PR DESCRIPTION
As of release v1.1.0, Winfetch now requires Imagemagick for certain features to be enabled, e.g. printing images in the terminal.

![](https://lptstr.github.io/lptstr-images/screenshots/projects/winfetch/computant.png)