### PR TITLE
Ocenaudio: fix hash, modify script (description, checkver, au.hash)

### DIFF
--- a/bucket/ocenaudio.json
+++ b/bucket/ocenaudio.json
@@ -4,11 +4,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.6.4",
-            "hash": "132fb9903228d9513eefc1b5a567c6f7403ab090abdfd1e2f36c1d8ba1f6bb25"
+            "hash": "45653b79bf6d49b9477f3307535fc06c5fc95da2cd8aff7d9880967f2ef3f586"
         },
         "32bit": {
             "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.6.4",
-            "hash": "b3356cbb44f9d2eb4665c040f4f317ef881123a6cdd85d0c696a5584e582f724"
+            "hash": "9d28c7bb80e51c3bce1328739477c019a817ddf1b9eec8f23307020051d4ca41"
         }
     },
     "bin": "ocenaudio.exe",

--- a/bucket/ocenaudio.json
+++ b/bucket/ocenaudio.json
@@ -1,14 +1,16 @@
 {
-    "homepage": "https://www.ocenaudio.com/",
     "version": "3.6.4",
+    "description": "Cross-platform, easy to use, fast and functional audio editor.",
+    "homepage": "https://www.ocenaudio.com/",
+    "license": "Freeware",
     "architecture": {
-        "32bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.6.4",
-            "hash": "sha1:10239f8de7a6567abc761d4ef76574865801df15"
-        },
         "64bit": {
             "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.6.4",
             "hash": "sha1:62c6e2e409b6ff21d6532ae6e78cc7f64679df72"
+        },
+        "32bit": {
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.6.4",
+            "hash": "sha1:10239f8de7a6567abc761d4ef76574865801df15"
         }
     },
     "bin": "ocenaudio.exe",
@@ -22,20 +24,16 @@
     "checkver": "ocenaudio ([\\d.]+)",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version",
-                "hash": {
-                    "url": "https://www.ocenaudio.com/fileinfo/ocenaudio_portable.zip",
-                    "regex": "SHA-1 sum:</strong> $sha1</p>"
-                }
-            },
             "64bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version",
-                "hash": {
-                    "url": "https://www.ocenaudio.com/fileinfo/ocenaudio64_portable.zip",
-                    "regex": "SHA-1 sum:</strong> $sha1</p>"
-                }
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version"
+            },
+            "32bit": {
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version"
             }
+        },
+        "hash": {
+            "url": "https://www.ocenaudio.com/fileinfo/$basename",
+            "regex": "$sha1"
         }
     }
 }

--- a/bucket/ocenaudio.json
+++ b/bucket/ocenaudio.json
@@ -2,13 +2,13 @@
     "homepage": "https://www.ocenaudio.com/",
     "version": "3.6.4",
     "architecture": {
-        "64bit": {
-            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.6.4",
-            "hash": "45653b79bf6d49b9477f3307535fc06c5fc95da2cd8aff7d9880967f2ef3f586"
-        },
         "32bit": {
             "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v3.6.4",
-            "hash": "9d28c7bb80e51c3bce1328739477c019a817ddf1b9eec8f23307020051d4ca41"
+            "hash": "sha1:10239f8de7a6567abc761d4ef76574865801df15"
+        },
+        "64bit": {
+            "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v3.6.4",
+            "hash": "sha1:62c6e2e409b6ff21d6532ae6e78cc7f64679df72"
         }
     },
     "bin": "ocenaudio.exe",
@@ -19,16 +19,22 @@
         ]
     ],
     "persist": "settings",
-    "checkver": {
-        "re": "ocenaudio ([\\d.]+)"
-    },
+    "checkver": "ocenaudio ([\\d.]+)",
     "autoupdate": {
         "architecture": {
-            "64bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version"
-            },
             "32bit": {
-                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version"
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio_portable.zip?version=v$version",
+                "hash": {
+                    "url": "https://www.ocenaudio.com/fileinfo/ocenaudio_portable.zip",
+                    "regex": "SHA-1 sum:</strong> $sha1</p>"
+                }
+            },
+            "64bit": {
+                "url": "https://www.ocenaudio.com/downloads/ocenaudio64_portable.zip?version=v$version",
+                "hash": {
+                    "url": "https://www.ocenaudio.com/fileinfo/ocenaudio64_portable.zip",
+                    "regex": "SHA-1 sum:</strong> $sha1</p>"
+                }
             }
         }
     }


### PR DESCRIPTION
Fix #2419

I seems that the developer of `oceanaudio` has modified some content, and repacked the file without updating the version number.

![repack](https://user-images.githubusercontent.com/27724471/60734323-282b4500-9f82-11e9-9050-c4eeaf4c8a44.png)