### PR TITLE
Add wsl-ssh-pageant version 20190513.14

### DIFF
--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -3,49 +3,29 @@
     "description": "A Pageant -> TCP bridge for use with WSL, allowing for Pageant to be used as an ssh-ageant within the WSL environment.",
     "license": "BSD-2-Clause",
     "version": "20190513.14",
+    "bin": [
+        "wsl-ssh-pageant.exe",
+        "wsl-ssh-pageant-gui.exe"
+    ],
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
                 "84b926fd8737cb509bba9ff5c51a01838088dadaa9513addccb5a8ace4a7f7dc",
                 "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
-            ],
-            "bin": [
-                "wsl-ssh-pageant-amd64.exe",
-                "wsl-ssh-pageant-amd64-gui.exe",
-                [
-                    "wsl-ssh-pageant-amd64.exe",
-                    "wsl-ssh-pageant"
-                ],
-                [
-                    "wsl-ssh-pageant-amd64-gui.exe",
-                    "wsl-ssh-pageant-gui"
-                ]
             ]
         },
         "32bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
                 "85d923a911b9604ab457219318264c776969990cf9d49ce60882c83835a8591d",
                 "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
-            ],
-            "bin": [
-                "wsl-ssh-pageant-386.exe",
-                "wsl-ssh-pageant-386-gui.exe",
-                [
-                    "wsl-ssh-pageant-386.exe",
-                    "wsl-ssh-pageant"
-                ],
-                [
-                    "wsl-ssh-pageant-386-gui.exe",
-                    "wsl-ssh-pageant-gui"
-                ]
             ]
         }
     }

--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://github.com/benpye/wsl-ssh-pageant/",
+    "description": "A Pageant -> TCP bridge for use with WSL, allowing for Pageant to be used as an ssh-ageant within the WSL environment.",
+    "license": "BSD-2-Clause",
+    "version": "20190513.14",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe"
+            ],
+            "hash": [
+                "84b926fd8737cb509bba9ff5c51a01838088dadaa9513addccb5a8ace4a7f7dc",
+                "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
+            ],
+            "bin": [
+                [
+                    "wsl-ssh-pageant-amd64.exe",
+                    "wsl-ssh-pageant"
+                ],
+                [
+                    "wsl-ssh-pageant-amd64-gui.exe",
+                    "wsl-ssh-pageant-gui"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe"
+            ],
+            "hash": [
+                "85d923a911b9604ab457219318264c776969990cf9d49ce60882c83835a8591d",
+                "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
+            ],
+            "bin": [
+                [
+                    "wsl-ssh-pageant-386.exe",
+                    "wsl-ssh-pageant"
+                ],
+                [
+                    "wsl-ssh-pageant-386-gui.exe",
+                    "wsl-ssh-pageant-gui"
+                ]
+            ]
+        }
+    }
+}

--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -14,6 +14,8 @@
                 "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
             ],
             "bin": [
+                "wsl-ssh-pageant-amd64.exe",
+                "wsl-ssh-pageant-amd64-gui.exe",
                 [
                     "wsl-ssh-pageant-amd64.exe",
                     "wsl-ssh-pageant"
@@ -34,6 +36,8 @@
                 "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
             ],
             "bin": [
+                "wsl-ssh-pageant-386.exe",
+                "wsl-ssh-pageant-386-gui.exe",
                 [
                     "wsl-ssh-pageant-386.exe",
                     "wsl-ssh-pageant"


### PR DESCRIPTION
This adds a tool I have written - wsl-ssh-pageant - it is used for interfacing a Putty style ssh agent with either ssh under WSL or now the native OpenSSH on Windows.

It can be found at https://github.com/benpye/wsl-ssh-pageant - it's fairly popular with nearly 100 stars on Github.