### PR TITLE
defraggler: changed domain name from urls (#2326)

### DIFF
--- a/bucket/defraggler.json
+++ b/bucket/defraggler.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.ccleaner.com/defraggler",
     "version": "2.22.995",
-    "url": "https://www.piriform.com/defraggler/download/portable/downloadfile#/dl.7z",
+    "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.7z",
     "hash": "2edfa974fc2e8e34c0b8c152077da9c3a4ab28cad81a4ced463f0cf6634a0f01",
     "architecture": {
         "64bit": {
@@ -29,10 +29,10 @@
         }
     },
     "checkver": {
-        "url": "https://www.piriform.com/defraggler/download",
+        "url": "https://www.ccleaner.com/defraggler/download",
         "re": "<strong>\\s*v([\\d.]+)</strong>"
     },
     "autoupdate": {
-        "url": "https://www.piriform.com/defraggler/download/portable/downloadfile#/dl.7z"
+        "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.7z"
     }
 }


### PR DESCRIPTION
* upstream has changed its domain name from `www.piriform.com`
  to `www.ccleaner.com`, so this fix urls up