### PR TITLE
Freecad: remove 32-bit, use portable version

### DIFF
--- a/bucket/freecad.json
+++ b/bucket/freecad.json
@@ -1,16 +1,12 @@
 {
-    "version": "0.18.2",
+    "version": "0.18.3",
     "description": "Free and open-source general-purpose parametric 3D CAD modeler and a building information modeling software with finite-element-method support.",
     "homepage": "https://www.freecadweb.org/",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.2/FreeCAD-0.18.16117.dbb4cc6-WIN-x64-installer.exe#/dl.7z",
-            "hash":"e2adfe5e692317735cf8c0a80e38e8b3d9dbc8ab241472b5e846e0a7d5be486c"
-        },
-        "32bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.2/FreeCAD-0.18.16117.dbb4cc6-WIN-x32-installer.exe#/dl.7z",
-            "hash":"10cae09ad5f86d8045a7ba0770f69ef5961f4d58a83ee87eb235a7b44ecdbd35"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.3/FreeCAD-0.18.16131.3129ae4-WIN-x64-portable.7z",
+            "hash": "2237f0ee8fc4998f949f7d66ebd4b7a1e5eb3fe0198e0951dd3a19e2fe6494e2"
         }
     },
     "bin": "bin\\FreeCADCmd.exe",
@@ -20,7 +16,6 @@
             "FreeCAD"
         ]
     ],
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse -Force",
     "checkver": {
         "github": "https://github.com/FreeCAD/FreeCAD/",
         "regex": "releases/download/([\\d.]+)/FreeCAD-(?<build>[\\w.]+)-WIN"
@@ -28,10 +23,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$version/FreeCAD-$matchBuild-WIN-x64-installer.exe#/dl.7z"
-            },
-            "32bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$version/FreeCAD-$matchBuild-WIN-x32-installer.exe#/dl.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/$version/FreeCAD-$matchBuild-WIN-x64-portable.7z"
             }
         }
     }


### PR DESCRIPTION
mentioned in #2308 (Outstanding Excavator Issues).

**FreeCAD** does not provide 32-bit binaries in newer versions, therefore causing the issue.

Notes:
* Remove 32-bit binaries.
* Use **portable version**(.7z) instead of extracting files from the installer(.msi).
* FreeCAD provides checksum files ([link](https://github.com/FreeCAD/FreeCAD/releases/download/0.18.3/FreeCAD-0.18.16131.3129ae4-WIN-x64-portable.7z-SHA256.txt)), but there are **line breaks**(\r\n) in the middle of the hash string.