### PR TITLE
Teraterm: Add version 4.103

### DIFF
--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -16,6 +16,10 @@
     "checkver": "releases/(?<tag>\\d+)\">Tera Term ([\\d.]+)</a>",
     "autoupdate": {
         "url": "http://pumath.dl.osdn.jp/ttssh2/$matchTag/teraterm-$version.zip",
-        "extract_dir": "teraterm-$version"
+        "extract_dir": "teraterm-$version",
+        "hash": {
+            "url": "https://osdn.net/projects/ttssh2/downloads/$matchTag/teraterm-$version.zip/",
+            "regex": "SHA256</dt>[\\n\\s]+<dd>([0-9a-f]+)</dd>"
+        }
     }
 }

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -19,7 +19,7 @@
         "extract_dir": "teraterm-$version",
         "hash": {
             "url": "https://osdn.net/projects/ttssh2/downloads/$matchTag/teraterm-$version.zip/",
-            "regex": "SHA256</dt>[\\n\\s]+<dd>([0-9a-f]+)</dd>"
+            "regex": "(?sm)MD5</dt>[\\n\\s]+<dd>$md5</dd>"
         }
     }
 }

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -1,10 +1,10 @@
 {
-    "homepage": "https://osdn.net/projects/ttssh2/",
-    "description": "Terminal emulator for ssh/telnet/serial connection.",
     "version": "4.103",
+    "description": "Terminal emulator for ssh/telnet/serial connection.",
+    "homepage": "https://osdn.net/projects/ttssh2/",
     "license": "BSD-3-Clause",
     "url": "http://pumath.dl.osdn.jp/ttssh2/71232/teraterm-4.103.zip",
-    "hash": "99c9b7559c0551412ed75673f2449d84f25a945e351c7a76689f5751628d56d5",
+    "hash": "sha1:15a98ab63cd2b0e7ba93f540eea0e124e6d10f8e",
     "extract_dir": "teraterm-4.103",
     "bin": "ttermpro.exe",
     "shortcuts": [
@@ -13,13 +13,21 @@
             "Tera Term"
         ]
     ],
+    "persist": [
+        "cygterm.cfg",
+        "KEYBOARD.CNF",
+        "ttpmenu.ini",
+        "ssh_known_hosts",
+        "TERATERM.INI"
+    ],
     "checkver": "releases/(?<tag>\\d+)\">Tera Term ([\\d.]+)</a>",
     "autoupdate": {
         "url": "http://pumath.dl.osdn.jp/ttssh2/$matchTag/teraterm-$version.zip",
-        "extract_dir": "teraterm-$version",
         "hash": {
-            "url": "https://osdn.net/projects/ttssh2/downloads/$matchTag/teraterm-$version.zip/",
-            "regex": "(?sm)MD5</dt>[\\n\\s]+<dd>$md5</dd>"
-        }
+            "url": "https://osdn.net/projects/ttssh2/downloads/$matchTag/$basename/",
+            "regex": "(?sm)SHA1</dt>\\s+<dd>$sha1</dd>"
+        },
+        "extract_dir": "teraterm-$version"
     }
 }
+

--- a/bucket/teraterm.json
+++ b/bucket/teraterm.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://osdn.net/projects/ttssh2/",
+    "description": "Terminal emulator for ssh/telnet/serial connection.",
+    "version": "4.103",
+    "license": "BSD-3-Clause",
+    "url": "http://pumath.dl.osdn.jp/ttssh2/71232/teraterm-4.103.zip",
+    "hash": "99c9b7559c0551412ed75673f2449d84f25a945e351c7a76689f5751628d56d5",
+    "extract_dir": "teraterm-4.103",
+    "bin": "ttermpro.exe",
+    "shortcuts": [
+        [
+            "ttermpro.exe",
+            "Tera Term"
+        ]
+    ],
+    "checkver": "releases/(?<tag>\\d+)\">Tera Term ([\\d.]+)</a>",
+    "autoupdate": {
+        "url": "http://pumath.dl.osdn.jp/ttssh2/$matchTag/teraterm-$version.zip",
+        "extract_dir": "teraterm-$version"
+    }
+}


### PR DESCRIPTION
close #2416.

**Tera Term** is a terminal emulator for ssh/telnet/serial connection.
Homepage: https://osdn.net/projects/ttssh2/

Please let me know if there are any problems. Thanks.