### PR TITLE
Using http instead of https allows 302 redirects to work for Eclipse

### DIFF
--- a/bucket/eclipse-automotive.json
+++ b/bucket/eclipse-automotive.json
@@ -4,11 +4,11 @@
     "version": "4.5.2",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/mars/2/eclipse-automotive-mars-2-incubation-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/mars/2/eclipse-automotive-mars-2-incubation-win32-x86_64.zip",
             "hash": "sha512:902cbb27824f644d422978f7beab95c9ef3d1067470099b106d3fa7848073f2ba86831bd18f872c462e0cbd2b211015d17d1ba58f69c076ced8157202f7653cb"
         },
         "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/mars/2/eclipse-automotive-mars-2-incubation-win32.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/mars/2/eclipse-automotive-mars-2-incubation-win32.zip",
             "hash": "sha512:722782f943fff7088b3473cba2776b5d016bf8cb4c71e5f373ea8f182cde58be0c38a0bcffed0c61bc374161cb3675866bc5e86134aad3c79741d69f3befee54"
         }
     },

--- a/bucket/eclipse-committers.json
+++ b/bucket/eclipse-committers.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-committers-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-committers-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:859f09f7e60e2689ff191550605e4040393ff3b16b74ddcf3e6abffbeaf3cd0b9d1ac0de5f1688ce82a1f70443a3dafa65ce7aa03af4f2437a7d211916ef6888"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-committers-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-cpp.json
+++ b/bucket/eclipse-cpp.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-cpp-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-cpp-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:4dc869fb9b2131d22deb21287626ab12c9e5b96a338bc359a671fd368634ef4e5936431bd0bf9ce6c88dfd1574cdf09dd45afc43a08c88f38e5e96cbab8ac537"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-cpp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-dsl.json
+++ b/bucket/eclipse-dsl.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-dsl-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-dsl-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:f3ba6857fdf3a002a35acdd57dd7869765fd02b2cf63ea6aa56cf313073e8774534710fd70ac0860139a815cac22ada4d2417d0c240d35d12e0bb65f3927ebe4"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-dsl-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-java.json
+++ b/bucket/eclipse-java.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-java-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-java-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:de3b75dd62241b76b0dd6db2c4beb4def77881331f9d5ef91cd8285c1a8512071a2d55c38e393640c199af7efc0bd9f4c414fc64cc3091ad2c2d39120ba2c651"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-java-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-javascript.json
+++ b/bucket/eclipse-javascript.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-javascript-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-javascript-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:55f977ec086f302cd69bcb37e7f6bc442ed997372d12ccbd944b427dc0b759d0f666332460ddb211942d38deec56698f80d4a930932f07a68cb4259cdc990a1f"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-javascript-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-jee.json
+++ b/bucket/eclipse-jee.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-jee-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-jee-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:85469f20c7e5ac5c0cddeaefc4d48d2c64d3a7bb4c999f40c0d3860c83ec6699695e477a917c570c1aa7a4f59efd93ca75b2f254300996de8baca6dee931f672"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-jee-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-mat.json
+++ b/bucket/eclipse-mat.json
@@ -4,11 +4,11 @@
     "version": "1.9.0.20190605",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/1.9.0/rcp/MemoryAnalyzer-1.9.0.20190605-win32.win32.x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/mat/1.9.0/rcp/MemoryAnalyzer-1.9.0.20190605-win32.win32.x86_64.zip",
             "hash": "sha512:19c9be9a0ef27f739f928cb789d41b37f19a41ae47930e43776a96348fbccf312f5d5f31663cdd313eb6aae2798ec49a7e6248f2c00a5d787d5af5214b2a1ad6"
         },
         "32bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/1.9.0/rcp/MemoryAnalyzer-1.9.0.20190605-win32.win32.x86.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/mat/1.9.0/rcp/MemoryAnalyzer-1.9.0.20190605-win32.win32.x86.zip",
             "hash": "sha512:935874b4a1dc578296b4d09bb2a5e454aeb3e926495677e7f318f2cad7ea52e4b4b907adfa36b4307a999f35438e99481dfe26b9594d0e3448e7012ebd87ec5f"
         }
     },
@@ -27,14 +27,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip",
                 "hash": {
                     "url": "https://www.eclipse.org/downloads/sums.php?file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86_64.zip&type=sha512",
                     "find": "([a-fA-F0-9]{128})"
                 }
             },
             "32bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86.zip",
                 "hash": {
                     "url": "https://www.eclipse.org/downloads/sums.php?file=/mat/$matchShort/rcp/MemoryAnalyzer-$version-win32.win32.x86.zip&type=sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-modeling.json
+++ b/bucket/eclipse-modeling.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-modeling-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-modeling-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:d7cf9771690669ad3b2c445baa4c69a5358e7d5fa014635068cac8e45f4cdbd17e53dce91bba86e5f3a1e14120bbd001511490286759132ca0beef597870619a"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-modeling-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-parallel.json
+++ b/bucket/eclipse-parallel.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-parallel-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-parallel-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:3e053243397477aaf29479482613f0f459c8cba22e0337a76e634f412ae6b419737e1979aaebbcb3c3637ec5a53de8e55eea8ce43d65a08bfaf045146a2ade2b"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-parallel-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-php.json
+++ b/bucket/eclipse-php.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-php-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-php-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:d077bc10db5bab6164a6e0a1cf1b97454c9ba612284e83e793e0bf4538cdd45c10273f661087d27c953392d06023cebab2e2b14ebaf8ce37b1986da5088d273f"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-php-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-platform.json
+++ b/bucket/eclipse-platform.json
@@ -4,7 +4,7 @@
     "version": "4.12-201906051800",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.12-201906051800/eclipse-platform-4.12-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.12-201906051800/eclipse-platform-4.12-win32-x86_64.zip",
             "hash": "sha512:9fdc8091cfa9024caaf48f14b2c909cfa20b7ae353c3fa2c3cc42b7598c8e0524b7c3b39554b3760ca5591ae9e980df245402c9d91f093cda834de78c4d01ebd"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-platform-$matchRelease-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-platform-$matchRelease-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-platform-$matchRelease-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-rcp.json
+++ b/bucket/eclipse-rcp.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-rcp-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-rcp-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:a4b11ce40e7bdffee56be687609c913bfcade74fb5e5f1d6599c303bfe777b8d1978a9b5dcad8b58b0a7e73cf7aef0a28e33c899c70a1e0f9c854af9a0a398bb"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rcp-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-reporting.json
+++ b/bucket/eclipse-reporting.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-reporting-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-reporting-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:a93cb19355e4efd895ba0cb3473a2650e46ad777093b7d3060409546c7d81793e3c941ff49960a3623517b10ae01ac328f089c69e1348ac5cdda0e910bc10206"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-reporting-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-rust.json
+++ b/bucket/eclipse-rust.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-rust-2019-06-R-incubation-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-rust-2019-06-R-incubation-win32-x86_64.zip",
             "hash": "sha512:de04235ce088d2e360f422c38c49d86bcf986f68738df1bf6dbf1e287f0b6adf82e48460222d8793c31bbca4f4f81ed0031146386009a6c03044dd7d370968cc"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-rust-$version-$matchR-incubation-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-scout.json
+++ b/bucket/eclipse-scout.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-scout-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-scout-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:158eb99f9fe5f6c8714bdb6337c7c9a5c4fa0b76a80e31e04492bc7f5938513241503e5141766a5e489dc201f21209e1c1f3d6dd90abd5b053ff2d4349fbdc21"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-scout-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-sdk.json
+++ b/bucket/eclipse-sdk.json
@@ -4,7 +4,7 @@
     "version": "4.12-201906051800",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.12-201906051800/eclipse-SDK-4.12-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/drops4/R-4.12-201906051800/eclipse-SDK-4.12-win32-x86_64.zip",
             "hash": "sha512:f65b086dfa075c0f7bc41e1ff68a330cffa8ff4adc3e461d8692ed3471e4e92ad51f95341cb95a313336d10ca9b02195f378d1c89de747bc0830d0e1810295e1"
         }
     },
@@ -23,7 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-SDK-$matchRelease-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/eclipse/downloads/$matchDrop/eclipse-SDK-$matchRelease-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/eclipse/downloads/$matchDrop/checksum/eclipse-SDK-$matchRelease-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"

--- a/bucket/eclipse-testing.json
+++ b/bucket/eclipse-testing.json
@@ -4,7 +4,7 @@
     "version": "2019-06",
     "architecture": {
         "64bit": {
-            "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-testing-2019-06-R-win32-x86_64.zip",
+            "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/2019-06/R/eclipse-testing-2019-06-R-win32-x86_64.zip",
             "hash": "sha512:e572a6cd0d806227dc5045598705a1b0bc301a178ef8fe4eba866835256102187cf4121d9011a3fac397e57857fcd80a9eecc3fd7c52c397277c2a9737df6a76"
         }
     },
@@ -22,7 +22,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip",
+                "url": "http://www.eclipse.org/downloads/download.php?r=1&file=/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip",
                 "hash": {
                     "url": "https://download.eclipse.org/technology/epp/downloads/release/$version/$matchR/eclipse-testing-$version-$matchR-win32-x86_64.zip.sha512",
                     "find": "([a-fA-F0-9]{128})"


### PR DESCRIPTION
Currently, scoop [cannot follow `302` redirects from an `https` URL to an `http` one](https://github.com/lukesampson/scoop/issues/3155).
Unfortunately, some of the Eclipse mirrors are still using `http`, so the redirect does not work, depending on which mirror gets chosen.