### PR TITLE
fritzing: Fix checkver

### DIFF
--- a/bucket/fritzing.json
+++ b/bucket/fritzing.json
@@ -23,8 +23,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/fritzing/fritzing-app/",
-        "re": "\\/releases\\/tag\\/(?:v)?([\\w.]+)"
+        "url": "http://fritzing.org/download/",
+        "re": "/download/([\\w.]+)/windows/"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
#2308 

The next expected version is 0.9.4b. (https://github.com/fritzing/fritzing-app/issues/3443)