### PR TITLE
add beaker

### DIFF
--- a/bucket/beaker.json
+++ b/bucket/beaker.json
@@ -1,0 +1,34 @@
+{
+	"version": "0.8.8",
+	"description": "An experimental peer-to-peer Web browser",
+	"homepage": "https://beakerbrowser.com/",
+	"license": "MIT",
+	"url": "https://github.com/beakerbrowser/beaker/releases/download/0.8.8/beaker-browser-setup-0.8.8.exe#/dl.7z",
+	"hash": "6662842f36e3d4e5e52aa8ca209d6727850a97831980214ed749829409a2d886",
+	"bin": "Beaker Browser.exe",
+	"extract_dir": "\\$PLUGINSDIR",
+	"shortcuts": [
+		[
+			"Beaker Browser.exe",
+			"Beaker Browser"
+		]
+	],
+	"installer": {
+		"script": [
+			"$arch = \"$dir\\app-64.7z\"",
+			"Remove-Item \"$dir\\*.dll\" -Force",
+			"extract_7zip \"$arch\" \"$dir\"",
+			"Remove-Item \"$arch\" -Force"
+		]
+	},
+	"checkver": {
+		"github": "https://github.com/beakerbrowser/beaker"
+	},
+	"autoupdate": {
+		"url": "https://github.com/beakerbrowser/beaker/releases/download/$version/beaker-browser-setup-$version.exe#/dl.7z",
+		"hash": {
+			"url": "$baseurl/latest.yml",
+			"regex": "sha512: $sha512"
+		}
+	}
+}

--- a/bucket/beaker.json
+++ b/bucket/beaker.json
@@ -13,13 +13,17 @@
 			"Beaker Browser"
 		]
 	],
-	"installer": {
-		"script": [
-			"$arch = \"$dir\\app-64.7z\"",
-			"Remove-Item \"$dir\\*.dll\" -Force",
-			"extract_7zip \"$arch\" \"$dir\"",
-			"Remove-Item \"$arch\" -Force"
-		]
+	"architecture": {
+		"64bit": {
+			"installer": {
+				"script": [
+					"$arch = \"$dir\\app-64.7z\"",
+					"Remove-Item \"$dir\\*.dll\" -Force",
+					"extract_7zip \"$arch\" \"$dir\"",
+					"Remove-Item \"$arch\" -Force"
+				]
+			}
+		}
 	},
 	"checkver": {
 		"github": "https://github.com/beakerbrowser/beaker"
@@ -28,7 +32,7 @@
 		"url": "https://github.com/beakerbrowser/beaker/releases/download/$version/beaker-browser-setup-$version.exe#/dl.7z",
 		"hash": {
 			"url": "$baseurl/latest.yml",
-			"regex": "sha512: $sha512"
+			"regex": "sha512: $base64"
 		}
 	}
 }

--- a/bucket/beaker.json
+++ b/bucket/beaker.json
@@ -1,38 +1,38 @@
 {
-	"version": "0.8.8",
-	"description": "An experimental peer-to-peer Web browser",
-	"homepage": "https://beakerbrowser.com/",
-	"license": "MIT",
-	"url": "https://github.com/beakerbrowser/beaker/releases/download/0.8.8/beaker-browser-setup-0.8.8.exe#/dl.7z",
-	"hash": "6662842f36e3d4e5e52aa8ca209d6727850a97831980214ed749829409a2d886",
-	"bin": "Beaker Browser.exe",
-	"extract_dir": "\\$PLUGINSDIR",
-	"shortcuts": [
-		[
-			"Beaker Browser.exe",
-			"Beaker Browser"
-		]
-	],
-	"architecture": {
-		"64bit": {
-			"installer": {
-				"script": [
-					"$arch = \"$dir\\app-64.7z\"",
-					"Remove-Item \"$dir\\*.dll\" -Force",
-					"extract_7zip \"$arch\" \"$dir\"",
-					"Remove-Item \"$arch\" -Force"
-				]
-			}
-		}
-	},
-	"checkver": {
-		"github": "https://github.com/beakerbrowser/beaker"
-	},
-	"autoupdate": {
-		"url": "https://github.com/beakerbrowser/beaker/releases/download/$version/beaker-browser-setup-$version.exe#/dl.7z",
-		"hash": {
-			"url": "$baseurl/latest.yml",
-			"regex": "sha512: $base64"
-		}
-	}
+    "version": "0.8.8",
+    "description": "An experimental peer-to-peer Web browser",
+    "homepage": "https://beakerbrowser.com/",
+    "license": "MIT",
+    "url": "https://github.com/beakerbrowser/beaker/releases/download/0.8.8/beaker-browser-setup-0.8.8.exe#/dl.7z",
+    "hash": "6662842f36e3d4e5e52aa8ca209d6727850a97831980214ed749829409a2d886",
+    "bin": "Beaker Browser.exe",
+    "extract_dir": "\\$PLUGINSDIR",
+    "shortcuts": [
+        [
+            "Beaker Browser.exe",
+            "Beaker Browser"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": [
+                    "$arch = \"$dir\\app-64.7z\"",
+                    "Remove-Item \"$dir\\*.dll\" -Force",
+                    "extract_7zip \"$arch\" \"$dir\"",
+                    "Remove-Item \"$arch\" -Force"
+                ]
+            }
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/beakerbrowser/beaker"
+    },
+    "autoupdate": {
+        "url": "https://github.com/beakerbrowser/beaker/releases/download/$version/beaker-browser-setup-$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/latest.yml",
+            "regex": "sha512: $base64"
+        }
+    }
 }


### PR DESCRIPTION
beaker browser is 64-bit only. Should `"architecture"` be used in `"autoupdate"` ?