### PR TITLE
Add rainmeter-portable: feedback needed

### DIFF
--- a/bucket/rainmeter-portable.json
+++ b/bucket/rainmeter-portable.json
@@ -32,9 +32,7 @@
         "Plugins"
     ],
     "post_install": [
-        "if(!(Test-Path \"$persist_dir\\Layouts\\*\")) { Copy-Item \"$dir\\Defaults\\Layouts\\*\" \"$dir\\Layouts\" -Force -Recurse | Out-Null }",
-        "if(!(Test-Path \"$persist_dir\\Skins\\*\")) { Copy-Item \"$dir\\Defaults\\Skins\\*\" \"$dir\\Skins\" -Force -Recurse | Out-Null }",
-        "if((Get-Content \"$dir\\Rainmeter.ini\") -eq $Null) { Copy-Item \"$dir\\Defaults\\Layouts\\illustro default\\Rainmeter.ini\" \"$persist_dir\" -Force -Recurse | Out-Null }",
+        "if((Get-Content \"$dir\\Rainmeter.ini\") -eq $Null) { Copy-Item \"$dir\\Defaults\\Layouts\\illustro default\\Rainmeter.ini\", \"$dir\\Defaults\\Skins\", \"$dir\\Defaults\\Layouts\" \"$persist_dir\" -Force -Recurse | Out-Null }",
         "if(Test-Path \"$dir\\Plugins.original\") { Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse; Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null }",
         "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe.nsis\", \"$dir\\inst.exe\" -Force -Recurse"
     ],

--- a/bucket/rainmeter-portable.json
+++ b/bucket/rainmeter-portable.json
@@ -1,0 +1,57 @@
+{
+    "homepage": "https://rainmeter.net/",
+    "description": "Rainmeter is a desktop customization tool for Windows.",
+    "version": "4.3.0.3298",
+    "license": "GPL-2.0-only",
+    "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.3.0.3298/Rainmeter-4.3.exe#/inst.exe",
+    "hash": "1bb57129f6871c7e5a835ded406de7096aebbe53196006ca0d00073948fbb16b",
+    "depends": "7zip",
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": "7z x \"$dir\\inst.exe\" -o\"$dir\" -aoa"
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": "7z x \"$dir\\inst.exe\" -o\"$dir\" -aos"
+            }
+        }
+    },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\Rainmeter.ini\")) { New-Item \"$dir\\Rainmeter.ini\" -Type File | Out-Null }",
+        "if(!(Test-Path \"$persist_dir\\Rainmeter.data\")) { New-Item \"$dir\\Rainmeter.data\" -Type File | Out-Null }",
+        "if(!(Test-Path \"$persist_dir\\Rainmeter.stats\")) { New-Item \"$dir\\Rainmeter.stats\" -Type File | Out-Null }"
+    ],
+    "persist": [
+        "Rainmeter.ini",
+        "Rainmeter.data",
+        "Rainmeter.stats",
+        "Layouts",
+        "Skins",
+        "Plugins"
+    ],
+    "post_install": [
+        "if(!(Test-Path \"$persist_dir\\Layouts\\*\")) { Copy-Item \"$dir\\Defaults\\Layouts\\*\" \"$dir\\Layouts\" -Force -Recurse | Out-Null }",
+        "if(!(Test-Path \"$persist_dir\\Skins\\*\")) { Copy-Item \"$dir\\Defaults\\Skins\\*\" \"$dir\\Skins\" -Force -Recurse | Out-Null }",
+        "if((Get-Content \"$dir\\Rainmeter.ini\") -eq $Null) { Copy-Item \"$dir\\Defaults\\Layouts\\illustro default\\Rainmeter.ini\" \"$persist_dir\" -Force -Recurse | Out-Null }",
+        "if(Test-Path \"$dir\\Plugins.original\") { Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse; Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null }",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe.nsis\", \"$dir\\inst.exe\" -Force -Recurse"
+    ],
+    "bin": [
+        "Rainmeter.exe",
+        "SkinInstaller.exe"
+    ],
+    "shortcuts": [
+        [
+            "Rainmeter.exe",
+            "Rainmeter"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/rainmeter/rainmeter"
+    },
+    "autoupdate": {
+        "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe#/inst.exe"
+    }
+}

--- a/bucket/rainmeter-portable.json
+++ b/bucket/rainmeter-portable.json
@@ -3,18 +3,18 @@
     "description": "Rainmeter is a desktop customization tool for Windows.",
     "version": "4.3.0.3298",
     "license": "GPL-2.0-only",
-    "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.3.0.3298/Rainmeter-4.3.exe#/inst.exe",
+    "url": "https://github.com/rainmeter/rainmeter/releases/download/v4.3.0.3298/Rainmeter-4.3.exe",
     "hash": "1bb57129f6871c7e5a835ded406de7096aebbe53196006ca0d00073948fbb16b",
     "depends": "7zip",
     "architecture": {
         "64bit": {
             "installer": {
-                "script": "7z x \"$dir\\inst.exe\" -o\"$dir\" -aoa"
+                "script": "7z x \"$dir\\$fname\" -o\"$dir\" -aoa"
             }
         },
         "32bit": {
             "installer": {
-                "script": "7z x \"$dir\\inst.exe\" -o\"$dir\" -aos"
+                "script": "7z x \"$dir\\$fname\" -o\"$dir\" -aos"
             }
         }
     },
@@ -43,7 +43,7 @@
         "    Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse",
         "    Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null",
         "}",
-        "@('$PLUGINSDIR', 'uninst.exe.nsis', 'inst.exe') | ForEach-Object { Remove-Item \"$dir\\$_\" -Force -Recurse }"
+        "@('$PLUGINSDIR', 'uninst.exe.nsis', $fname) | ForEach-Object { Remove-Item \"$dir\\$_\" -Force -Recurse }"
     ],
     "bin": [
         "Rainmeter.exe",
@@ -59,6 +59,6 @@
         "github": "https://github.com/rainmeter/rainmeter"
     },
     "autoupdate": {
-        "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe#/inst.exe"
+        "url": "https://github.com/rainmeter/rainmeter/releases/download/v$version/Rainmeter-$majorVersion.$minorVersion.exe"
     }
 }

--- a/bucket/rainmeter-portable.json
+++ b/bucket/rainmeter-portable.json
@@ -19,9 +19,9 @@
         }
     },
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\Rainmeter.ini\")) { New-Item \"$dir\\Rainmeter.ini\" -Type File | Out-Null }",
-        "if(!(Test-Path \"$persist_dir\\Rainmeter.data\")) { New-Item \"$dir\\Rainmeter.data\" -Type File | Out-Null }",
-        "if(!(Test-Path \"$persist_dir\\Rainmeter.stats\")) { New-Item \"$dir\\Rainmeter.stats\" -Type File | Out-Null }"
+        "@('Rainmeter.ini', 'Rainmeter.data', 'Rainmeter.stats') | ForEach-Object {",
+        "    if(!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" -Type File | Out-Null }",
+        "}"
     ],
     "persist": [
         "Rainmeter.ini",
@@ -32,9 +32,18 @@
         "Plugins"
     ],
     "post_install": [
-        "if((Get-Content \"$dir\\Rainmeter.ini\") -eq $Null) { Copy-Item \"$dir\\Defaults\\Layouts\\illustro default\\Rainmeter.ini\", \"$dir\\Defaults\\Skins\", \"$dir\\Defaults\\Layouts\" \"$persist_dir\" -Force -Recurse | Out-Null }",
-        "if(Test-Path \"$dir\\Plugins.original\") { Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse; Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null }",
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe.nsis\", \"$dir\\inst.exe\" -Force -Recurse"
+        "    # Makes default welcome skins appear on new installation.",
+        "if(!(Get-Content \"$dir\\Rainmeter.ini\")) {",
+        "    @('Layouts\\illustro default\\Rainmeter.ini', 'Skins', 'Layouts') | ForEach-Object {",
+        "        Copy-Item \"$dir\\Defaults\\$_\" \"$persist_dir\" -Force -Recurse | Out-Null",
+        "    }",
+        "}",
+        "    # If there was an update for plugin, copy default plugins after persisting.",
+        "if (Test-Path \"$dir\\Plugins.original\") {",
+        "    Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse",
+        "    Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null",
+        "}",
+        "@('$PLUGINSDIR', 'uninst.exe.nsis', 'inst.exe') | ForEach-Object { Remove-Item \"$dir\\$_\" -Force -Recurse }"
     ],
     "bin": [
         "Rainmeter.exe",


### PR DESCRIPTION
There was a problem with unpacking different architectures in https://github.com/lukesampson/scoop-extras/pull/694. Looking for input on this solution: it works, persistence isn't trivial here, but to my knowledge I managed to persist everything.

`"if((Get-Content \"$dir\\Rainmeter.ini\") -eq $Null) { Copy-Item \"$dir\\Defaults\\Layouts\\illustro default\\Rainmeter.ini\", \"$dir\\Defaults\\Skins\", \"$dir\\Defaults\\Layouts\" \"$persist_dir\" -Force -Recurse | Out-Null }",` makes default welcome skins appear on new installation.

`"if(Test-Path \"$dir\\Plugins.original\") { Copy-Item \"$dir\\Plugins.original\\*\" \"$persist_dir\\Plugins\" -Force -Recurse; Remove-Item \"$dir\\Plugins.original\" -Force -Recurse | Out-Null }",` updates default plugins in case of an update.