### PR TITLE
Piriform Apps: Change URLs, add persist, modify checkver

### DIFF
--- a/bucket/ccleaner.json
+++ b/bucket/ccleaner.json
@@ -1,13 +1,10 @@
 {
-    "homepage": "https://www.piriform.com/ccleaner",
+    "homepage": "https://www.ccleaner.com/ccleaner",
     "version": "5.60.7307",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://www.ccleaner.com/legal/end-user-license-agreement"
-    },
-    "description": "A tool for cleaning your PC, which protects your privacy and makes your computer faster and more secure.",
-    "url": "https://download.ccleaner.com/slim/ccsetup560_slim.exe#/dl.7z",
-    "hash": "44254a3e55e54007b9e925a08339f564af5b11fd8fd1769dcb3246bfab84041d",
+    "license": "Freeware",
+    "description": "Number-one tool for cleaning your PC.",
+    "url": "https://download.ccleaner.com/portable/ccsetup560.zip",
+    "hash": "06b6fac2e5f79ec795f048f85d805f8e06290520bf18c45544ee95176f0503e3",
     "architecture": {
         "64bit": {
             "bin": [
@@ -33,19 +30,17 @@
             ]
         }
     },
-    "persist": "ccleaner.ini",
     "pre_install": [
-        "if(!(test-path \"$persist_dir\\ccleaner.ini\")) { Add-Content \"$dir\\ccleaner.ini\" \"[Options]`nHelpImproveCCleaner=0\" }",
-        "if(!(test-path \"$dir\\portable.dat\")) { Add-Content \"$dir\\portable.dat\" \"#PORTABLE#\" }",
-        "Remove-Item \"$dir\\`$*\" -Recurse",
-        "Remove-Item \"$dir\\uninst.exe\"",
-        "Remove-Item \"$dir\\CCUpdate.exe\""
+        "if(!(Test-Path \"$persist_dir\\ccleaner.ini\")) {",
+        "   Set-Content \"$dir\\ccleaner.ini\" (@('[Options]', 'UpdateAuto=0', 'UpdateNotify=0', 'UpdateCheck=0', 'HelpImproveCCleaner=0') -join \"`r`n\") -Encoding ASCII",
+        "}"
     ],
+    "persist": "ccleaner.ini",
     "checkver": {
-        "url": "https://www.piriform.com/ccleaner/download",
-        "re": "<strong>v([\\d.]+)</strong>"
+        "url": "https://www.ccleaner.com/ccleaner/download",
+        "regex": "<strong>v([\\d.]+)</strong>"
     },
     "autoupdate": {
-        "url": "https://download.ccleaner.com/slim/ccsetup$majorVersion$minorVersion_slim.exe#/dl.7z"
+        "url": "https://download.ccleaner.com/portable/ccsetup$majorVersion$minorVersion.zip"
     }
 }

--- a/bucket/defraggler.json
+++ b/bucket/defraggler.json
@@ -1,12 +1,9 @@
 {
     "homepage": "https://www.ccleaner.com/defraggler",
-    "description": "Speed up your PC with quick & easy defragmentation.",
     "version": "2.22.995",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://www.ccleaner.com/legal/end-user-license-agreement"
-    },
-    "url": "https://www.piriform.com/defraggler/download/portable/downloadfile#/dl.7z",
+    "license": "Freeware",
+    "description": "Speed up your PC with quick & easy defragmentation.",
+    "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dfsetup222.zip",
     "hash": "2edfa974fc2e8e34c0b8c152077da9c3a4ab28cad81a4ced463f0cf6634a0f01",
     "architecture": {
         "64bit": {
@@ -14,6 +11,10 @@
                 [
                     "Defraggler64.exe",
                     "Defraggler"
+                ],
+                [
+                    "df64.exe",
+                    "df"
                 ]
             ],
             "shortcuts": [
@@ -24,7 +25,10 @@
             ]
         },
         "32bit": {
-            "bin": "Defraggler.exe",
+            "bin": [
+                "Defraggler.exe",
+                "df.exe"
+            ],
             "shortcuts": [
                 [
                     "Defraggler.exe",
@@ -33,11 +37,17 @@
             ]
         }
     },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\Defraggler.ini\")) {",
+        "   Set-Content \"$dir\\Defraggler.ini\" (@('[Software\\Piriform\\Defraggler]', 'UpdateCheck=0') -join \"`r`n\") -Encoding ASCII",
+        "}"
+    ],
+    "persist": "Defraggler.ini",
     "checkver": {
-        "url": "https://www.piriform.com/defraggler/download",
-        "re": "<strong>\\s*v([\\d.]+)</strong>"
+        "url": "https://www.ccleaner.com/defraggler/download",
+        "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.piriform.com/defraggler/download/portable/downloadfile#/dl.7z"
+        "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dfsetup$majorVersion$minorVersion.zip"
     }
 }

--- a/bucket/defraggler.json
+++ b/bucket/defraggler.json
@@ -3,7 +3,7 @@
     "version": "2.22.995",
     "license": "Freeware",
     "description": "Speed up your PC with quick & easy defragmentation.",
-    "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dfsetup222.zip",
+    "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.zip",
     "hash": "2edfa974fc2e8e34c0b8c152077da9c3a4ab28cad81a4ced463f0cf6634a0f01",
     "architecture": {
         "64bit": {
@@ -48,6 +48,6 @@
         "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dfsetup$majorVersion$minorVersion.zip"
+        "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.zip"
     }
 }

--- a/bucket/recuva.json
+++ b/bucket/recuva.json
@@ -1,12 +1,9 @@
 {
     "homepage": "https://www.ccleaner.com/recuva",
-    "description": "A file recovery tool, which can undelete files that have been marked as deleted.",
     "version": "1.53.1087",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://www.ccleaner.com/legal/end-user-license-agreement"
-    },
-    "url": "https://www.piriform.com/recuva/download/portable/downloadfile#/dl.7z",
+    "license": "Freeware",
+    "description": "Recover your deleted files quickly and easily.",
+    "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/rcsetup153.zip",
     "hash": "997a082fb03fcdf272d58c25aba488a136cf115a1e1b53930339fb5ef95bf91f",
     "architecture": {
         "64bit": {
@@ -24,10 +21,7 @@
             ]
         },
         "32bit": {
-            "bin": [
-                "recuva.exe",
-                "Recuva"
-            ],
+            "bin": "recuva.exe",
             "shortcuts": [
                 [
                     "recuva.exe",
@@ -36,11 +30,17 @@
             ]
         }
     },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\recuva.ini\")) {",
+        "   Set-Content \"$dir\\recuva.ini\" (@('[Software\\Piriform\\Recuva]', 'UpdateCheck=0') -join \"`r`n\") -Encoding ASCII",
+        "}"
+    ],
+    "persist": "recuva.ini",
     "checkver": {
-        "url": "https://www.piriform.com/recuva/download",
-        "re": "<strong>\\s*v([\\d.]+)</strong>"
+        "url": "https://www.ccleaner.com/recuva/download",
+        "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.piriform.com/recuva/download/portable/downloadfile#/dl.7z"
+        "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/rcsetup$majorVersion$minorVersion.zip"
     }
 }

--- a/bucket/recuva.json
+++ b/bucket/recuva.json
@@ -3,7 +3,7 @@
     "version": "1.53.1087",
     "license": "Freeware",
     "description": "Recover your deleted files quickly and easily.",
-    "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/rcsetup153.zip",
+    "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/dl.zip",
     "hash": "997a082fb03fcdf272d58c25aba488a136cf115a1e1b53930339fb5ef95bf91f",
     "architecture": {
         "64bit": {
@@ -41,6 +41,6 @@
         "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/rcsetup$majorVersion$minorVersion.zip"
+        "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/dl.zip"
     }
 }

--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -3,7 +3,7 @@
     "version": "1.32.740",
     "license": "Freeware",
     "description": "Fast, lightweight, advanced system information tool for your PC.",
-    "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/spsetup132.zip",
+    "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/dl.zip",
     "hash": "1a662d847f16850658216634eda7c98ce06b0c861017de16e8dc8ff12a412abe",
     "architecture": {
         "64bit": {
@@ -41,6 +41,6 @@
         "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/spsetup$majorVersion$minorVersion.zip"
+        "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/dl.zip"
     }
 }

--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -1,12 +1,9 @@
 {
-    "homepage": "https://www.piriform.com/speccy",
-    "description": "A system information tool for your PC.",
+    "homepage": "https://www.ccleaner.com/speccy",
     "version": "1.32.740",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://www.ccleaner.com/legal/end-user-license-agreement"
-    },
-    "url": "https://www.piriform.com/speccy/download/portable/downloadfile#/dl.7z",
+    "license": "Freeware",
+    "description": "Fast, lightweight, advanced system information tool for your PC.",
+    "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/spsetup132.zip",
     "hash": "1a662d847f16850658216634eda7c98ce06b0c861017de16e8dc8ff12a412abe",
     "architecture": {
         "64bit": {
@@ -33,11 +30,17 @@
             ]
         }
     },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\Speccy.ini\")) {",
+        "   Set-Content \"$dir\\Speccy.ini\" (@('[Software\\Piriform\\Speccy]', 'NeedUpdate=0') -join \"`r`n\") -Encoding ASCII",
+        "}"
+    ],
+    "persist": "Speccy.ini",
     "checkver": {
-        "url": "https://www.piriform.com/speccy/download",
-        "re": "Latest version: <b>(\\d+\\.\\d+\\.\\d+)</b>"
+        "url": "https://www.ccleaner.com/speccy/download",
+        "regex": "Latest version: <b>([\\d.]+)</b>"
     },
     "autoupdate": {
-        "url": "https://www.piriform.com/speccy/download/portable/downloadfile#/dl.7z"
+        "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/spsetup$majorVersion$minorVersion.zip"
     }
 }


### PR DESCRIPTION
I'm not sure if this will fix Piriform apps' hash errors...

- Change URLs to ccleaner.com
- Modify `checkver` and download URLs and download filenames (change to filename returned by URL)
- Add `persist` (and switch off autoupdate)
