### PR TITLE
streamlabs-obs: Fix checkver

### DIFF
--- a/bucket/streamlabs-obs.json
+++ b/bucket/streamlabs-obs.json
@@ -22,8 +22,8 @@
         }
     },
     "checkver": {
-        "github": "https://github.com/stream-labs/streamlabs-obs",
-        "re": "/releases/tag/v([\\d.]+)\""
+        "url": "https://api.github.com/repos/stream-labs/streamlabs-obs/tags",
+        "regex": "\"v([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
There are too many `0.16.0-previewXX` in release page...