### PR TITLE
firefox-nightly: fix version and enable autoupdate

### DIFF
--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -1,17 +1,19 @@
 {
     "description": "Nightly builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/nightly/",
-    "version": "nightly",
+    "version": "68.0a1",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=win64&lang=en-US#/firefox.7z"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-68.0a1.en-US.win64.zip",
+            "hash": "9c029b39249dbabf4747fe2e7d0e330c6f519c588c98d859a91a4ea70ea6ff0d"
         },
         "32bit": {
-            "url": "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=win&lang=en-US#/firefox.7z"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-68.0a1.en-US.win32.zip",
+            "hash": "9831d9916cc091ff999ea73de5406a32c3c6dec5651b6d6b609bbdb0a118781d"
         }
     },
-    "extract_dir": "core",
+    "extract_dir": "firefox",
     "bin": [
         [
             "firefox.exe",
@@ -23,5 +25,27 @@
             "firefox.exe",
             "Firefox Nightly"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/",
+        "re": "firefox-([\\d\\.]+a\\d+)\\.en-US"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.zip",
+                "hash": {
+                    "find": "([a-f0-9]{64})\\ssha256\\s\\d+\\sfirefox-$version.en-US.win64.zip",
+                    "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.checksums"
+                }
+            },
+            "32bit": {
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.zip",
+                "hash": {
+                    "find": "([a-f0-9]{64})\\ssha256\\s\\d+\\sfirefox-$version.en-US.win32.zip",
+                    "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.checksums"
+                }
+            }
+        }
+    }
 }

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-68.0a1.en-US.win64.zip",
-            "hash": "9c029b39249dbabf4747fe2e7d0e330c6f519c588c98d859a91a4ea70ea6ff0d"
+            "hash": "sha512:fd291fb029198c39602cb14aad644ac0cd683160a39a86e1d4d15f12df6e858e7df6d81dc6b4fe326570805a79aa52f1d0e12a37956480e1fbd4210fe9fca91e"
         },
         "32bit": {
             "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-68.0a1.en-US.win32.zip",
-            "hash": "9831d9916cc091ff999ea73de5406a32c3c6dec5651b6d6b609bbdb0a118781d"
+            "hash": "sha512:b59bd83494b13bda45225195cb9b268a8324e9d239a9123d2ad4cc23deb03dfd5c6b81ee0062e181c19448978ae9e9a2beeaf7b05c8d92968949f1b744d08429"
         }
     },
     "extract_dir": "firefox",
@@ -35,14 +35,14 @@
             "64bit": {
                 "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.zip",
                 "hash": {
-                    "regex": "(^$sha256\\ssha256\\s\\d+\\s$basename",
+                    "regex": "(^$sha256)\\ssha256\\s\\d+\\s$basename",
                     "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.checksums"
                 }
             },
             "32bit": {
                 "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.zip",
                 "hash": {
-                    "find": "([a-f0-9]{64})\\ssha256\\s\\d+\\sfirefox-$version.en-US.win32.zip",
+                    "regex": "(^$sha256)\\ssha256\\s\\d+\\s$basename",
                     "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.checksums"
                 }
             }

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -35,14 +35,12 @@
             "64bit": {
                 "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.zip",
                 "hash": {
-                    "regex": "(^$sha256)\\ssha256\\s\\d+\\s$basename",
                     "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.checksums"
                 }
             },
             "32bit": {
                 "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.zip",
                 "hash": {
-                    "regex": "(^$sha256)\\ssha256\\s\\d+\\s$basename",
                     "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.checksums"
                 }
             }

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -35,7 +35,7 @@
             "64bit": {
                 "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.zip",
                 "hash": {
-                    "find": "([a-f0-9]{64})\\ssha256\\s\\d+\\sfirefox-$version.en-US.win64.zip",
+                    "regex": "(^$sha256\\ssha256\\s\\d+\\s$basename",
                     "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.checksums"
                 }
             },

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -28,7 +28,7 @@
     ],
     "checkver": {
         "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/",
-        "re": "firefox-([\\d\\.]+a\\d+)\\.en-US"
+        "regex": "firefox-([\\w.]+)\\.en-US"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This tries to fix part of #1140 .
This only fixes firefox-nightly. We still need to figure out how to extract latest version numbers from firefox-beta and firefox-developer

Also downloads .zip release of Firefox Nightly instead of the installer .exe