### PR TITLE
octant: Add version 0.4.1

### DIFF
--- a/bucket/octant.json
+++ b/bucket/octant.json
@@ -1,0 +1,24 @@
+{
+    "homepage": "https://github.com/vmware/octant",
+    "description": "A web-based, highly extensible platform for developers to better understand the complexity of Kubernetes clusters.",
+    "license": "Apache-2.0",
+    "version": "0.4.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/vmware/octant/releases/download/v0.4.0/octant_0.4.1_Windows-64bit.zip",
+            "hash": "eb951990bc4e04d4faf37671f166c51ebeb9f6bc5a1cc286bcf8f94c4db0693e"
+        }
+    },
+    "bin": "octant.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/vmware/octant/releases/download/v$version/octant_$version_Windows-64bit.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
octant is an augmented [kubectl](https://github.com/ScoopInstaller/Main/blob/master/bucket/kubectl.json) that provides detailed information about a Kubernetes cluster in a browser. Since it is not strictly a CLI tool, this PR is made to the extra rather than main bucket.

Let me know if this change can be made against main instead so that related tooling can installed from a single bucket.