### PR TITLE
grafana: Fix download hash

### DIFF
--- a/bucket/grafana.json
+++ b/bucket/grafana.json
@@ -15,7 +15,7 @@
     "architecture": {
         "64bit": {
             "url": "https://dl.grafana.com/oss/release/grafana-6.2.1.windows-amd64.zip",
-            "hash": "f1dd1e2cc9b5bb1d199f1b0b113aec33fa3ca6fad5b5c48173b875c4fbdc41f9"
+            "hash": "19aba43ed8f11c7351d87d7a5fbf41b4e00db915cf3d8e70be8b06fd6bb187e2"
         }
     },
     "autoupdate": {


### PR DESCRIPTION
Hi, 
the hash you provided is for the .msi installer but the standalone binaries are downloaded.
See [https://grafana.com/grafana/download?platform=windows](https://grafana.com/grafana/download?platform=windows)