### PR TITLE
Update VSCodium binary name

### DIFF
--- a/bucket/vscodium-portable.json
+++ b/bucket/vscodium-portable.json
@@ -30,7 +30,7 @@
         }
     },
     "notes": "Add VSCodium Portable as a context menu option by running: \"$dir\\vscodium-install-context.reg\"",
-    "bin": "bin\\vscodium.cmd",
+    "bin": "bin\\codium.cmd",
     "shortcuts": [
         [
             "VSCodium.exe",

--- a/bucket/vscodium.json
+++ b/bucket/vscodium.json
@@ -30,7 +30,7 @@
         }
     },
     "notes": "Add VSCodium as a context menu option by running: \"$dir\\vscodium-install-context.reg\"",
-    "bin": "bin\\vscodium.cmd",
+    "bin": "bin\\codium.cmd",
     "shortcuts": [
         [
             "VSCodium.exe",


### PR DESCRIPTION
The binary name of VSCodium has [changed](https://github.com/VSCodium/vscodium/pull/176).

Also, the hash check failed.