### PR TITLE
Move jetbrains-toolbox from Main

### DIFF
--- a/bucket/jetbrains-toolbox.json
+++ b/bucket/jetbrains-toolbox.json
@@ -1,0 +1,43 @@
+{
+    "version": "1.15.5387",
+    "description": "Toolbox App. A control panel for all JetBrains tools.",
+    "homepage": "https://www.jetbrains.com/toolbox/",
+    "license": "Freeware",
+    "notes": [
+        "By default all your tools are installed into '$dir\\apps' folder and are persisted.",
+        "This could be changed inside settings menu."
+    ],
+    "url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-1.15.5387.exe#/cosi.7z",
+    "hash": "05f5b98eb2e52cddb3f3e4bacada979bb542a4a93f67830dea26e4a76e50c740",
+    "post_install": [
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe\" -Recurse",
+        "$config = \"$env:LOCALAPPDATA\\JetBrains\\Toolbox\\.settings.json\"",
+        "if (-not (Test-Path $config)) {",
+        "    $settings = @{",
+        "        'autostart' = $false",
+        "        'install_location' = \"$dir\"",
+        "        'update' = @{'install_automatically' = $false}",
+        "    }",
+        "    New-Item $config -Type File -Force | Out-Null",
+        "    Set-Content $config ($settings | ConvertToPrettyJson) -Encoding ASCII -Force",
+        "}"
+    ],
+    "bin": "jetbrains-toolbox.exe",
+    "shortcuts": [
+        [
+            "jetbrains-toolbox.exe",
+            "JetBrains Toolbox"
+        ]
+    ],
+    "persist": "apps",
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release",
+        "jsonpath": "$.TBA..build"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-$version.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
- Add description
- Use jsonpath for checkver
- Do not install. Extraction is enough
- Create default configuration file if there is none.
    - Old implementation was completely nonsense
    - It was basically adding install_location all the time even when that file exists.
         - So it override user setting
			- This is unacceptable since it break if user change this location in GUI
