### PR TITLE
fmedia: Remove 32bit and update to 1.9

### DIFF
--- a/bucket/fmedia.json
+++ b/bucket/fmedia.json
@@ -1,29 +1,23 @@
 {
     "homepage": "http://fmedia.firmdev.com/",
-    "description": "fmedia is a fast media player/recorder/converter for Windows, macOS, Linux and FreeBSD.",
+    "description": "A fast media player/recorder/converter",
     "license": "GPL-3.0-only",
-    "version": "1.6",
+    "version": "1.9",
     "architecture": {
         "64bit": {
-            "url": "http://fmedia.firmdev.com/fmedia-1.6-win-x64.zip#/dl.7z",
-            "hash": "ce7d7e74b091e3aa111615b473d85b1137301979a6cb4ec500942da3ac3e5dbb"
-        },
-        "32bit": {
-            "url": "http://fmedia.firmdev.com/fmedia-1.6-win-x86.zip#/dl.7z",
-            "hash": "bf7f0d7c9a9c38c1ebf2c4a49c36656e80cb5b433de5b36d12692c985b62bf42"
+            "url": "http://fmedia.firmdev.com/fmedia-1.9-win-x64.zip",
+            "hash": "9169cbc33df27bf98c037bb3406c086313498da62dd5f6e58a2a7fccae2b06b7"
         }
     },
+    "extract_dir": "fmedia",
+    "bin": "fmedia.exe",
     "shortcuts": [
         [
             "fmedia-gui.exe",
             "fmedia"
         ]
     ],
-    "extract_dir": "fmedia",
-    "bin": [
-        "fmedia.exe",
-        "fmedia-gui.exe"
-    ],
+    "persist": "fmedia.conf",
     "checkver": {
         "url": "http://fmedia.firmdev.com/",
         "regex": "fmedia-([\\d.]+)-win-x64.zip"
@@ -31,11 +25,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://fmedia.firmdev.com/fmedia-$version-win-x64.zip#/dl.7z"
-            },
-            "32bit": {
-                "url": "http://fmedia.firmdev.com/fmedia-$version-win-x86.zip#/dl.7z"
+                "url": "http://fmedia.firmdev.com/fmedia-$version-win-x64.zip"
             }
         }
-    }
+    },
+    "notes": "For 32bit, use 'versions/fmedia16' instead."
 }


### PR DESCRIPTION
For 32bit, see https://github.com/ScoopInstaller/Versions/pull/161