### PR TITLE
alacritty: Update to version 0.3.0

### DIFF
--- a/bucket/alacritty.json
+++ b/bucket/alacritty.json
@@ -2,9 +2,9 @@
     "homepage": "https://github.com/jwilm/alacritty",
     "description": "A cross-platform, GPU-accelerated terminal emulator",
     "license": "Apache-2.0",
-    "version": "0.2.9",
-    "url": "https://github.com/jwilm/alacritty/releases/download/v0.2.9/Alacritty-v0.2.9-windows.zip",
-    "hash": "7edceed0ab442d746addf161a8310342c265d5ec95c23a689b13e4039f473359",
+    "version": "0.3.0",
+    "url": "https://github.com/jwilm/alacritty/releases/download/v0.3.0/Alacritty-v0.3.0-windows-portable.zip",
+    "hash": "0a6b8f173ff9e53cc38ec6d9ca82aea649e0eb733935ac269a02ecebba81847e",
     "bin": "alacritty.exe",
     "shortcuts": [
         [
@@ -15,7 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/jwilm/alacritty/releases/download/v$version/Alacritty-v$version-windows.zip"
+        "url": "https://github.com/jwilm/alacritty/releases/download/v$version/Alacritty-v$version-windows-portable.zip"
     },
     "suggest": {
         "vcredist": "extras/vcredist2017"


### PR DESCRIPTION
And also change `autoupdate` url.

@chrisduerr I hope that we don't have any more breaking changes for how Alacritty is published.