### PR TITLE
ios-webkit-debug-proxy: Fix checkver

### DIFF
--- a/bucket/ios-webkit-debug-proxy.json
+++ b/bucket/ios-webkit-debug-proxy.json
@@ -9,7 +9,10 @@
         }
     },
     "bin": "ios_webkit_debug_proxy.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/google/ios-webkit-debug-proxy/releases",
+        "regex": "/ios-webkit-debug-proxy-([\\d.]+)-win64-bin.zip"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Simply extract version numbers from the latest .zip file to skip some versions without windows build.

https://github.com/google/ios-webkit-debug-proxy/issues/316