### PR TITLE
vlc: Update download URLs.

### DIFF
--- a/bucket/vlc.json
+++ b/bucket/vlc.json
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://download.videolan.org/pub/vlc/3.0.7.1/win64/vlc-3.0.7.1-win64.7z",
+            "url": "https://get.videolan.org/vlc/3.0.7.1/win64/vlc-3.0.7.1-win64.7z",
             "hash": "4860310edad634fa058c40633a5b80310085d2ab13aad91e485885a45c90890c",
             "extract_dir": "vlc-3.0.7.1"
         },
         "32bit": {
-            "url": "https://download.videolan.org/pub/vlc/3.0.7.1/win32/vlc-3.0.7.1-win32.7z",
+            "url": "https://get.videolan.org/vlc/3.0.7.1/win32/vlc-3.0.7.1-win32.7z",
             "hash": "9cb0e906141106994f29cdb6b2fd1594e9a906e6b44217e9b7313813f202e2df",
             "extract_dir": "vlc-3.0.7.1"
         }
@@ -28,11 +28,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.videolan.org/pub/vlc/$version/win64/vlc-$version-win64.7z",
+                "url": "https://get.videolan.org/vlc/$version/win64/vlc-$version-win64.7z",
                 "extract_dir": "vlc-$version"
             },
             "32bit": {
-                "url": "https://download.videolan.org/pub/vlc/$version/win32/vlc-$version-win32.7z",
+                "url": "https://get.videolan.org/vlc/$version/win32/vlc-$version-win32.7z",
                 "extract_dir": "vlc-$version"
             }
         },


### PR DESCRIPTION
I don't track VLC's mirror system, so I don't know if there was a wider change that didn't get picked up by Scoop or if it's just something that changed with newer releases of VLC. But, without this patch I'm unable to install VLC.