### PR TITLE
Add eMule and eMule-community.

### DIFF
--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://www.emule-project.net/",
+    "description": "One of the biggest and most reliable peer-to-peer file sharing clients around the world.",
+    "version": "0.51c",
+    "license": "GPLv2",
+    "url": "https://files.emule-project.net/eMule0.51c.zip",
+    "hash": "sha512:dd93edad816e17ee85ffda3f7bd228ea3e4f06e53402415dce4e6e8b934d2d7606d77ab40eed264e7713fc24ecf37c9f2904d49da402b39270bc2de380f903cc",
+    "extract_dir": "eMule0.51c",
+    "bin": "emule.exe",
+    "shortcuts": [
+        [
+            "emule.exe",
+            "eMule"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.emule-project.net",
+        "re": "Community: (\\d\\.\\d{2}[a-z])"
+    },
+    "autoupdate": {
+        "url": "https://files.emule-project.net/eMule$version.zip",
+        "extract_dir": "eMule$version"
+    }
+}

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.emule-project.net/",
     "description": "One of the biggest and most reliable peer-to-peer file sharing clients around the world.",
     "version": "0.51c",
-    "license": "GPLv2",
+    "license": "GPL-2.0-or-later",
     "url": "https://files.emule-project.net/eMule0.51c.zip",
     "hash": "sha512:dd93edad816e17ee85ffda3f7bd228ea3e4f06e53402415dce4e6e8b934d2d7606d77ab40eed264e7713fc24ecf37c9f2904d49da402b39270bc2de380f903cc",
     "extract_dir": "eMule0.51c",

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -13,10 +13,7 @@
             "eMule"
         ]
     ],
-    "checkver": "Community: ([\\w.]+)",
-        "url": "https://www.emule-project.net",
-        "re": "Community: (\\d\\.\\d{2}[a-z])"
-    },
+    "checkver": "Community:\\s+([\\w.]+)",
     "autoupdate": {
         "url": "https://files.emule-project.net/eMule$version.zip",
         "extract_dir": "eMule$version"

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -13,7 +13,7 @@
             "eMule"
         ]
     ],
-    "checkver": {
+    "checkver": "Community: ([\\w.]+)",
         "url": "https://www.emule-project.net",
         "re": "Community: (\\d\\.\\d{2}[a-z])"
     },

--- a/bucket/emule-community.json
+++ b/bucket/emule-community.json
@@ -4,7 +4,7 @@
     "version": "0.51c",
     "license": "GPL-2.0-or-later",
     "url": "https://files.emule-project.net/eMule0.51c.zip",
-    "hash": "sha512:dd93edad816e17ee85ffda3f7bd228ea3e4f06e53402415dce4e6e8b934d2d7606d77ab40eed264e7713fc24ecf37c9f2904d49da402b39270bc2de380f903cc",
+    "hash": "601affcde7ce890c217d3779bfda89e49653389f61bf9919e2e332ef8796495e",
     "extract_dir": "eMule0.51c",
     "bin": "emule.exe",
     "shortcuts": [

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -13,7 +13,7 @@
             "eMule"
         ]
     ],
-    "checkver": {
+    "checkver": "([\\w.]+)\\s+|",
         "url": "https://www.emule-project.net",
         "re": "(\\d\\.\\d{2}[a-z]) | Community"
     },

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -3,8 +3,8 @@
     "description": "One of the biggest and most reliable peer-to-peer file sharing clients around the world.",
     "version": "0.50a",
     "license": "GPL-2.0-or-later",
-    "url": "http://prdownloads.sourceforge.net/emule/eMule0.50a.zip",
-    "hash": "sha512:7ca6f5a4d0474fa4ca9d40ed9c9a9f79e0c2f90f0fde5ce2ebcc3c108919179ea4252891dc324f011fae57a5bc5a323bb17e218f1b150be4ca30826244a5a890",
+    "url": "https://downloads.sourceforge.net/project/emule/eMule/0.50a/eMule0.50a.zip",
+    "hash": "sha1:8403ff232b1a9d8a7a9ed45045f5061776919c73",
     "extract_dir": "eMule0.50a",
     "bin": "emule.exe",
     "shortcuts": [
@@ -13,8 +13,7 @@
             "eMule"
         ]
     ],
-    "checkver": "([\\w.]+)\\s+\\|"
-    ,
+    "checkver": "([\\w.]+)\\s+\\|",
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/emule/eMule/$version/eMule$version.zip",
         "extract_dir": "eMule$version"

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.emule-project.net/",
     "description": "One of the biggest and most reliable peer-to-peer file sharing clients around the world.",
     "version": "0.50a",
-    "license": "GPLv2",
+    "license": "GPL-2.0-or-later",
     "url": "http://prdownloads.sourceforge.net/emule/eMule0.50a.zip",
     "hash": "sha512:7ca6f5a4d0474fa4ca9d40ed9c9a9f79e0c2f90f0fde5ce2ebcc3c108919179ea4252891dc324f011fae57a5bc5a323bb17e218f1b150be4ca30826244a5a890",
     "extract_dir": "eMule0.50a",

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -13,10 +13,8 @@
             "eMule"
         ]
     ],
-    "checkver": "([\\w.]+)\\s+|",
-        "url": "https://www.emule-project.net",
-        "re": "(\\d\\.\\d{2}[a-z]) | Community"
-    },
+    "checkver": "([\\w.]+)\\s+\\|"
+    ,
     "autoupdate": {
         "url": "https://downloads.sourceforge.net/project/emule/eMule/$version/eMule$version.zip",
         "extract_dir": "eMule$version"

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://www.emule-project.net/",
+    "description": "One of the biggest and most reliable peer-to-peer file sharing clients around the world.",
+    "version": "0.50a",
+    "license": "GPLv2",
+    "url": "http://prdownloads.sourceforge.net/emule/eMule0.50a.zip",
+    "hash": "sha512:7ca6f5a4d0474fa4ca9d40ed9c9a9f79e0c2f90f0fde5ce2ebcc3c108919179ea4252891dc324f011fae57a5bc5a323bb17e218f1b150be4ca30826244a5a890",
+    "extract_dir": "eMule0.50a",
+    "bin": "emule.exe",
+    "shortcuts": [
+        [
+            "emule.exe",
+            "eMule"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.emule-project.net",
+        "re": "(\\d\\.\\d{2}[a-z]) | Community"
+    },
+    "autoupdate": {
+        "url": "http://prdownloads.sourceforge.net/emule/eMule$version.zip",
+        "extract_dir": "eMule$version"
+    }
+}

--- a/bucket/emule.json
+++ b/bucket/emule.json
@@ -18,7 +18,7 @@
         "re": "(\\d\\.\\d{2}[a-z]) | Community"
     },
     "autoupdate": {
-        "url": "http://prdownloads.sourceforge.net/emule/eMule$version.zip",
+        "url": "https://downloads.sourceforge.net/project/emule/eMule/$version/eMule$version.zip",
         "extract_dir": "eMule$version"
     }
 }


### PR DESCRIPTION
As eMule hasn't updated for years, I add not only eMule but also eMule-community which is a more up-to-date version.
The [eMule download page](https://www.emule-project.net/home/perl/general.cgi?l=42&rm=download) tells that "All community releases and source code are available on [GitHub](https://github.com/irwir/eMule/releases/)". But there is a newer version 0.51d on [GitHub](https://github.com/irwir/eMule/releases/) than the lastest version 0.51c on [eMule download page](https://www.emule-project.net/home/perl/general.cgi?l=42&rm=download) and hence I am not sure is it OK to download from [GitHub](https://github.com/irwir/eMule/releases/).