### PR TITLE
onefetch: Fix checkver

### DIFF
--- a/bucket/onefetch.json
+++ b/bucket/onefetch.json
@@ -5,7 +5,10 @@
     "license": "MIT",
     "notes": "You may have to enable ANSI Color Codes in your terminal. See https://stackoverflow.com/questions/51680709/",
     "bin": "onefetch.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/o2sh/onefetch/releases",
+        "regex": "download/v([\\d.]+)/onefetch_windows-x86_64.zip"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/o2sh/onefetch/releases/download/v1.5.4/onefetch_windows-x86_64.zip",


### PR DESCRIPTION
mentioned in Outstanding Excavator issues (#2308).

The problem is caused by that only some of the release versions has a Windows version of it (v1.5.4 has Windows version, but v1.5.5 does not) (see: https://github.com/o2sh/onefetch/releases)

This fixes the problem by manually matching "release files with Windows version" with regex.