### PR TITLE
terminus: Use portable version

### DIFF
--- a/bucket/terminus.json
+++ b/bucket/terminus.json
@@ -5,25 +5,30 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Eugeny/terminus/releases/download/v1.0.75/terminus-1.0.75-full.nupkg",
-            "hash": "ff92992c137eb508e20055a03fc46b6289502f4594d505ec6171660178d65140"
+            "url": "https://github.com/Eugeny/terminus/releases/download/v1.0.75/terminus-1.0.75-portable.exe#/dl.7z",
+            "hash": "9a71c08578fdb6be6327ba9a7087ffb6f27432ab791b5ea15b4268d8fd4b369e",
+            "installer": {
+                "script": [
+                    "extract_7zip \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            },
+            "bin": "Terminus.exe",
+            "shortcuts": [
+                [
+                    "Terminus.exe",
+                    "Terminus"
+                ]
+            ]
         }
     },
-    "extract_dir": "lib\\net45",
-    "bin": "Terminus.exe",
-    "shortcuts": [
-        [
-            "Terminus.exe",
-            "Terminus"
-        ]
-    ],
     "checkver": {
         "github": "https://github.com/Eugeny/terminus"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Eugeny/terminus/releases/download/v$version/terminus-$version-full.nupkg"
+                "url": "https://github.com/Eugeny/terminus/releases/download/v$version/terminus-$version-portable.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Using `terminus-$version-portable.exe` for smaller download size (70MB vs. 140MB).