### PR TITLE
Libre Office Stable: Add version 6.2.5

### DIFF
--- a/bucket/libreoffice-stable.json
+++ b/bucket/libreoffice-stable.json
@@ -1,0 +1,63 @@
+{
+    "version": "6.2.5",
+    "description": "Powerful office suite.",
+    "homepage": "https://libreoffice.org/",
+    "license": "MPL-2.0",
+    "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/6.2.5.2/portable/LibreOfficePortable_6.2.5_MultilingualStandard.paf.exe#/dl.7z",
+    "hash": "55c462c4e07690cdfef832aace013115b5480238c40a83b0707144145dc1c963",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\Data\\settings\")) {",
+        "    New-Item \"$dir\\Data\\settings\\LibreOfficePortableSettings.ini\" -Value \"[LibreOfficePortableSettings]`nInvalidPackageWarningShown=$version.0\" -Force | Out-Null",
+        "    if (Test-Path \"$Env:AppData\\LibreOffice\") {",
+        "        Write-Host -F yellow \"Copying old '$Env:AppData\\LibreOffice' to '$persist_dir\\Data\\settings'\"",
+        "        Get-Item \"$Env:AppData\\LibreOffice\\*\\*\" | Copy-Item -Destination \"$dir\\Data\\settings\" -Recurse -Force",
+        "    }",
+        "    else { Copy-Item \"$dir\\App\\DefaultData\\*\" \"$dir\\Data\" -Recurse -Force }",
+        "}",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force"
+    ],
+    "shortcuts": [
+        [
+            "LibreOfficePortable.exe",
+            "LibreOffice\\LibreOffice"
+        ],
+        [
+            "LibreOfficeBasePortable.exe",
+            "LibreOffice\\LibreOffice Base"
+        ],
+        [
+            "LibreOfficeCalcPortable.exe",
+            "LibreOffice\\LibreOffice Calc"
+        ],
+        [
+            "LibreOfficeDrawPortable.exe",
+            "LibreOffice\\LibreOffice Draw"
+        ],
+        [
+            "LibreOfficeImpressPortable.exe",
+            "LibreOffice\\LibreOffice Impress"
+        ],
+        [
+            "LibreOfficeMathPortable.exe",
+            "LibreOffice\\LibreOffice Math"
+        ],
+        [
+            "LibreOfficeWriterPortable.exe",
+            "LibreOffice\\LibreOffice Writer"
+        ]
+    ],
+    "persist": "Data",
+    "checkver": {
+        "url": "https://download.documentfoundation.org/libreoffice/portable/?C=M;O=D",
+        "regex": ">([\\d.]+)/<"
+    },
+    "autoupdate": {
+        "url": "https://downloadarchive.documentfoundation.org/libreoffice/old/$version.2/portable/LibreOfficePortable_$version_MultilingualStandard.paf.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2015"
+    }
+}


### PR DESCRIPTION
Only stable version has portable version. There is only a x86 version. I don't want to add so many shortcuts, maybe we can remove them except the libreoffice?