### PR TITLE
chrome: Update to 75.0.3770.90 (manually)

### DIFF
--- a/bucket/chrome.json
+++ b/bucket/chrome.json
@@ -1,16 +1,16 @@
 {
-    "version": "74.0.3729.131",
+    "version": "75.0.3770.90",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://redirector.gvt1.com/edgedl/release2/chrome/VgjlGsaFfgA_74.0.3729.131/74.0.3729.131_chrome_installer.exe#/cosi.7z",
-            "hash": "aafc8b370770ed51e2ede16731e303347ee7184376c54d09d2d1fb44a95627a1"
+            "url": "https://redirector.gvt1.com/edgedl/release2/chrome/XAlboe3DWkM_75.0.3770.90/75.0.3770.90_chrome_installer.exe#/cosi.7z",
+            "hash": "b578b4e4e186505d5d3e156857bbdf72b19c01baf50651a5c33544d75ba36824"
         },
         "32bit": {
-            "url": "https://redirector.gvt1.com/edgedl/release2/chrome/AN8PReQd-R9n_74.0.3729.131/74.0.3729.131_chrome_installer.exe#/cosi.7z",
-            "hash": "8e2b910de0047a488266e0521339c1aa25e0dc6c950a184893efe269b18d9588"
+            "url": "https://redirector.gvt1.com/edgedl/release2/chrome/AN_q_RfOOOCt_75.0.3770.90/75.0.3770.90_chrome_installer.exe#/cosi.7z",
+            "hash": "c3dfe179f2ec20266ceb8af98ebbb19c884952062eea0a913821a48c645642dd"
         }
     },
     "installer": {


### PR DESCRIPTION
The [excavator](https://scoop.r15.ch/extras/mud-20190617-210001.log) continues to fail with:
````
Downloading 75.0.3770.90_chrome_installer.exe to compute hashes!
The SSL connection could not be established, see inner exception. Authentication failed, see inner exception.
URL https://redirector.gvt1.com/edgedl/release2/chrome/AN_q_RfOOOCt_75.0.3770.90/75.0.3770.90_chrome_installer.exe#/cosi.7z is not valid
Could not find hash!
ERROR Could not update chrome 32bit