### PR TITLE
tor-expert: Fix checkver.url, add description

### DIFF
--- a/bucket/tor-expert.json
+++ b/bucket/tor-expert.json
@@ -1,5 +1,6 @@
 {
     "version": "0.3.5.8",
+    "description": "Enables anonymous communication over the onion network (export mode).",
     "license": "BSD-3-Clause",
     "url": "https://dist.torproject.org/torbrowser/8.0.7/tor-win32-0.3.5.8.zip",
     "homepage": "https://www.torproject.org",
@@ -9,7 +10,7 @@
         "Tor/tor-gencert.exe"
     ],
     "checkver": {
-        "url": "https://www.torproject.org/download/download.html.en",
+        "url": "https://www.torproject.org/download/tor/",
         "re": "torbrowser/(?<browser>[\\d.]+)/tor-win32-(?<version>[\\d.]+)\\.zip"
     },
     "autoupdate": {
@@ -18,5 +19,8 @@
             "url": "https://dist.torproject.org/torbrowser/$matchBrowser/sha256sums-signed-build.txt"
         }
     },
-    "notes": "Warning This version of tor does not come pre-configured it is up to you the user to configure it. Please see https://www.torproject.org/docs/tor-manual.html.en for config info"
+    "notes": [
+        "NOTE: You will need to configure tor before using it, as it does not come pre-configured.",
+        "Please see https://www.torproject.org/docs/tor-manual.html.en for configuration details."
+    ]
 }

--- a/bucket/tor-expert.json
+++ b/bucket/tor-expert.json
@@ -16,7 +16,7 @@
     "autoupdate": {
         "url": "https://dist.torproject.org/torbrowser/$matchBrowser/tor-win32-$version.zip",
         "hash": {
-            "url": "https://dist.torproject.org/torbrowser/$matchBrowser/sha256sums-signed-build.txt"
+            "url": "$baseurl/sha256sums-signed-build.txt"
         }
     },
     "notes": [


### PR DESCRIPTION
Fixes:
tor-expert: couldn't match 'torbrowser/(?<browser>[\d.]+)/tor-win32-(?<version>[\d.]+)\.zip' in https://www.torproject.org/download/download.html.en
in https://scoop.r15.ch/extras/mud-20190624-210001.log
