### PR TITLE
DBGL: Add version 0.82

### DIFF
--- a/bucket/dbgl.json
+++ b/bucket/dbgl.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "http://members.quicknet.nl/blankendaalr/dbgl/",
+    "description": "Open-source, free, multi-platform frontend for DOSBox.",
+    "version": "0.82",
+    "license": "GPL-2.0-or-later",
+    "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl082.zip",
+    "hash": "86036221e37fba2a2dfd2e95edb896b70e55a0d2c5fb1fa96b4ef233354a4b56",
+    "post_install": "if(-Not(Test-Path env:JAVA_HOME)){ Write-Host \"JRE is not found on this machine.`nDBGL will not work unless JRE is installed.`nRun`n    scoop bucket add java && scoop install java/adoptopenjdk-hotspot-jre`nto install it\"}",
+    "bin": [
+        [
+            "launch.exe",
+            "dbgl"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "launch.exe",
+            "DOSBox Game Launcher"
+        ]
+    ],
+    "checkver": {
+        "regex": "v([\\d.]+) <sup>\\([\\d/]+\\)</sup>"
+    },
+    "autoupdate": {
+        "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl$cleanVersion.zip"
+    }
+}

--- a/bucket/dbgl.json
+++ b/bucket/dbgl.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl082.zip",
     "hash": "86036221e37fba2a2dfd2e95edb896b70e55a0d2c5fb1fa96b4ef233354a4b56",
-    "suggest": "java/adoptopenjdk-hotspot-jre",
+    "suggest": ["java/adoptopenjdk-hotspot-jre"],
     "bin": [
         [
             "launch.exe",
@@ -23,4 +23,3 @@
         "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl$cleanVersion.zip"
     }
 }
-

--- a/bucket/dbgl.json
+++ b/bucket/dbgl.json
@@ -5,7 +5,9 @@
     "license": "GPL-2.0-or-later",
     "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl082.zip",
     "hash": "86036221e37fba2a2dfd2e95edb896b70e55a0d2c5fb1fa96b4ef233354a4b56",
-    "suggest": ["java/adoptopenjdk-hotspot-jre"],
+    "suggest": {
+        "Java Runtime Environment": "java/adoptopenjdk-hotspot-jre"
+    },
     "bin": [
         [
             "launch.exe",

--- a/bucket/dbgl.json
+++ b/bucket/dbgl.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl082.zip",
     "hash": "86036221e37fba2a2dfd2e95edb896b70e55a0d2c5fb1fa96b4ef233354a4b56",
-    "post_install": "if(-Not(Test-Path env:JAVA_HOME)){ Write-Host \"JRE is not found on this machine.`nDBGL will not work unless JRE is installed.`nRun`n    scoop bucket add java && scoop install java/adoptopenjdk-hotspot-jre`nto install it\"}",
+    "suggest": "java/adoptopenjdk-hotspot-jre",
     "bin": [
         [
             "launch.exe",
@@ -18,10 +18,9 @@
             "DOSBox Game Launcher"
         ]
     ],
-    "checkver": {
-        "regex": "v([\\d.]+) <sup>\\([\\d/]+\\)</sup>"
-    },
+    "checkver": "v([\\d.]+)\\s+<sup",
     "autoupdate": {
         "url": "http://members.quicknet.nl/blankendaalr/dbgl/download/dbgl$cleanVersion.zip"
     }
 }
+


### PR DESCRIPTION
Requested in #2162.


**DBGL** is an open-source frontend for DOSBox.
Homepage: http://members.quicknet.nl/blankendaalr/dbgl/


~The `post-install` section will check whether JRE is installed. (by checking env variable `JAVA_HOME`), and prompt the user to install it if JRE is not detected.~ (suggest user to install Java instead)


Please let me know if there are any problems. Thanks.