### PR TITLE
waterfox@56.2.10: hash check failed

### DIFF
--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/MrAlex94/Waterfox/blob/master/LICENSE"
     },
     "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.2.10%20Setup.exe#/dl.7z",
-    "hash": "39b567f1ffe420571e9420cdbf5d6408f6f63446dac686be9fb3998ef55a7fee",
+    "hash": "11a6283ea313b15c460c445c686c25e2fcd0bf392045d306a01bf5eed99c9d7b",
     "extract_dir": "core",
     "bin": "waterfox.exe",
     "shortcuts": [


### PR DESCRIPTION
```
$ scoop update waterfox
waterfox: 56.2.9 -> 56.2.10
Updating one outdated app:
Updating 'waterfox' (56.2.9 -> 56.2.10)
Downloading new version
Downloading https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.2.10%20Setup.exe#/dl.7z (72.0 MB)...
Checking hash of Waterfox%2056.2.10%20Setup.exe ... ERROR Hash check failed!
App:         extras/waterfox
URL:         https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.2.10%20Setup.exe#/dl.7z
First bytes: 4D 5A 90 00 03 00 00 00
Expected:    39b567f1ffe420571e9420cdbf5d6408f6f63446dac686be9fb3998ef55a7fee
Actual:      11a6283ea313b15c460c445c686c25e2fcd0bf392045d306a01bf5eed99c9d7b
```