### PR TITLE
mupdf: fix hash

### DIFF
--- a/bucket/mupdf.json
+++ b/bucket/mupdf.json
@@ -4,7 +4,7 @@
     "version": "1.16.0-rc2",
     "license": "AGPL-3.0-only",
     "url": "https://mupdf.com/downloads/archive/mupdf-1.16.0-rc2-windows.zip",
-    "hash": "sha1:82d40bd958a2e291592363fef60c1c163862df59",
+    "hash": "sha1:12be67e1db33cc6e45394e73a87aac2151cd947c",
     "extract_dir": "mupdf-1.16.0-windows",
     "bin": [
         "mupdf.exe",


### PR DESCRIPTION
Fix #2515.

It looks like that the developers of **mupdf** has modified the file (a minor update/fix?) without updating the version number.