### PR TITLE
msiafterburner: add vcredist2008 suggestion

### DIFF
--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -5,6 +5,9 @@
     "version": "4.6.0",
     "url": "http://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip#/MSIAfterburnerSetup460.7z",
     "hash": "d186cdf533727df267e0cb7cccfdb5673fbb8cb443ab009de023cae07345e31a",
+    "suggest": {
+        "Visual C++ Redist 2008": "extras/vcredist2008"
+    },
     "persist": [
         [
             "Profiles",


### PR DESCRIPTION
msi afterburner requires vcredist2008 otherwise it won't start, complaining about side-by-side configuration if started as admin and silently crashing if started as user