### PR TITLE
Add PureRef 1.9.2

### DIFF
--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -3,7 +3,9 @@
     "version": "1.9.2",
     "description": "Simple and lightweight tool for artists to organize and view reference images",
     "license": "Freeware",
-<<<<<<< HEAD
+    "suggest": {
+        "Microsoft Visual C++ Redistributables 2015": "extras/vcredist2015"
+    },
     "bin": "PureRef.exe",
     "shortcuts": [
         [
@@ -11,11 +13,6 @@
             "PureRef"
         ]
     ],
-=======
-    "suggest": {
-        "Microsoft Visual C++ Redistributables 2015": "extras/vcredist2015"
-    },
->>>>>>> 2f40b241... Remove extract_dir
     "architecture": {
         "64bit": {
             "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",

--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -3,6 +3,7 @@
     "version": "1.9.2",
     "description": "Simple and lightweight tool for artists to organize and view reference images",
     "license": "Freeware",
+<<<<<<< HEAD
     "bin": "PureRef.exe",
     "shortcuts": [
         [
@@ -10,16 +11,26 @@
             "PureRef"
         ]
     ],
+=======
+    "suggest": {
+        "Microsoft Visual C++ Redistributables 2015": "extras/vcredist2015"
+    },
+>>>>>>> 2f40b241... Remove extract_dir
     "architecture": {
         "64bit": {
             "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
-            "extract_dir": "pureref-$version"
         },
         "32bit": {
             "url": "https://www.pureref.com/files/portable.php?build=WIN32#/PureRef.exe",
-            "extract_dir": "pureref-$version"
         }
     },
+    "bin": "PureRef.exe",
+    "shortcuts": [
+        [
+            "PureRef.exe",
+            "PureRef"
+        ]
+    ],
     "checkver": {
         "url": "https://www.pureref.com/changelog.php",
         "re": "Version\\s+([\\d.]+)"
@@ -28,11 +39,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
-                "extract_dir": "pureref-$version"
             },
             "32bit": {
                 "url": "https://www.pureref.com/files/portable.php?build=WIN32/PureRef.exe",
-                "extract_dir": "pureref-$version"
             }
         }
     }

--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -1,0 +1,39 @@
+{
+    "homepage": "https://www.pureref.com/",
+    "version": "1.9.2",
+    "description": "Simple and lightweight tool for artists to organize and view reference images",
+    "license": "Freeware",
+    "bin": "PureRef.exe",
+    "shortcuts": [
+        [
+            "PureRef.exe",
+            "PureRef"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
+            "extract_dir": "pureref-$version"
+        },
+        "32bit": {
+            "url": "https://www.pureref.com/files/portable.php?build=WIN32#/PureRef.exe",
+            "extract_dir": "pureref-$version"
+        }
+    },
+    "checkver": {
+        "url": "https://www.pureref.com/changelog.php",
+        "re": "Version\\s+([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
+                "extract_dir": "pureref-$version"
+            },
+            "32bit": {
+                "url": "https://www.pureref.com/files/portable.php?build=WIN32/PureRef.exe",
+                "extract_dir": "pureref-$version"
+            }
+        }
+    }
+}

--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -16,9 +16,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
+            "hash": "deadb1491977dd02e4be49b0b049e1dfa5c90d09c485bdb96df63824d5c9b3bd"
         },
         "32bit": {
             "url": "https://www.pureref.com/files/portable.php?build=WIN32#/PureRef.exe",
+            "hash": "09b26fe2f0dc7c0d336395838dc10b427656b3981319b86a13fa28855c0f43b0"
         }
     },
     "bin": "PureRef.exe",

--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -37,10 +37,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe",
+                "url": "https://www.pureref.com/files/portable.php?build=WIN64#/PureRef.exe"
             },
             "32bit": {
-                "url": "https://www.pureref.com/files/portable.php?build=WIN32/PureRef.exe",
+                "url": "https://www.pureref.com/files/portable.php?build=WIN32#/PureRef.exe"
             }
         }
     }


### PR DESCRIPTION
https://www.pureref.com/

PureRef is a freeware (no license restrictions) tool for artists to visualize and organize their reference images on a board.
You can add images through drag-and-drop and pasting.

I could not find any page that references the hashes for the executables so I'm leaving it to scoop to calculate them.

I tested this locally and it works fine.
If anything else is needed, please tell.