### PR TITLE
obs-studio: Update to version 23.1.0

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -1,11 +1,11 @@
 {
     "homepage": "https://obsproject.com/",
     "license": "GPL-2.0-only",
-    "version": "23.0.2",
+    "version": "23.1.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/obsproject/obs-studio/releases/download/23.0.2/OBS-Studio-23.0.2-Full-x64.zip",
-            "hash": "6ddbab4a53349034801c4f46d41f31548c4f301f73d1573c427b0724cec41e36",
+            "url": "https://github.com/obsproject/obs-studio/releases/download/23.1.0/OBS-Studio-23.1-Full-x64.zip",
+            "hash": "409f2520b8eb7b3bf06c74a790d8edb6c4c2ca2a0bb407243cc4e890e7745005",
             "shortcuts": [
                 [
                     "bin\\64bit\\obs64.exe",
@@ -14,8 +14,8 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/obsproject/obs-studio/releases/download/23.0.2/OBS-Studio-23.0.2-Full-x86.zip",
-            "hash": "58e924d4ea40ce18f826e605c4cdd05d3a072f64be51a75ab8dae1fc58153788",
+            "url": "https://github.com/obsproject/obs-studio/releases/download/23.1.0/OBS-Studio-23.1-Full-x86.zip",
+            "hash": "4271dcb6ee2cba8c7ecf2243af90c192a5adb95c45aa20bb8a0ef81ea3e10d85",
             "shortcuts": [
                 [
                     "bin\\32bit\\obs32.exe",

--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -30,15 +30,16 @@
     ],
     "pre_install": "if(!(test-path \"$dir\\portable_mode.txt\")) { Add-Content \"$dir\\portable_mode.txt\" $null }",
     "checkver": {
-        "github": "https://github.com/obsproject/obs-studio"
+        "github": "https://github.com/obsproject/obs-studio",
+        "regex": "/download/([\\d\\.]+)/OBS-Studio-(?<short>[\\d\\.]+)-Full"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Full-x64.zip"
+                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$matchShort-Full-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Full-x86.zip"
+                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$matchShort-Full-x86.zip"
             }
         }
     }


### PR DESCRIPTION
The automatic update using `checkver` will fail because the new version doesn't have the `.0` in the file name in the [download URLs](https://github.com/obsproject/obs-studio/releases/download/23.1.0/OBS-Studio-23.1-Full-x64.zip) from [the Github releases page](https://github.com/obsproject/obs-studio/releases). 