### PR TITLE
Add Shiba version 1.2.1

### DIFF
--- a/bucket/shiba.json
+++ b/bucket/shiba.json
@@ -38,7 +38,7 @@
                 "url": "https://github.com/rhysd/Shiba/releases/download/v$version/Shiba-win32-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/rhysd/Shiba/releases/download/$$version/Shiba-win32-ia32.zip"
+                "url": "https://github.com/rhysd/Shiba/releases/download/v$version/Shiba-win32-ia32.zip"
             }
         }
     }

--- a/bucket/shiba.json
+++ b/bucket/shiba.json
@@ -1,15 +1,13 @@
 {
-    "version": "1.2.1",
-    "description": "Rich markdown live preview app with linter",
     "homepage": "https://github.com/rhysd/Shiba",
+    "description": "Rich markdown live preview app with linter",
     "license": "MIT",
+    "version": "1.2.1",
     "architecture": {
         "64bit": {
             "url": "https://github.com/rhysd/Shiba/releases/download/v1.2.1/Shiba-win32-x64.zip",
             "hash": "ae2aa930ca25fb2e1be6df69ed8053f70d023bf3c35fac7103eb511606dc2327",
-            "bin": [
-                "Shiba-win32-x64\\Shiba.exe"
-            ],
+            "bin": "Shiba-win32-x64\\Shiba.exe",
             "shortcuts": [
                 [
                     "Shiba-win32-x64\\Shiba.exe",
@@ -20,9 +18,7 @@
         "32bit": {
             "url": "https://github.com/rhysd/Shiba/releases/download/v1.2.1/Shiba-win32-ia32.zip",
             "hash": "07f8f47f3ab5455bb0132d050e069cffcf0284698a981c5e4df192dd2fb2e1eb",
-            "bin": [
-                "Shiba-win32-ia32\\Shiba.exe"
-            ],
+            "bin": "Shiba-win32-ia32\\Shiba.exe",
             "shortcuts": [
                 [
                     "Shiba-win32-ia32\\Shiba.exe",

--- a/bucket/shiba.json
+++ b/bucket/shiba.json
@@ -1,0 +1,45 @@
+{
+    "version": "1.2.1",
+    "description": "Rich markdown live preview app with linter",
+    "homepage": "https://github.com/rhysd/Shiba",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rhysd/Shiba/releases/download/v1.2.1/Shiba-win32-x64.zip",
+            "hash": "ae2aa930ca25fb2e1be6df69ed8053f70d023bf3c35fac7103eb511606dc2327",
+            "bin": [
+                "Shiba-win32-x64\\Shiba.exe"
+            ],
+            "shortcuts": [
+                [
+                    "Shiba-win32-x64\\Shiba.exe",
+                    "Shiba"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/rhysd/Shiba/releases/download/v1.2.1/Shiba-win32-ia32.zip",
+            "hash": "07f8f47f3ab5455bb0132d050e069cffcf0284698a981c5e4df192dd2fb2e1eb",
+            "bin": [
+                "Shiba-win32-ia32\\Shiba.exe"
+            ],
+            "shortcuts": [
+                [
+                    "Shiba-win32-ia32\\Shiba.exe",
+                    "Shiba"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rhysd/Shiba/releases/download/v$version/Shiba-win32-x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/rhysd/Shiba/releases/download/$$version/Shiba-win32-ia32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added a markdown live preview app.

I did not use `extract_dir` because the working directory of the binary file Shiba.exe must be an actual directory instead of a symbolic link.