### PR TITLE
vcredist: Update 2019 to 14.21.27702.2 and modify installer args

### DIFF
--- a/bucket/vcredist.json
+++ b/bucket/vcredist.json
@@ -1,19 +1,19 @@
 {
     "homepage": "https://www.visualstudio.com/downloads/",
-    "version": "14.20.27508.1",
+    "version": "14.21.27702.2",
     "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/21614507-28c5-47e3-973f-85e7f66545a4/f3a2caa13afd59dd0e57ea374dbe8855/vc_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/092cda8f-872f-47fd-b549-54bbb8a81877/ddc5ec3f90091ca690a67d0d697f1242/vc_redist.x86.exe"
+        "https://download.visualstudio.microsoft.com/download/pr/9e04d214-5a9d-4515-9960-3d71398d98c3/1e1e62ab57bbb4bf5199e8ce88f040be/vc_redist.x64.exe",
+        "https://download.visualstudio.microsoft.com/download/pr/c8edbb87-c7ec-4500-a461-71e8912d25e9/99ba493d660597490cbb8b3211d2cae4/vc_redist.x86.exe"
     ],
     "hash": [
-        "14b07d8f4108a8b8b306af3f6fe6eb78814dfadebd500416fb24856ad668518e",
-        "261f8122ce3e3da66fe4300e2a88325469251da85b62fbddb03ec49f97b62c14"
+        "d6cd2445f68815fe02489fafe0127819e44851e26dfbe702612bc0d223cbbc2b",
+        "3a43e8a55a3f3e4b73d01872c16d47a19dd825756784f4580187309e7d1fcb74"
     ],
     "post_install": [
-        "run \"$dir/vc_redist.x64.exe\" \"/install /passive /norestart\" | Out-Null",
-        "run \"$dir/vc_redist.x86.exe\" \"/install /passive /norestart\" | Out-Null"
+        "run \"$dir/vc_redist.x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vc_redist.x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
-    "notes": "You can now remove all vcredist installers with 'scoop uninstall vcredist vcredist2008 vcredist2010 vcredist2012 vcredist2013 vcredist2019'",
+    "notes": "You can now remove all vcredist installers with 'scoop uninstall vcredist vcredist2008 vcredist2010 vcredist2012 vcredist2013'",
     "depends": [
         "vcredist2008",
         "vcredist2010",

--- a/bucket/vcredist2008.json
+++ b/bucket/vcredist2008.json
@@ -10,8 +10,8 @@
         "6b3e4c51c6c0e5f68c8a72b497445af3dbf976394cbb62aa23569065c28deeb6"
     ],
     "post_install": [
-        "run \"$dir/vcredist_x64.exe\" \"/qb\" | Out-Null",
-        "run \"$dir/vcredist_x86.exe\" \"/qb\" | Out-Null"
+        "run \"$dir/vcredist_x64.exe\" \"/fo /qn /norestart\" | Out-Null",
+        "run \"$dir/vcredist_x86.exe\" \"/fo /qn /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2008'"
 }

--- a/bucket/vcredist2010.json
+++ b/bucket/vcredist2010.json
@@ -10,8 +10,8 @@
         "67313b3d1bc86e83091e8de22981f14968f1a7fb12eb7ad467754c40cd94cc3d"
     ],
     "post_install": [
-        "run \"$dir/vcredist_x64.exe\" \"/passive /norestart\" | Out-Null",
-        "run \"$dir/vcredist_x86.exe\" \"/passive /norestart\" | Out-Null"
+        "run \"$dir/vcredist_x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vcredist_x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2010'"
 }

--- a/bucket/vcredist2012.json
+++ b/bucket/vcredist2012.json
@@ -10,8 +10,8 @@
         "b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386"
     ],
     "post_install": [
-        "run \"$dir/vcredist_x64.exe\" \"/passive /norestart\" | Out-Null",
-        "run \"$dir/vcredist_x86.exe\" \"/passive /norestart\" | Out-Null"
+        "run \"$dir/vcredist_x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vcredist_x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2012'"
 }

--- a/bucket/vcredist2013.json
+++ b/bucket/vcredist2013.json
@@ -10,8 +10,8 @@
         "89f4e593ea5541d1c53f983923124f9fd061a1c0c967339109e375c661573c17"
     ],
     "post_install": [
-        "run \"$dir/vcredist_x64.exe\" \"/install /passive /norestart\" | Out-Null",
-        "run \"$dir/vcredist_x86.exe\" \"/install /passive /norestart\" | Out-Null"
+        "run \"$dir/vcredist_x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vcredist_x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2013'"
 }

--- a/bucket/vcredist2015.json
+++ b/bucket/vcredist2015.json
@@ -10,8 +10,8 @@
         "12a69af8623d70026690ba14139bf3793cc76c865759cad301b207c1793063ed"
     ],
     "post_install": [
-        "run \"$dir/vc_redist.x64.exe\" \"/install /passive /norestart\" | Out-Null",
-        "run \"$dir/vc_redist.x86.exe\" \"/install /passive /norestart\" | Out-Null"
+        "run \"$dir/vc_redist.x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vc_redist.x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2015'"
 }

--- a/bucket/vcredist2017.json
+++ b/bucket/vcredist2017.json
@@ -10,8 +10,8 @@
         "7355962b95d6a5441c304cd2b86baf37bc206f63349f4a02289bcfb69ef142d3"
     ],
     "post_install": [
-        "run \"$dir/vc_redist.x64.exe\" \"/install /passive /norestart\" | Out-Null",
-        "run \"$dir/vc_redist.x86.exe\" \"/install /passive /norestart\" | Out-Null"
+        "run \"$dir/vc_redist.x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vc_redist.x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2017'"
 }

--- a/bucket/vcredist2019.json
+++ b/bucket/vcredist2019.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://www.visualstudio.com/downloads/",
-    "version": "14.20.27508.1",
+    "version": "14.21.27702.2",
     "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/21614507-28c5-47e3-973f-85e7f66545a4/f3a2caa13afd59dd0e57ea374dbe8855/vc_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/092cda8f-872f-47fd-b549-54bbb8a81877/ddc5ec3f90091ca690a67d0d697f1242/vc_redist.x86.exe"
+        "https://download.visualstudio.microsoft.com/download/pr/9e04d214-5a9d-4515-9960-3d71398d98c3/1e1e62ab57bbb4bf5199e8ce88f040be/vc_redist.x64.exe",
+        "https://download.visualstudio.microsoft.com/download/pr/c8edbb87-c7ec-4500-a461-71e8912d25e9/99ba493d660597490cbb8b3211d2cae4/vc_redist.x86.exe"
     ],
     "hash": [
-        "14b07d8f4108a8b8b306af3f6fe6eb78814dfadebd500416fb24856ad668518e",
-        "261f8122ce3e3da66fe4300e2a88325469251da85b62fbddb03ec49f97b62c14"
+        "d6cd2445f68815fe02489fafe0127819e44851e26dfbe702612bc0d223cbbc2b",
+        "3a43e8a55a3f3e4b73d01872c16d47a19dd825756784f4580187309e7d1fcb74"
     ],
     "post_install": [
-        "run \"$dir/vc_redist.x64.exe\" \"/install /passive /norestart\" | Out-Null",
-        "run \"$dir/vc_redist.x86.exe\" \"/install /passive /norestart\" | Out-Null"
+        "run \"$dir/vc_redist.x64.exe\" \"/fo /quiet /norestart\" | Out-Null",
+        "run \"$dir/vc_redist.x86.exe\" \"/fo /quiet /norestart\" | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall vcredist2019'"
 }


### PR DESCRIPTION
Fix #2261 

Use repair instead of install, i.e., do nothing while same version of vcredist is installed.