### PR TITLE
pwsafe: Fix checkver

### DIFF
--- a/bucket/pwsafe.json
+++ b/bucket/pwsafe.json
@@ -22,8 +22,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/pwsafe/pwsafe",
-        "re": "/download/(?:v?)([\\d.]+)/pwsafe"
+        "url": "https://github.com/pwsafe/pwsafe/releases",
+        "re": "pwsafe64-([\\d.]+).msi"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
#2308

The `1.xBETA` versions are built for linux.

It could be skipped by extracting versions directly from filenames of windows-specific `msi` installer.