### PR TITLE
SoapUI: persist bin/ext

### DIFF
--- a/bucket/soapui.json
+++ b/bucket/soapui.json
@@ -30,6 +30,7 @@
     },
     "extract_dir": "SoapUI-5.5.0",
     "bin": "bin/soapui.bat",
+    "persist": "bin/ext",
     "shortcuts": [
         [
             "bin/soapui.bat",


### PR DESCRIPTION
This directory can be used by users to drop jars that will be added to the classpath at runtime (like JDBC drivers). Persisting this folder makes it possible to not lose these additional jars when new versions of SoapUI are installed.