### PR TITLE
onefetch: Add autoupdate

### DIFF
--- a/bucket/onefetch.json
+++ b/bucket/onefetch.json
@@ -1,11 +1,22 @@
 {
-    "description": "Onefetch is a command-line system information tool that displays information about your project directly on your terminal.",
+    "description": "A command-line system information tool that displays information about your project directly on your terminal.",
     "homepage": "https://github.com/o2sh/onefetch",
     "version": "1.0.0",
     "license": "MIT",
     "notes": "You may have to enable ANSI Color Codes in your terminal. See https://stackoverflow.com/questions/51680709/",
-    "url": "https://github.com/o2sh/onefetch/releases/download/v1.0.0/onefetch_windows_x86-64.zip",
     "bin": "onefetch.exe",
-    "hash": "2f3894dfc42b8bfb75f336dd749fc7e3abfa130758d468d4b7d4bf3a4c12fd02",
-    "checkver": "github"
+    "checkver": "github",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/o2sh/onefetch/releases/download/v1.0.0/onefetch_windows_x86-64.zip",
+            "hash": "2f3894dfc42b8bfb75f336dd749fc7e3abfa130758d468d4b7d4bf3a4c12fd02"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/o2sh/onefetch/releases/download/v$version/onefetch_windows_x86-64.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes `onefetch: 1.5.4 (scoop version is 1.0.0)` in https://scoop.r15.ch/extras/mud-20190624-020001.log