### PR TITLE
prime95: Fix checkver & au.*

### DIFF
--- a/bucket/prime95.json
+++ b/bucket/prime95.json
@@ -25,20 +25,24 @@
     ],
     "checkver": {
         "url": "https://www.mersenne.org/download/",
-        "regex": "Windows:\\s+64-bit</td><td>([^<]+)</td>"
+        "regex": "Windows:\\s+64-bit\\D+(?<version>[\\w.]+).*href=\"https?://www.mersenne.org/ftp_root/gimps/(?<file64>[^.]+).win64.zip\".*Windows:\\s+32-bit\\D+(?<version32>[\\w.]+).*href=\"https?://www.mersenne.org/ftp_root/gimps/(?<file32>[^.]+).win32.zip\""
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.mersenne.org/ftp_root/gimps/p95v$cleanVersion.win64.zip"
+                "url": "http://www.mersenne.org/ftp_root/gimps/$matchFile64.win64.zip",
+                "hash": {
+                    "url": "https://www.mersenne.org/download/",
+                    "find": "\\.win64\\.zip[^:]+SHA256:<br>$sha256"
+                }
             },
             "32bit": {
-                "url": "https://www.mersenne.org/ftp_root/gimps/p95v$cleanVersion.win32.zip"
+                "url": "http://www.mersenne.org/ftp_root/gimps/$matchFile32.win32.zip",
+                "hash": {
+                    "url": "https://www.mersenne.org/download/",
+                    "find": "\\.win32\\.zip[^:]+SHA256:<br>$sha256"
+                }
             }
-        },
-        "hash": {
-            "url": "https://www.mersenne.org/download/",
-            "find": "$basename[^>]+>[^>]+>[^>]+>[^>]+>SHA256:<br>([^<]+)"
         }
     }
 }

--- a/bucket/prime95.json
+++ b/bucket/prime95.json
@@ -30,14 +30,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.mersenne.org/ftp_root/gimps/$matchFile64.win64.zip",
+                "url": "https://www.mersenne.org/ftp_root/gimps/$matchFile64.win64.zip",
                 "hash": {
                     "url": "https://www.mersenne.org/download/",
                     "find": "\\.win64\\.zip[^:]+SHA256:<br>$sha256"
                 }
             },
             "32bit": {
-                "url": "http://www.mersenne.org/ftp_root/gimps/$matchFile32.win32.zip",
+                "url": "https://www.mersenne.org/ftp_root/gimps/$matchFile32.win32.zip",
                 "hash": {
                     "url": "https://www.mersenne.org/download/",
                     "find": "\\.win32\\.zip[^:]+SHA256:<br>$sha256"


### PR DESCRIPTION
Tested and working locally.
Fixes:
```
The remote server returned an error: (404) Not Found.
URL https://www.mersenne.org/ftp_root/gimps/p95v298b5.win32.zip is not valid
Could not find hash!
ERROR Could not update prime95 32bit