### PR TITLE
Add cryptomator

### DIFF
--- a/cryptomator.json
+++ b/cryptomator.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/cryptomator/cryptomator",
+    "description": "Multi-platform transparent client-side encryption of your files in the cloud.",
+    "license": "GPL-3.0-only",
+    "version": "1.4.9",
+    "url": "https://github.com/cryptomator/cryptomator/releases/download/1.4.9/Cryptomator-1.4.9-x64.exe",
+    "hash": "5f6520a7f05ca00a086d81b57e8fd56045d8632e1905e6e46427fdaaaeedf3fb",
+    "installer": {
+        "args": [
+            "/VERYSILENT",
+            "/NORESTART",
+            "/DIR=\"$dir\""
+        ]
+    },
+    "uninstaller": {
+        "file": "unins000.exe",
+        "args": [
+            "/VERYSILENT"
+        ]
+    },
+    "bin": [
+        [
+            "Cryptomator.exe"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/cryptomator/cryptomator/releases/download/$version/Cryptomator-$version-x64.exe"
+    }
+}


### PR DESCRIPTION
This PR adds an app manifest for [cryptomator](https://github.com/cryptomator/cryptomator):

- Releases from GitHub
- Currently only available as (non-portable) installer (also see https://github.com/cryptomator/cryptomator/issues/48)

This manifest is also similar to the Chocolatey [package](https://chocolatey.org/packages/cryptomator/).