### PR TITLE
telegram: Fix autoupdate url

### DIFF
--- a/bucket/telegram.json
+++ b/bucket/telegram.json
@@ -18,6 +18,6 @@
         "github": "https://github.com/telegramdesktop/tdesktop"
     },
     "autoupdate": {
-        "url": "https://github.com/telegramdesktop/tdesktop/releases/download/v$version/tportable.$version.zip"
+        "url": "https://updates.tdesktop.com/tsetup/tportable.$version.zip"
     }
 }


### PR DESCRIPTION
Fixes `telegram: 1.7.9 (scoop version is 1.7.7) autoupdate available` in https://scoop.r15.ch/extras/mud-20190624-020001.log