### PR TITLE
kitty: Update to version 0.71.0.4 (manually)

### DIFF
--- a/bucket/kitty.json
+++ b/bucket/kitty.json
@@ -1,8 +1,7 @@
 {
-    "##": "@rasa will fix autoupdate soon",
     "homepage": "http://kitty.9bis.net",
     "license": "MIT",
-    "version": "0.71.0.2",
+    "version": "0.71.0.4",
     "url": [
         "https://www.9bis.net/kitty/?file=genpass.exe#/genpass.exe",
         "https://www.9bis.net/kitty/?file=kageant.exe#/kageant.exe",
@@ -13,11 +12,11 @@
     ],
     "hash": [
         "13673f67164c1d0431ffdb8da93c97e64e18f0458eb7d30ebd52ee18f72ef94e",
-        "d746b1c818380d9a6bc2153e0f1f738fb03154facef45b6daf2f3199a503f1d3",
-        "b5107a234e33cf7777f7e274edb147f8d7008c97b36462b690adc55b0dbbbd79",
-        "ccb7fa8b9db776a7934e621d7ebecc275bc5e17b68cf0393bbf4822cd4992f47",
-        "f0e6373c64ded7707ce748fab0c35ac3564707d4cc8504b2e67fddf4e9005d87",
-        "aaa7bbe71de8da46c93531536f3621e89b18021c80d01be0c75cb45e1f48d96b"
+        "db058d9c25c9b36d9a1f66b7b76d3f7c591e468dd289812835c74413c0562da3",
+        "3b4e8da7b879b2cf33c4e43b795dc4aa2a9df8b17e366a58276a0916b1d41800",
+        "f1470d2143e66325b355eedc61a0a8d0b92238c3c6d99e570f21c63a856af3ff",
+        "d0c0911c75fa37311a5ee600e511026798825e3174f5f06875f34cd81b6c8d52",
+        "a5c635efc825ab797b0464b821f0a2228a1f77d1c7505ed2723a9e5c2300db51"
     ],
     "bin": [
         "genpass.exe",


### PR DESCRIPTION
I used the code in https://github.com/lukesampson/scoop/pull/3518 (but this is not dependent on #3518 first being merged in)

Fixes #2263 
Fixes #2330 
Fixes #2334
