### PR TITLE
Add Streamlink Twitch GUI

### DIFF
--- a/bucket/streamlink-twitch-gui.json
+++ b/bucket/streamlink-twitch-gui.json
@@ -25,7 +25,9 @@
             "Streamlink Twitch GUI"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/streamlink/streamlink-twitch-gui"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/streamlink-twitch-gui.json
+++ b/bucket/streamlink-twitch-gui.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://github.com/streamlink/streamlink-twitch-gui",
+    "homepage": "https://streamlink.github.io/streamlink-twitch-gui/",
     "description": "A multi platform Twitch.tv browser for Streamlink",
     "license": "MIT",
     "version": "1.7.1",

--- a/bucket/streamlink-twitch-gui.json
+++ b/bucket/streamlink-twitch-gui.json
@@ -36,7 +36,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v$version/streamlink-twitch-gui-v$version-checksums.txt",
+            "url": "$baseurl/streamlink-twitch-gui-v$version-checksums.txt",
             "regex": "$sha256\\s+$basename"
         }
     }

--- a/bucket/streamlink-twitch-gui.json
+++ b/bucket/streamlink-twitch-gui.json
@@ -1,0 +1,42 @@
+{
+    "homepage": "https://github.com/streamlink/streamlink-twitch-gui",
+    "description": "A multi platform Twitch.tv browser for Streamlink",
+    "license": "MIT",
+    "version": "1.7.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v1.7.1/streamlink-twitch-gui-v1.7.1-win64.zip",
+            "hash": "bba43dab03937106d12a9d7d929b3f7871a9135caf850120cb5c071abf547bee"
+        },
+        "32bit": {
+            "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v1.7.1/streamlink-twitch-gui-v1.7.1-win32.zip",
+            "hash": "d2e509ecb93b20b324c178cfabd0c60da3879c08b4a07089b89e9d3fa4986a76"
+        }
+    },
+    "extract_dir": "streamlink-twitch-gui",
+    "bin": "streamlink-twitch-gui.exe",
+    "suggest": {
+        "streamlink": "extras/streamlink"
+    },
+    "shortcuts": [
+        [
+            "streamlink-twitch-gui.exe",
+            "Streamlink Twitch GUI"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v$version/streamlink-twitch-gui-v$version-win64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v$version/streamlink-twitch-gui-v$version-win32.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/streamlink/streamlink-twitch-gui/releases/download/v$version/streamlink-twitch-gui-v$version-checksums.txt",
+            "regex": "$sha256\\s+$basename"
+        }
+    }
+}

--- a/bucket/streamlink-twitch-gui.json
+++ b/bucket/streamlink-twitch-gui.json
@@ -16,7 +16,8 @@
     "extract_dir": "streamlink-twitch-gui",
     "bin": "streamlink-twitch-gui.exe",
     "suggest": {
-        "streamlink": "extras/streamlink"
+        "streamlink": "extras/streamlink",
+        "VLC": "extras/vlc"
     },
     "shortcuts": [
         [

--- a/bucket/streamlink.json
+++ b/bucket/streamlink.json
@@ -5,7 +5,10 @@
     "url": "https://github.com/streamlink/streamlink/releases/download/1.1.1/streamlink-1.1.1.exe#/dl.7z",
     "hash": "7de2e885f0c273b92bf6dfeef88ba5cdd9aad2242a6c85223b2d885af1c1ccef",
     "notes": "Streamlink settings can be changed in '%APPDATA%\\streamlink\\streamlinkrc'",
-    "bin": "bin\\streamlink.exe",
+    "bin": [
+        "bin\\streamlink.exe",
+        "bin\\streamlinkw.exe"
+    ],
     "post_install": [
         "If(!(Test-Path \"$env:APPDATA\\streamlink\\streamlinkrc\")) {",
         "    Write-Host \"Copying default 'streamlinkrc' to '%APPDATA%\\streamlink\\streamlinkrc'\"",
@@ -18,10 +21,13 @@
     ],
     "pre_install": [
         "\"#!`\"$dir\\Python\\python.exe`\"\" | Set-Content \"$dir\\bin\\python.txt\"",
+        "\"#!`\"$dir\\Python\\pythonw.exe`\"\" | Set-Content \"$dir\\bin\\pythonw.txt\"",
         "if((Get-Command Get-Content).parameters.ContainsKey('AsByteStream')) {",
         "   Get-Content -AsByteStream \"$dir\\bin\\launcher_exe.dat\",\"$dir\\bin\\python.txt\",\"$dir\\bin\\streamlink-append.zip\" | Set-Content -AsByteStream \"$dir\\bin\\streamlink.exe\"",
+        "   Get-Content -AsByteStream \"$dir\\bin\\launcher_noconsole_exe.dat\",\"$dir\\bin\\pythonw.txt\",\"$dir\\bin\\streamlinkw-append-noconsole.zip\" | Set-Content -AsByteStream \"$dir\\bin\\streamlinkw.exe\"",
         "} else {",
         "   Get-Content -Encoding byte \"$dir\\bin\\launcher_exe.dat\",\"$dir\\bin\\python.txt\",\"$dir\\bin\\streamlink-append.zip\" | Set-Content -Encoding byte \"$dir\\bin\\streamlink.exe\"",
+        "   Get-Content -Encoding byte \"$dir\\bin\\launcher_noconsole_exe.dat\",\"$dir\\bin\\pythonw.txt\",\"$dir\\bin\\streamlinkw-append-noconsole.zip\" | Set-Content -Encoding byte \"$dir\\bin\\streamlinkw.exe\"",
         "}"
     ],
     "suggest": {


### PR DESCRIPTION
fix #1972

A new terminal window will get opened when Streamlink Twitch GUI calls (scoop-managed) VLC player by shim.

It could be avoided with setting `player` to the real executable.