### PR TITLE
richcopy & robocopy-gui: Add two old files copy tools

### DIFF
--- a/bucket/richcopy.json
+++ b/bucket/richcopy.json
@@ -1,0 +1,33 @@
+{
+    "homepage": "https://docs.microsoft.com/en-us/previous-versions/technet-magazine/dd547088(v=msdn.10)",
+    "version": "4.0.217.0",
+    "license": "Freeware",
+    "description": "High performance and optimized file copy",
+    "url": "http://download.microsoft.com/download/f/d/0/fd05def7-68a1-4f71-8546-25c359cc0842/hoffmanutilityspotlight2009_04.exe#/dl.7z",
+    "hash": "e4c1b4ff3e92cb502f8f05cd233425208dfbf186aadb06b8ea2ff59bc08b0a24",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\HOFFMA~1.EXE\" -ExtractDir 'HoffmanUtilitySpotlight' -Removal",
+            "Expand-MsiArchive \"$dir\\RichCopySetup.msi\" -Removal",
+            "Remove-Item \"$dir\\setup.exe\", \"$dir\\Windows\" -Recurse -Force"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "shortcuts": [
+                [
+                    "RichCopy64.exe",
+                    "RichCopy"
+                ]
+            ]
+        },
+        "32bit": {
+            "shortcuts": [
+                [
+                    "RichCopy.exe",
+                    "RichCopy"
+                ]
+            ]
+        }
+    }
+}

--- a/bucket/robocopy-gui.json
+++ b/bucket/robocopy-gui.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://docs.microsoft.com/en-us/previous-versions/technet-magazine/cc160891(v=msdn.10)",
+    "version": "3.1.2.0",
+    "license": "Freeware",
+    "description": "Robocopy GUI",
+    "url": "http://download.microsoft.com/download/f/d/0/fd05def7-68a1-4f71-8546-25c359cc0842/utilityspotlight2006_11.exe#/dl.7z",
+    "hash": "07322e9c25a9bd122592f26388f0e120931fcdf72258cce374e0e84df88342b9",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\UTILIT~1.EXE\" -ExtractDir 'UtilitySpotlight' -Removal",
+            "Expand-MsiArchive \"$dir\\Setup.msi\" -Removal",
+            "Remove-Item \"$dir\\setup.exe\", \"$dir\\*Folder\", \"$dir\\Documents\" -Recurse -Force"
+        ]
+    },
+    "shortcuts": [
+        [
+            "RobocopyGW.exe",
+            "Robocopy GUI"
+        ]
+    ]
+}


### PR DESCRIPTION
Add two old files copy tools: Robocopy GUI and RichCopy, made by Microsoft staff, and all are provided as-is, and not supported by Microsoft.