### PR TITLE
dupeguru: Fix shim problem and add 32bit arch

### DIFF
--- a/bucket/dupeguru.json
+++ b/bucket/dupeguru.json
@@ -3,19 +3,41 @@
     "description": "dupeGuru is a cross-platform (Linux, OS X, Windows) GUI tool to find duplicate files in a system.",
     "license": "GPL-3.0-only",
     "version": "4.0.4",
-    "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.4/dupeGuru_win64_4.0.4.exe#/dl.7z",
-    "hash": "72637b8d526d97c7b1836857f4012de831a07b3f156028b1b854f1e6e6fd1d84",
-    "bin": "dupeguru.exe",
-    "shortcuts": [
-        [
-            "dupeguru.exe",
-            "dupeGuru"
-        ]
-    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.4/dupeGuru_win64_4.0.4.exe#/dl.7z",
+            "hash": "72637b8d526d97c7b1836857f4012de831a07b3f156028b1b854f1e6e6fd1d84",
+            "bin": "dupeguru-win64.exe",
+            "shortcuts": [
+                [
+                    "dupeguru-win64.exe",
+                    "dupeGuru"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.4/dupeGuru_win32_4.0.4.exe#/dl.7z",
+            "hash": "6af5aa5b9ac0a2784abed63ca362872300a989bbcdec8998edbf65afd042f229",
+            "bin": "dupeguru-win32.exe",
+            "shortcuts": [
+                [
+                    "dupeguru-win32.exe",
+                    "dupeGuru"
+                ]
+            ]
+        }
+    },
     "checkver": {
         "github": "https://github.com/arsenetar/dupeguru"
     },
     "autoupdate": {
-        "url": "https://github.com/arsenetar/dupeguru/releases/download/$version/dupeGuru_win64_$version.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/arsenetar/dupeguru/releases/download/$version/dupeGuru_win64_$version.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/arsenetar/dupeguru/releases/download/$version/dupeGuru_win32_$version.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/dupeguru.json
+++ b/bucket/dupeguru.json
@@ -7,7 +7,12 @@
         "64bit": {
             "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.4/dupeGuru_win64_4.0.4.exe#/dl.7z",
             "hash": "72637b8d526d97c7b1836857f4012de831a07b3f156028b1b854f1e6e6fd1d84",
-            "bin": "dupeguru-win64.exe",
+            "bin": [
+                [
+                    "dupeguru-win64.exe",
+                    "dupeguru"
+                ]
+            ],
             "shortcuts": [
                 [
                     "dupeguru-win64.exe",
@@ -18,7 +23,12 @@
         "32bit": {
             "url": "https://github.com/arsenetar/dupeguru/releases/download/4.0.4/dupeGuru_win32_4.0.4.exe#/dl.7z",
             "hash": "6af5aa5b9ac0a2784abed63ca362872300a989bbcdec8998edbf65afd042f229",
-            "bin": "dupeguru-win32.exe",
+            "bin": [
+                [
+                    "dupeguru-win32.exe",
+                    "dupeguru"
+                ]
+            ],
             "shortcuts": [
                 [
                     "dupeguru-win32.exe",


### PR DESCRIPTION
This should close #2152.

Instead of trying to create shortcuts and shim for `dupeguru.exe`, it uses `dupeguru-win32.exe` or `dupeguru-win64.exe`