### PR TITLE
TestCentric: Add version 1.0.0-alpha4

### DIFF
--- a/bucket/testcentric.json
+++ b/bucket/testcentric.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://github.com/TestCentric/testcentric-gui",
+    "description": "GUI Runner for NUnit",
+    "version": "1.0.0-alpha4",
+    "license": "MIT",
+    "url": "https://github.com/TestCentric/testcentric-gui/releases/download/1.0.0-alpha4/testcentric-gui.1.0-alpha4.nupkg",
+    "hash": "5b3d1a2a8b119f74730d0d2546a29c5ba9d894c9abeb60f6ae4c551e065ed8c8",
+    "extract_dir": "tools",
+    "post_install": "New-Item -Path \"$dir\\nunit.scoop.addins\" -ItemType File -Value '../../nunit-extension-*/current/     # find extensions installed under scoop' | Out-Null",
+    "bin": "testcentric.exe",
+    "shortcuts": [
+        [
+            "testcentric.exe",
+            "TestCentric"
+        ]
+    ],
+    "suggest": {
+        "NuGet": "nuget",
+        "NUnit Extension": [
+            "nunit-extension-nunit-project-loader",
+            "nunit-extension-nunit-v2-driver",
+            "nunit-extension-nunit-v2-result-writer",
+            "nunit-extension-teamcity-event-listener",
+            "nunit-extension-vs-project-loader"
+        ]
+    },
+    "checkver": {
+        "url": "https://github.com/TestCentric/testcentric-gui/releases",
+        "regex": "tag/(.*)\""
+    },
+    "autoupdate": {
+        "url": "https://github.com/TestCentric/testcentric-gui/releases/download/$version/testcentric-gui.$majorVersion.$minorVersion-$preReleaseVersion.nupkg"
+    }
+}


### PR DESCRIPTION
New NUnit GUI, it could find scoop installed NUnit extensions automatically.

It will be released on Chocolatey, if so, the manifest will change url and au.hash.