### PR TITLE
fix: solve shadowsocksr-csharp install error

### DIFF
--- a/bucket/shadowsocksr-csharp.json
+++ b/bucket/shadowsocksr-csharp.json
@@ -3,7 +3,7 @@
     "description": "An Internet censorship circumventing tunnel tool, forked by Breakwa11 from shadowsocks, maintained now by Akariiin",
     "version": "4.9.2",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/shadowsocksrr/shadowsocksr-csharp/releases/download/4.9.2/ShadowsocksR-win-4.9.2.zip",
+    "url": "https://github.com/shadowsocksrr/shadowsocksr-csharp/releases/download/4.9.2/ShadowsocksR-win-4.9.2.zip#dl.7z",
     "hash": "e3f6860aeff0f45db52f74c0060a657d59c2436ccfcba3ed534e1e01ad5212d3",
     "extract_dir": "ShadowsocksR-win-4.9.2",
     "bin": [


### PR DESCRIPTION
fix: solve shadowsocksr-csharp install error on ExtractToFile because of the archive entry is compressed using an unsupported compression method.