### PR TITLE
Add OpenOCD version 0.10.0

### DIFF
--- a/bucket/openocd.json
+++ b/bucket/openocd.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "http://openocd.org/",
+    "description": "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing",
+    "version": "0.10.0",
+    "license": "GPL-2.0-or-later",
+    "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-0.10.0#/openocd-0.10.0.7z",
+    "hash": "f46687cd783a7a86716c78474e8132e32de84b773914f23f2226f81509ffcfca",
+    "extract_dir": "openocd-0.10.0",
+    "architecture": {
+        "32bit": {
+            "bin": "bin/openocd.exe"
+        },
+        "64bit": {
+            "bin": "bin-x64/openocd.exe"
+        }
+    }
+}

--- a/bucket/openocd.json
+++ b/bucket/openocd.json
@@ -1,17 +1,29 @@
 {
-    "homepage": "http://openocd.org/",
-    "description": "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing",
     "version": "0.10.0",
+    "description": "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing.",
+    "homepage": "http://openocd.org/",
     "license": "GPL-2.0-or-later",
-    "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-0.10.0#/openocd-0.10.0.7z",
+    "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-0.10.0#/dl.7z",
     "hash": "f46687cd783a7a86716c78474e8132e32de84b773914f23f2226f81509ffcfca",
     "extract_dir": "openocd-0.10.0",
     "architecture": {
-        "32bit": {
-            "bin": "bin/openocd.exe"
-        },
         "64bit": {
-            "bin": "bin-x64/openocd.exe"
+            "bin": "bin-x64\\openocd.exe"
+        },
+        "32bit": {
+            "bin": "bin\\openocd.exe"
         }
+    },
+    "checkver": {
+        "url": "http://www.freddiechopin.info/en/download/category/4-openocd",
+        "regex": "OpenOCD\\s+([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://www.freddiechopin.info/en/download/category/4-openocd?download=154%3Aopenocd-$version#/dl.7z",
+        "hash": {
+            "url": "http://www.freddiechopin.info/en/download/category/4-openocd",
+            "regex": "$sha256"
+        },
+        "extract_dir": "openocd-$version"
     }
 }


### PR DESCRIPTION
OpenOCD is a tool used to program and debug a bunch of Microcontrollers using JTAG.