### PR TITLE
Fix MuseScore download links

### DIFF
--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -30,19 +30,19 @@
     ],
     "checkver": {
         "url": "https://sparkle.musescore.org/stable/3/win/appcast.xml",
-        "regex": "sparkle:version=\"([\\d.]+)\""
+        "regex": "download/v(?<short>[\\d.]+)/[^\"]+\"\\s+sparkle:version=\"(?<version>[\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchHead/MuseScore-$matchHead-x86_64.msi",
+                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchShort/MuseScore-$matchHead-x86_64.msi",
                 "hash": {
                     "url": "https://musescore.org/en/download/musescore.msi",
                     "find": ">SHA256 Checksum: ([0-9a-fA-F]{64})</"
                 }
             },
             "32bit": {
-                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchHead/MuseScore-$matchHead-x86.msi",
+                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchShort/MuseScore-$matchHead-x86.msi",
                 "hash": {
                     "url": "https://musescore.org/en/download/musescore-32bit.msi",
                     "find": ">SHA256 Checksum: ([0-9a-fA-F]{64})</"

--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.1.0/MuseScore-3.1.0-x86_64.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.1/MuseScore-3.1.0-x86_64.msi",
             "hash": "69f253b5e7d66731ec33f4b6cdc22afc730f863580e61a735cad60a16d8159a7"
         },
         "32bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.1.0/MuseScore-3.1.0-x86.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.1/MuseScore-3.1.0-x86.msi",
             "hash": "180ac4ebca95106fa7ab01d076fe5bcac3b43edb44611ac17465c688e3b6c968"
         }
     },


### PR DESCRIPTION
Currently published MuseScore manifest has invalid download links (for both 32bit and 64bit images). This prevents latest MuseScore from being installed:

![Installation](https://user-images.githubusercontent.com/42297/58841878-0f4d0e00-8629-11e9-8271-10475a62f1a5.png)

It looks like the [MuseScore 3.1 release assets](https://github.com/musescore/MuseScore/releases/tag/v3.1) didn't follow the expected pattern defined in `musescore.json/autoupdate`. This PR manually fixes the links.