### PR TITLE
zmc: update to 7.0.0.49

### DIFF
--- a/bucket/zmc.json
+++ b/bucket/zmc.json
@@ -1,28 +1,29 @@
 {
     "homepage": "https://www.azul.com/products/zulu-mission-control",
-    "version": "7.0.0",
-    "description": "Alternative of JDK Mession Control",
+    "version": "7.0.0.49",
+    "description": "A build of JDK Mission Control, an open source Java runtime profiling and monitoring utility.",
     "license": "UPL-1.0",
     "architecture": {
         "64bit": {
-            "url": "http://static.azul.com/zmc/bin/zmc7.0.0-EA-win_x64.zip",
-            "hash": "c210156b0b75a8a3e84b452359006d8e5023a66d8efe895061d836cd7b5dfd3f",
-            "extract_dir": "zmc7.0.0-EA-win_x64",
-            "shortcuts": [
-                [
-                    "zmc.exe",
-                    "Zulu Mission Control"
-                ]
-            ]
+            "url": "http://static.azul.com/zmc/bin/zmc7.0.0.49-ca-win_x64.zip",
+            "hash": "b0cc73a11fa6b84aaee2552e12ec6cf49df5208c56a743d3d5358b3b30a0eaa6",
+            "extract_dir": "zmc7.0.0.49-ca-win_x64"
         }
     },
     "persist": "configuration",
-    "checkver": "zmc([\\d.]+)-EA-win",
+    "checkver": "zmc([\\d.]+)-ca-win",
+    "bin": "zmc.exe",
+    "shortcuts": [
+        [
+            "zmc.exe",
+            "Zulu Mission Control"
+        ]
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://static.azul.com/zmc/bin/zmc$version-EA-win_x64.zip",
-                "extract_dir": "zmc$version-EA-win_x64"
+                "url": "http://static.azul.com/zmc/bin/zmc$version-ca-win_x64.zip",
+                "extract_dir": "zmc$version-ca-win_x64"
             }
         }
     }


### PR DESCRIPTION
#2308

- update version to [GA](https://www.azul.com/press_release/azul-systems-announces-general-availability-zulu-mission-control-v7-0/ ) version 7.0.0.49

- update description from [FAQ](https://www.azul.com/products/zulu-mission-control/zulu-mission-control-faq/)

- add `bin` field

P.S. I'm really puzzled about `ca` in the filename `zmc7.0.0.49-ca-win_x64.zip`.