### PR TITLE
Calibre: Change URL to fosshub

### DIFF
--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -5,13 +5,13 @@
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v3.42.0/calibre-64bit-3.42.0.msi",
-            "hash": "sha512:25a37b93d155ab9fd4730fe6f2a388605ceac1a12782540c194c288c2baa25cef87730fe94bd012f1ca6cf2dcb3a83f65306b1577db3792cb847e66ca61ae232",
+            "url": "https://www.fosshub.com/Calibre.html/calibre-64bit-3.41.3.msi",
+            "hash": "502d441871dc8582e3fafcea3adf4a179dc2eaa9124fc9f8af635ad932f37838",
             "extract_dir": "PFiles\\Calibre2"
         },
         "32bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v3.42.0/calibre-3.42.0.msi",
-            "hash": "sha512:73dd498e499e49e19327b1cfb7a80306a7a1ff22b78c744c179839eda97ceb8eed1b270ff31daf669c05a744d5add1a297dfa549a58fefde0d3fc9f8ddaac361",
+            "url": "https://www.fosshub.com/Calibre.html/calibre-3.41.3.msi",
+            "hash": "727d57b5096ca236113af68a9b69a253af40676985ca63b2f2d1816800aaa022",
             "extract_dir": "PFiles\\Calibre"
         }
     },
@@ -23,19 +23,17 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/kovidgoyal/calibre"
+        "url": "https://www.fosshub.com/Calibre.html",
+        "regex": "softwareVersion\">([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-64bit-$version.msi"
+                "url": "https://www.fosshub.com/Calibre.html/calibre-64bit-$version.msi"
             },
             "32bit": {
-                "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-$version.msi"
+                "url": "https://www.fosshub.com/Calibre.html/calibre-$version.msi"
             }
-        },
-        "hash": {
-            "url": "https://calibre-ebook.com/signatures/$basename.sha512"
         }
     }
 }

--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -5,13 +5,13 @@
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://www.fosshub.com/Calibre.html/calibre-64bit-3.41.3.msi",
-            "hash": "502d441871dc8582e3fafcea3adf4a179dc2eaa9124fc9f8af635ad932f37838",
+            "url": "https://www.fosshub.com/Calibre.html/calibre-64bit-3.42.0.msi",
+            "hash": "e014242bc20e13ab9e9f8b89055c0e8c6e433abb6886dff4fdcab5977884a0a3",
             "extract_dir": "PFiles\\Calibre2"
         },
         "32bit": {
-            "url": "https://www.fosshub.com/Calibre.html/calibre-3.41.3.msi",
-            "hash": "727d57b5096ca236113af68a9b69a253af40676985ca63b2f2d1816800aaa022",
+            "url": "https://www.fosshub.com/Calibre.html/calibre-3.42.0.msi",
+            "hash": "65157d78bbfbd2ca56485a219552f01c10384c86f096438ea40ea0e0ec2fd3ad",
             "extract_dir": "PFiles\\Calibre"
         }
     },

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -3,8 +3,8 @@
     "version": "3.42.0",
     "description": "Powerful and easy to use e-book manager.",
     "license": "GPL-3.0",
-    "url": "https://github.com/kovidgoyal/calibre/releases/download/v3.42.0/calibre-portable-installer-3.42.0.exe#/calibre-portable-installer.exe",
-    "hash": "sha512:50ce2ff9a8a49f2bd7d9b801ed50ec64c453860ffdcbaebb31c63072299b76edf9826092a6c9f85d1aebae4aa4a9ca3c6975186d3c0e05533bbc9e680b73631b",
+    "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-3.41.3.exe",
+    "hash": "af59d8ccdef6fd466fb628ffe68554f8c6315bac9f1596388f34d346d4252cca",
     "persist": [
         "Calibre Portable/Calibre Library",
         "Calibre Portable/Calibre Settings"
@@ -20,12 +20,10 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/kovidgoyal/calibre"
+        "url": "https://www.fosshub.com/Calibre.html",
+        "regex": "softwareVersion\">([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/kovidgoyal/calibre/releases/download/v$version/calibre-portable-installer-$version.exe#/calibre-portable-installer.exe",
-        "hash": {
-            "url": "https://calibre-ebook.com/signatures/$basename.sha512"
-        }
+        "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-$version.exe"
     }
 }

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -3,8 +3,8 @@
     "version": "3.42.0",
     "description": "Powerful and easy to use e-book manager.",
     "license": "GPL-3.0",
-    "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-3.41.3.exe",
-    "hash": "af59d8ccdef6fd466fb628ffe68554f8c6315bac9f1596388f34d346d4252cca",
+    "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-3.42.0.exe",
+    "hash": "ae97751d5f0dd77abbf5aede105968b34cb144f3fc69c78d82fab4f43e0915eb",
     "persist": [
         "Calibre Portable/Calibre Library",
         "Calibre Portable/Calibre Settings"


### PR DESCRIPTION
FossHub is more stabler and faster than GitHub.