### PR TITLE
Add Process Explorer.

### DIFF
--- a/bucket/processexplorer.json
+++ b/bucket/processexplorer.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer",
+    "description": "Process Explorer is a freeware task manager and system monitor for Microsoft Windows created by SysInternals, which has been acquired by Microsoft and re-branded as Windows Sysinternals.",
+    "license": "EULA",
+    "version": "16.22",
+    "url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
+    "extract_dir": ".\\",
+    "hash": "d393f062091c4fcf720ce0cad56520a920ffcc9412cdc7941150e3bb3fc4fefa",
+    "bin": [
+        "procexp.exe",
+        "procexp64.exe"
+    ],
+    "shortcuts": {
+        "32bit": [
+            "procexp.exe",
+            "ProcessExplorer"
+        ],
+        "64bit": [
+            "procexp64.exe",
+            "ProcessExplorer"
+        ]
+    },
+    "checkver": "Process\\s+Explorer\\s+v([\\d.]+)",
+    "autoupdate": {
+        "url": "https://download.sysinternals.com/files/ProcessExplorer.zip",
+        "extract_dir": ".\\"
+    }
+}


### PR DESCRIPTION
Although scoop tell me Process Explorer was installed successfully, Short cut is not added. and there are many errors during scoop installing Process Explorer. Could you please kindly help me to find the reasons?