### PR TITLE
uniextract2: Add version 2.0.0-rc.2

### DIFF
--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://github.com/Bioruebe/UniExtract2/releases",
-        "regex": "\\/Bioruebe\\/UniExtract2\\/releases\\/download\\/v(?<version>[\\w.-]+)\\/(?<filename>\\w+\\.zip)"
+        "regex": "download/v([\\w.-]+)/(?<filename>\\w+\\.zip)"
     },
     "autoupdate": {
         "url": "https://github.com/Bioruebe/UniExtract2/releases/download/v$version/$matchFilename"

--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0.0-rc.2",
+    "description": "A program designed to decompress and extract files from any type of archive or installer.",
+    "homepage": "https://github.com/Bioruebe/UniExtract2",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/Bioruebe/UniExtract2/releases/download/v2.0.0-rc.2/UniExtractRC2.zip",
+    "hash": "4ad412f2df056eb5cdf60078550d47c10fbbb67188aa915752d2757d95f1393b",
+    "extract_dir": "UniExtract",
+    "bin": "UniExtract.exe",
+    "persist": [
+        "log",
+        "UniExtract.ini"
+    ],
+    "shortcuts": [
+        [
+            "UniExtract.exe",
+            "Universal Extractor"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/Bioruebe/UniExtract2/releases",
+        "regex": "\\/Bioruebe\\/UniExtract2\\/releases\\/download\\/v(?<version>[\\w.-]+)\\/(?<filename>\\w+\\.zip)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Bioruebe/UniExtract2/releases/download/v$version/$matchFilename"
+    }
+}

--- a/bucket/uniextract2.json
+++ b/bucket/uniextract2.json
@@ -1,6 +1,6 @@
 {
     "version": "2.0.0-rc.2",
-    "description": "A program designed to decompress and extract files from any type of archive or installer.",
+    "description": "Decompress and extract files from any type of archive or installer.",
     "homepage": "https://github.com/Bioruebe/UniExtract2",
     "license": "GPL-2.0-or-later",
     "url": "https://github.com/Bioruebe/UniExtract2/releases/download/v2.0.0-rc.2/UniExtractRC2.zip",


### PR DESCRIPTION
Official homepage for UniExtract2: https://github.com/Bioruebe/UniExtract2
Please let me know if there are any problems. Thanks.