### PR TITLE
filezilla: persist fzdefaults.xml and improvments

### DIFF
--- a/bucket/filezilla.json
+++ b/bucket/filezilla.json
@@ -19,6 +19,9 @@
             "FileZilla"
         ]
     ],
+    "persist": [
+        "fzdefaults.xml"
+    ],
     "checkver": {
         "url": "https://filezilla-project.org/download.php?show_all=1",
         "re": "The latest stable version of FileZilla Client is ([\\d.]+)"

--- a/bucket/filezilla.json
+++ b/bucket/filezilla.json
@@ -1,6 +1,8 @@
 {
-    "homepage": "https://filezilla-project.org/",
     "version": "3.42.1",
+    "description": "Fast and reliable cross-platform FTP, FTPS and SFTP client with lots of useful features and an intuitive graphical user interface.",
+    "homepage": "https://filezilla-project.org/",
+    "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://download.filezilla-project.org/client/FileZilla_3.42.1_win64.zip",
@@ -12,6 +14,12 @@
         }
     },
     "extract_dir": "FileZilla-3.42.1",
+    "pre_install": [
+        "$file = 'fzdefaults.xml'",
+        "if (-not (Test-Path \"$persist_dir\\$file\")) {",
+        "    Copy-Item \"$dir\\docs\\fzdefaults.xml.example\" \"$dir\\fzdefaults.xml\"",
+        "}"
+    ],
     "bin": "filezilla.exe",
     "shortcuts": [
         [
@@ -19,15 +27,12 @@
             "FileZilla"
         ]
     ],
-    "persist": [
-        "fzdefaults.xml"
-    ],
+    "persist": "fzdefaults.xml",
     "checkver": {
         "url": "https://filezilla-project.org/download.php?show_all=1",
         "re": "The latest stable version of FileZilla Client is ([\\d.]+)"
     },
     "autoupdate": {
-        "extract_dir": "FileZilla-$version",
         "architecture": {
             "64bit": {
                 "url": "https://download.filezilla-project.org/client/FileZilla_$version_win64.zip"
@@ -37,7 +42,8 @@
             }
         },
         "hash": {
-            "url": "https://download.filezilla-project.org/client/FileZilla_$version.sha512"
-        }
+            "url": "$baseurl/FileZilla_$version.sha512"
+        },
+        "extract_dir": "FileZilla-$version"
     }
 }


### PR DESCRIPTION
Various settings can be configured in fzdefaults.xml, it would be convenient if this config file is persisted across version upgrades.