### PR TITLE
Improve gnucash manifest

### DIFF
--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -5,7 +5,7 @@
     "version": "3.6",
     "url": "https://github.com/Gnucash/gnucash/releases/download/3.6/gnucash-3.6.setup.exe",
     "hash": "cb8ba5aa13dce6c9caedfb774abef47b8e352c2cda7d762d3f74840f1b12766a",
-    "bin": "bin/gnucash.exe",
+    "bin": "bin\\gnucash.exe",
     "innosetup": true,
     "shortcuts": [
         [

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -9,7 +9,7 @@
     "innosetup": true,
     "shortcuts": [
         [
-            "bin/gnucash.exe",
+            "bin\\gnucash.exe",
             "GnuCash"
         ]
     ],

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -18,5 +18,9 @@
     },
     "autoupdate": {
         "url": "https://github.com/Gnucash/gnucash/releases/download/$version/gnucash-$version.setup.exe",
+        "hash": {
+            "url": "https://github.com/Gnucash/gnucash/releases",
+            "find": "([A-Fa-f\\d]{64}).*gnucash-$version.setup.exe"
+        }
     }
 }

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -3,7 +3,7 @@
     "description": "Personal and small-business financial-accounting software",
     "license": "GPL-2.0-or-later",
     "version": "3.6",
-    "url": "https://downloads.sourceforge.net/project/gnucash/gnucash%20%28stable%29/3.2/gnucash-3.2.setup.exe#/gnucash-setup.exe",
+    "url": "https://github.com/Gnucash/gnucash/releases/download/3.6/gnucash-3.6.setup.exe",
     "hash": "cb8ba5aa13dce6c9caedfb774abef47b8e352c2cda7d762d3f74840f1b12766a",
     "innosetup": true,
     "shortcuts": [
@@ -13,6 +13,6 @@
         ]
     ],
     "autoupdate": {
-        "url": "https://downloads.sourceforge.net/project/gnucash/gnucash%20%28stable%29/$version/gnucash-$version-setup.exe#/gnucash-setup.exe"
+        "url": "https://github.com/Gnucash/gnucash/releases/download/$version/gnucash-$version.setup.exe",
     }
 }

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -2,9 +2,9 @@
     "homepage": "https://www.gnucash.org/",
     "description": "Personal and small-business financial-accounting software",
     "license": "GPL-2.0-or-later",
-    "version": "3.2",
+    "version": "3.6",
     "url": "https://downloads.sourceforge.net/project/gnucash/gnucash%20%28stable%29/3.2/gnucash-3.2.setup.exe#/gnucash-setup.exe",
-    "hash": "0e06acfe7a9746eacf5282ba27919625b51c3d51fd548e6a529f78ff759ed70f",
+    "hash": "cb8ba5aa13dce6c9caedfb774abef47b8e352c2cda7d762d3f74840f1b12766a",
     "innosetup": true,
     "shortcuts": [
         [

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -13,6 +13,9 @@
             "GnuCash"
         ]
     ],
+    "checkver": {
+        "github": "https://github.com/Gnucash/gnucash"
+    },
     "autoupdate": {
         "url": "https://github.com/Gnucash/gnucash/releases/download/$version/gnucash-$version.setup.exe",
     }

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -20,7 +20,7 @@
         "url": "https://github.com/Gnucash/gnucash/releases/download/$version/gnucash-$version.setup.exe",
         "hash": {
             "url": "https://github.com/Gnucash/gnucash/releases/tag/$version",
-            "find": "([A-Fa-f\\d]{64}).*gnucash-$version.setup.exe"
+            "regex": "$sha256.*?$basename"
         }
     }
 }

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -19,7 +19,7 @@
     "autoupdate": {
         "url": "https://github.com/Gnucash/gnucash/releases/download/$version/gnucash-$version.setup.exe",
         "hash": {
-            "url": "https://github.com/Gnucash/gnucash/releases",
+            "url": "https://github.com/Gnucash/gnucash/releases/tag/$version",
             "find": "([A-Fa-f\\d]{64}).*gnucash-$version.setup.exe"
         }
     }

--- a/bucket/gnucash.json
+++ b/bucket/gnucash.json
@@ -5,6 +5,7 @@
     "version": "3.6",
     "url": "https://github.com/Gnucash/gnucash/releases/download/3.6/gnucash-3.6.setup.exe",
     "hash": "cb8ba5aa13dce6c9caedfb774abef47b8e352c2cda7d762d3f74840f1b12766a",
+    "bin": "bin/gnucash.exe",
     "innosetup": true,
     "shortcuts": [
         [


### PR DESCRIPTION
Hi, 

The original manifest points to the sourceforge repository so I changed the url field to the gnucash github repository for convenience.

I also added :
- A bin field to allow scoop to create a shim
- A checkver field pointing to the github repository
- A hash field to grab the latest version hash with a regex