### PR TITLE
fiddler: Extract instead of installation

### DIFF
--- a/bucket/fiddler.json
+++ b/bucket/fiddler.json
@@ -1,26 +1,27 @@
 {
-    "license": "Freeware",
-    "homepage": "https://www.telerik.com/fiddler",
-    "description": "The free web debugging proxy for any browser, system or platform",
     "version": "5.0.20192.25091",
-    "url": "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe",
+    "description": "The free web debugging proxy for any browser, system or platform.",
+    "homepage": "https://www.telerik.com/fiddler",
+    "license": "Freeware",
+    "url": "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe#/dl.7z",
     "hash": "4dff6cb1b88a503d3982c7ccbcd5622496eba4c21aab5a2c0c0f1e376a2eb809",
     "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
+        "script": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\FiddlerSetup.exe\" \"$dir\" -Removal"
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
+    "bin": "Fiddler.exe",
+    "shortcuts": [
+        [
+            "Fiddler.exe",
+            "Fiddler"
         ]
-    },
-    "uninstaller": {
-        "file": "uninst.exe",
-        "args": "/S"
-    },
+    ],
     "checkver": {
         "url": "https://www.fiddler2.com/UpdateCheck.aspx?isBeta=False",
         "useragent": "Fiddler/$version",
-        "regex": "([\\d.]+)\\s*\\[.*\\]"
+        "regex": "([\\d.]+)\\s*\\["
     },
     "autoupdate": {
-        "url": "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe"
+        "url": "https://telerik-fiddler.s3.amazonaws.com/fiddler/FiddlerSetup.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
There are two installers inside `$PLUGINSDIR`, not sure how to handle these, opening this PR for some feedback, suggestions
![A](https://i.imgur.com/eW4UcMa.png)