### PR TITLE
playnite: fix checkver

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -18,7 +18,8 @@
         "}"
     ],
     "checkver": {
-        "github": "https://github.com/JosefNemec/Playnite/"
+        "url": "https://github.com/JosefNemec/Playnite/releases",
+        "regex": "download/([\\d.]+)/Playnite\\d+.zip"
     },
     "autoupdate": {
         "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/Playnite$cleanVersion.zip"


### PR DESCRIPTION
mentioned in **Outstanding Excavator issues**(#2308).

The reason causing 404 error is that **Playnite 5.x is currently only available for patreons(paid subscribers)** (see https://github.com/JosefNemec/Playnite/releases)

This fixes the problem by modifying `checkver` to use regex to match downloadable files only, rather than using Github's version idendifiers.