### PR TITLE
grafana: Stable version, unify hash and download check

### DIFF
--- a/bucket/grafana.json
+++ b/bucket/grafana.json
@@ -1,27 +1,28 @@
 {
-    "version": "6.2.0",
+    "version": "6.1.6",
     "homepage": "https://grafana.com/",
     "description": "Open platform for analytics and data monitoring",
-    "extract_dir": "grafana-6.2.0",
+    "extract_dir": "grafana-6.1.6",
     "bin": "bin\\grafana-server.exe",
     "persist": [
         "conf",
         "data"
     ],
     "checkver": {
-        "github": "https://github.com/grafana/grafana"
+        "url": "https://grafana.com/grafana/download?platform=windows",
+        "re": "grafana-([\\d.]+)\\.windows"
     },
     "architecture": {
         "64bit": {
-            "url": "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-6.2.0.windows-amd64.zip",
-            "hash": "ce7ca2ade2be4a2ab852a49dbd0adffd18fb8ff6a10841e99c27628605cd81db"
+            "url": "https://dl.grafana.com/oss/release/grafana-6.1.6.windows-amd64.zip",
+            "hash": "178e6fb92dfb560fa4f2871bccb93a37283a35cc8ce40a3b6962ccb92e645f33"
         }
     },
     "autoupdate": {
         "extract_dir": "grafana-$version",
         "architecture": {
             "64bit": {
-                "url": "https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana-$version.windows-amd64.zip",
+                "url": "https://dl.grafana.com/oss/release/grafana-$version.windows-amd64.zip",
                 "hash": {
                     "url": "https://grafana.com/grafana/download/$version?platform=windows",
                     "find": "([A-Fa-f\\d]{64})"


### PR DESCRIPTION
- Return to stable version
- Hash, download, version now come from a single source (previously 3)

  - Current download link is broken because of the split-sources