### PR TITLE
flutter: remove dart from dependencies

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -12,7 +12,6 @@
         "bbd8dd269dd70d97e0224025281e55b7e2e32364d5c47e082ca7f45e33d1a613"
     ],
     "depends": [
-        "dart",
         "android-sdk",
         "java/adopt8-hotspot"
     ],


### PR DESCRIPTION
Dart should not be listed as a dependency because last versions of
flutter already have dart-sdk packaged in the bin/cache directory

(merging this should close #2079)