### PR TITLE
cpu-z: fix hash

### DIFF
--- a/bucket/cpu-z.json
+++ b/bucket/cpu-z.json
@@ -4,7 +4,7 @@
     "description": "System information software.",
     "license": "Freeware",
     "url": "http://download.cpuid.com/cpu-z/cpu-z_1.89-en.zip",
-    "hash": "ee81ff235de6c94460f264e875fbe6d4c0d1cf1e21cd996fe1fafa59440146d4",
+    "hash": "2567e1b039cc358a1447cfff1170dff42b19b89d8d37b97dd939ee179106494f",
     "architecture": {
         "32bit": {
             "bin": [


### PR DESCRIPTION
fix issue #2360
`cpu-z` has a minor update that is not listed in the version history. From its [previous version history details](https://www.cpuid.com/softwares/cpu-z.html#version-history), this seems to be a rare case. I suggest we just *modify the hash value* to solve the problem for now.
![pic](https://user-images.githubusercontent.com/27724471/60201461-e6f8ae00-987a-11e9-9770-c9bc46be78a9.png)