### PR TITLE
Fix RStudio checkver and autoupdate

### DIFF
--- a/bucket/rstudio.json
+++ b/bucket/rstudio.json
@@ -1,9 +1,9 @@
 {
-    "version": "1.1.463",
+    "version": "1.2.1335",
     "license": "AGPL-3.0-only",
     "homepage": "https://www.rstudio.com/",
-    "url": "https://download1.rstudio.org/RStudio-1.1.463.zip",
-    "hash": "d0b1d8805b0db25d43435a2fcfefb4e6561add51f55be805e799b51d8bfa8114",
+    "url": "https://download1.rstudio.org/desktop/windows/RStudio-1.2.1335.zip",
+    "hash": "f833cd9806feaf3aaf9526a6e096b35a0c75e9f210403588dc8eed246c68470c",
     "depends": "r",
     "bin": "bin/rstudio.exe",
     "shortcuts": [
@@ -25,10 +25,9 @@
         "}"
     ],
     "checkver": {
-        "url": "https://www.rstudio.com/products/rstudio/download/",
-        "re": "RStudio-([\\d.]+).zip"
+        "github": "https://github.com/rstudio/rstudio/"
     },
     "autoupdate": {
-        "url": "https://download1.rstudio.org/RStudio-$version.zip"
+        "url": "https://download1.rstudio.org/desktop/windows/RStudio-$version.zip"
     }
 }


### PR DESCRIPTION
Change checkver to "github" to be able to detect again new versions. Small change to autoupdate url.