### PR TITLE
ISLC: Fix hash

### DIFF
--- a/bucket/islc.json
+++ b/bucket/islc.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://www.wagnardsoft.com/",
-    "description": "Utility that will monitor and clear the memory standby list when it is > 1000mb (1gb). It may help users who have stutters in games when using windows 10 Creator update and higher version of windows.",
+    "description": "Utility that will monitor and clear the memory standby list when it is > 1000mb (1gb).",
     "license": "Freeware",
     "version": "1.0.1.2",
-    "url": "https://www.wagnardsoft.com/ISLC/ISLC%20v1.0.1.2.exe#/ISLC-1.0.1.2.7z",
-    "hash": "5bf09fa1f74055001d1b63dbf10990dc7df3effdd3d205efc9848749724c2fec",
+    "url": "https://www.wagnardsoft.com/ISLC/ISLC%20v1.0.1.2.exe#/dl.7z",
+    "hash": "sha1:078c58989143f93c6b0eb79b202e05d7c15a9adc",
     "extract_dir": "ISLC v1.0.1.2",
     "shortcuts": [
         [
@@ -13,16 +13,13 @@
         ]
     ],
     "persist": "Intelligent standby list cleaner ISLC.exe.Config",
-    "checkver": {
-        "url": "https://www.wagnardsoft.com/",
-        "re": "Intelligent standby list cleaner [Vv]([\\d\\.]*) Released"
-    },
+    "checkver": "/content/intelligent-standby-list-cleaner-v(?<link>\\d+)-released(?:.|\\n)+Intelligent standby list cleaner [Vv](?<version>[\\d.]+) Released",
     "autoupdate": {
-        "url": "https://www.wagnardsoft.com/ISLC/ISLC%20v$version.exe#/ISLC-$version.7z",
-        "extract_dir": "ISLC v$version",
+        "url": "https://www.wagnardsoft.com/ISLC/ISLC%20v$version.exe#/dl.7z",
         "hash": {
-            "url": "https://www.wagnardsoft.com/content/intelligent-standby-list-cleaner-v$cleanVersion-released",
-            "find": "SHA1:\\s+$sha1"
-        }
+            "url": "https://www.wagnardsoft.com/content/intelligent-standby-list-cleaner-v$matchLink-released",
+            "regex": "SHA1:\\s+$sha1"
+        },
+        "extract_dir": "ISLC v$version"
     }
 }


### PR DESCRIPTION
Fix https://github.com/lukesampson/scoop-extras/issues/2397

But I bump into another error

```
Installing 'islc' (1.0.1.2) [64bit]
ISLC%20v1.0.1.2.exe (338.8 KB) [===================================================================] 100%
Checking hash of ISLC%20v1.0.1.2.exe ... ok.
Extracting dl.7z ... Could not find 'ISLC v1.0.1.2'! (error 16)
所在位置 D:\scoop\apps\scoop\current\lib\core.ps1:506 字符: 9
+         throw "Could not find '$(fname $from)'! (error $($proc.ExitCo ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Could not find ....2'! (error 16):String) [], RuntimeExcep 
   tion
    + FullyQualifiedErrorId : Could not find 'ISLC v1.0.1.2'! (error 16)
```

Relpace `extract_dir` with `installer`  works well

```
    "installer": {
        "script": [
            "Move-Item \"$dir\\ISLC v$version\\*\" \"$dir\"",
            "Remove-Item \"$dir\\ISLC v$version\" -Recurse -Force"
        ]
    }
```

Maybe it caused by the space in `extract_dir`.