### PR TITLE
uget: Update to 2.2.2 , and add au.hash

### DIFF
--- a/bucket/uget-portable.json
+++ b/bucket/uget-portable.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Open source download manager.",
     "homepage": "https://ugetdm.com/",
     "license": "LGPL-2.1-only",
-    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.1/uget-2.2.1-win32%2Bgtk3.7z",
-    "hash": "a722bd02a6d77ac24b8bb7d1b3a6c7f37ca4dbab40859264b1e50dedbcda584a",
+    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.2/uget-2.2.2-win32%2Bgtk3.7z",
+    "hash": "sha1:22d54d9f63be15228c21d06444e0a2c22b4e2578",
     "pre_install": "Move-Item \"$dir\\uget-portable-mode\" \"$dir\\bin\"",
     "persist": "config",
     "bin": "bin\\uget.exe",
@@ -15,10 +15,14 @@
         ]
     ],
     "checkver": {
-        "url": "https://ugetdm.com/downloads/windows/",
-        "regex": "Latest Stable Version: ([\\d\\.]+)"
+        "url": "https://sourceforge.net/projects/urlget/rss?path=/uget%20%28stable%29",
+        "regex": "/uget-([\\d.]+)-win32\\+gtk3\\.7z"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$version-win32%2Bgtk3.7z"
+        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$version-win32%2Bgtk3.7z",
+        "hash": {
+            "url": "https://sourceforge.net/projects/urlget/files/uget%20%28stable%29/$version/",
+            "regex": "\"sha1\": \"$sha1\", \"name\": \"uget-$version-win32\\+gtk3\\.7z\""
+        }
     }
 }

--- a/bucket/uget.json
+++ b/bucket/uget.json
@@ -1,10 +1,10 @@
 {
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "Open source download manager.",
     "homepage": "https://ugetdm.com/",
     "license": "LGPL-2.1-only",
-    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.1/uget-2.2.1-win32%2Bgtk3.7z",
-    "hash": "a722bd02a6d77ac24b8bb7d1b3a6c7f37ca4dbab40859264b1e50dedbcda584a",
+    "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/2.2.2/uget-2.2.2-win32%2Bgtk3.7z",
+    "hash": "sha1:22d54d9f63be15228c21d06444e0a2c22b4e2578",
     "bin": "bin\\uget.exe",
     "shortcuts": [
         [
@@ -13,10 +13,14 @@
         ]
     ],
     "checkver": {
-        "url": "https://ugetdm.com/downloads/windows/",
-        "regex": "Latest Stable Version: ([\\d\\.]+)"
+        "url": "https://sourceforge.net/projects/urlget/rss?path=/uget%20%28stable%29",
+        "regex": "/uget-([\\d.]+)-win32\\+gtk3\\.7z"
     },
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$version-win32%2Bgtk3.7z"
+        "url": "https://downloads.sourceforge.net/project/urlget/uget%20%28stable%29/$version/uget-$version-win32%2Bgtk3.7z",
+        "hash": {
+            "url": "https://sourceforge.net/projects/urlget/files/uget%20%28stable%29/$version/",
+            "regex": "\"sha1\": \"$sha1\", \"name\": \"uget-$version-win32\\+gtk3\\.7z\""
+        }
     }
 }


### PR DESCRIPTION
The official websit haven't update

Note: There is a locale package. After https://github.com/lukesampson/scoop/pull/3518 is merged we could add it.