### PR TITLE
fsviewer: Update to 7.2 (manually)

### DIFF
--- a/bucket/fsviewer.json
+++ b/bucket/fsviewer.json
@@ -1,9 +1,9 @@
 {
-    "homepage": "http://www.faststone.org/FSViewerDetail.htm",
-    "version": "7.0",
-    "url": "http://www.faststonesoft.net/DN/FSViewer70.zip",
-    "hash": "e70f7fd9d89c89f95d82fd31ebb45e3f5239877ce28e51ee55a5d7043549e3c9",
-    "extract_dir": "FSViewer70",
+    "homepage": "https://www.faststone.org/FSViewerDetail.htm",
+    "version": "7.2",
+    "url": "http://www.faststonesoft.net/DN/FSViewer72.zip",
+    "hash": "82394097654ebac33b36622badb5e58914e5dcd1ca5aeafc1d2abb205e12b8f1",
+    "extract_dir": "FSViewer72",
     "bin": "FSViewer.exe",
     "shortcuts": [
         [
@@ -20,7 +20,8 @@
         "if(!(Test-Path \"$persist_dir\\HisFolderList.db\")) {New-Item (\"$persist_dir\\HisFolderList.db\") -Type File | Out-Null}"
     ],
     "checkver": {
-        "re": "Version ([\\d.]+)"
+        "url": "https://www.faststone.org/FSIVDownload.htm",
+        "re": "FastStone Image Viewer ([\\d.]+)"
     },
     "autoupdate": {
         "url": "http://www.faststonesoft.net/DN/FSViewer$cleanVersion.zip",

--- a/bucket/fsviewer.json
+++ b/bucket/fsviewer.json
@@ -1,5 +1,6 @@
 {
     "homepage": "https://www.faststone.org/FSViewerDetail.htm",
+    "description": "Fast, stable, user-friendly image browser, converter and editor",
     "version": "7.2",
     "url": "http://www.faststonesoft.net/DN/FSViewer72.zip",
     "hash": "82394097654ebac33b36622badb5e58914e5dcd1ca5aeafc1d2abb205e12b8f1",
@@ -16,8 +17,13 @@
         "HisFolderList.db"
     ],
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\FSSettings.db\")) {New-Item (\"$persist_dir\\FSSettings.db\") -Type File | Out-Null}",
-        "if(!(Test-Path \"$persist_dir\\HisFolderList.db\")) {New-Item (\"$persist_dir\\HisFolderList.db\") -Type File | Out-Null}"
+        "function ensureFile([String] $name) {",
+        "    if (!(Test-Path \"$persist_dir\\$name\") -and !(Test-Path \"$dir\\$name\")) {",
+        "        Add-Content -Path \"$dir\\$name\" -Value $null",
+        "    }",
+        "}",
+        "ensureFile 'FSSettings.db'",
+        "ensureFile 'HisFolderList.db'"
     ],
     "checkver": {
         "url": "https://www.faststone.org/FSIVDownload.htm",


### PR DESCRIPTION
The excavator log has been showing:
```
fsviewer: The operation has timed out.
URL http://www.faststone.org/FSViewerDetail.htm is not valid
```
for days
