### PR TITLE
Flutter: Fix env_add_path

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -16,7 +16,7 @@
         "java/adopt8-hotspot"
     ],
     "description": "Flutter is Google’s mobile app SDK for crafting high-quality native interfaces on iOS and Android in record time. This is the beta version, since Flutter wasn't officially 'released' yet.",
-    "env_add_path": "bin\\cache\\dart-sdk",
+    "env_add_path": "bin\\cache\\dart-sdk\\bin",
     "bin": [
         "bin\\flutter.bat",
         "flutter-dev-setup.ps1"


### PR DESCRIPTION
The Dart binaries are not in "bin\\cache\\dart-sdk", they are in "bin\\cache\\dart-sdk\\bin"