### PR TITLE
praat: Fix checkver and autoupdate

### DIFF
--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/praat/praat/releases",
+        "github": "https://github.com/praat/praat",
         "regex": "download/v([\\d.]+)/(?<filename>praat\\d+)"
     },
     "autoupdate": {

--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.1",
+    "version": "6.0.56",
     "homepage": "http://www.fon.hum.uva.nl/praat/",
     "description": "A free cross-platform software for the scientific analysis of speech in phonetics",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win64.zip",
-            "hash": "569df5dc8f651acf2838796acb35fd83820840e408913ef1c18a46f5a9234692"
+            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win64.zip",
+            "hash": "6f9eda9f12b56aba824d630eabe8f0b2f326bdddb01145fcd64d9ae781629e69"
         },
         "32bit": {
-            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win32.zip",
-            "hash": "841c54d74ddd8844ac145ea213fbb0b2f854401445e84de5628dc124f1afae39"
+            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win32.zip",
+            "hash": "822fba26b4e965594d1998c64d9e3241ceb4a35fe6a0a01316a2e3adc7d26443"
         }
     },
     "bin": "Praat.exe",
@@ -21,16 +21,15 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/praat/praat/releases",
-        "regex": "download/v([\\d.]+)/(?<filename>praat\\d+)"
+        "github": "https://github.com/praat/praat"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win64.zip"
+                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win64.zip"
             },
             "32bit": {
-                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win32.zip"
+                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win32.zip"
             }
         }
     }

--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.1",
+    "version": "6.0.56",
     "homepage": "http://www.fon.hum.uva.nl/praat/",
     "description": "A free cross-platform software for the scientific analysis of speech in phonetics",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win64.zip",
-            "hash": "569df5dc8f651acf2838796acb35fd83820840e408913ef1c18a46f5a9234692"
+            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win64.zip",
+            "hash": "6f9eda9f12b56aba824d630eabe8f0b2f326bdddb01145fcd64d9ae781629e69"
         },
         "32bit": {
-            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win32.zip",
-            "hash": "841c54d74ddd8844ac145ea213fbb0b2f854401445e84de5628dc124f1afae39"
+            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win32.zip",
+            "hash": "822fba26b4e965594d1998c64d9e3241ceb4a35fe6a0a01316a2e3adc7d26443"
         }
     },
     "bin": "Praat.exe",

--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.0.56",
+    "version": "6.1",
     "homepage": "http://www.fon.hum.uva.nl/praat/",
     "description": "A free cross-platform software for the scientific analysis of speech in phonetics",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win64.zip",
-            "hash": "6f9eda9f12b56aba824d630eabe8f0b2f326bdddb01145fcd64d9ae781629e69"
+            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win64.zip",
+            "hash": "569df5dc8f651acf2838796acb35fd83820840e408913ef1c18a46f5a9234692"
         },
         "32bit": {
-            "url": "http://www.fon.hum.uva.nl/praat/praat6056_win32.zip",
-            "hash": "822fba26b4e965594d1998c64d9e3241ceb4a35fe6a0a01316a2e3adc7d26443"
+            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win32.zip",
+            "hash": "841c54d74ddd8844ac145ea213fbb0b2f854401445e84de5628dc124f1afae39"
         }
     },
     "bin": "Praat.exe",
@@ -21,15 +21,16 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/praat/praat"
+        "url": "https://github.com/praat/praat/releases",
+        "regex": "download/v([\\d.]+)/(?<filename>praat\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win64.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win64.zip"
             },
             "32bit": {
-                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win32.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win32.zip"
             }
         }
     }

--- a/bucket/praat.json
+++ b/bucket/praat.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.0.54",
+    "version": "6.1",
     "homepage": "http://www.fon.hum.uva.nl/praat/",
     "description": "A free cross-platform software for the scientific analysis of speech in phonetics",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "http://www.fon.hum.uva.nl/praat/praat6054_win64.zip",
-            "hash": "3da65b8d38501c022f91c1e09797f7ef3496ceb0b3b7612c09b3f732e7fde077"
+            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win64.zip",
+            "hash": "569df5dc8f651acf2838796acb35fd83820840e408913ef1c18a46f5a9234692"
         },
         "32bit": {
-            "url": "http://www.fon.hum.uva.nl/praat/praat6054_win32.zip",
-            "hash": "8334cbed9c11e59dd36e4efdcf38a82f6eb9a2339d8ece692c352259b9db5388"
+            "url": "https://github.com/praat/praat/releases/download/v6.1/praat6100_win32.zip",
+            "hash": "841c54d74ddd8844ac145ea213fbb0b2f854401445e84de5628dc124f1afae39"
         }
     },
     "bin": "Praat.exe",
@@ -21,15 +21,16 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/praat/praat"
+        "url": "https://github.com/praat/praat/releases",
+        "regex": "download/v([\\d.]+)/(?<filename>praat\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win64.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win64.zip"
             },
             "32bit": {
-                "url": "http://www.fon.hum.uva.nl/praat/praat$cleanVersion_win32.zip"
+                "url": "https://github.com/praat/praat/releases/download/v$version/$matchFilename_win32.zip"
             }
         }
     }


### PR DESCRIPTION
mentioned in **Outstanding Excavator issues** (#2308)

The file name for praat version 6.1 is **praat6100_win64.zip** rather than **praat61_win64.zip**.
This fixes the problem by matching file name using regex.