### PR TITLE
testcentric: Fix au.url

### DIFF
--- a/bucket/testcentric.json
+++ b/bucket/testcentric.json
@@ -31,6 +31,6 @@
         "regex": "tag/(.*)\""
     },
     "autoupdate": {
-        "url": "https://github.com/TestCentric/testcentric-gui/releases/download/$version/testcentric-gui.$majorVersion.$minorVersion-$preReleaseVersion.nupkg"
+        "url": "https://github.com/TestCentric/testcentric-gui/releases/download/$version/testcentric-gui.$version.nupkg"
     }
 }

--- a/bucket/testcentric.json
+++ b/bucket/testcentric.json
@@ -26,10 +26,7 @@
             "nunit-extension-vs-project-loader"
         ]
     },
-    "checkver": {
-        "url": "https://github.com/TestCentric/testcentric-gui/releases",
-        "regex": "tag/(.*)\""
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/TestCentric/testcentric-gui/releases/download/$version/testcentric-gui.$version.nupkg"
     }


### PR DESCRIPTION
Fixes:
```
testcentric: 1.0.0 (scoop version is 1.0.0-beta4)
Autoupdating testcentric
DEBUG[1564236017] $substitutions (hashtable) -> /root/scoop/lib/autoupdate.ps1:181:5
DEBUG[1564236017] $substitutions.$dashVersion                   1-0-0
DEBUG[1564236017] $substitutions.$cleanVersion                  100
DEBUG[1564236017] $substitutions.$majorVersion                  1
DEBUG[1564236017] $substitutions.$basename                      testcentric-gui.1.0-1.0.0.nupkg
DEBUG[1564236017] $substitutions.$url                           https://github.com/TestCentric/testcentric-gui/releases/download/1.0.0/testcentric-gui.1…
DEBUG[1564236017] $substitutions.$match1                        1.0.0
DEBUG[1564236017] $substitutions.$underscoreVersion             1_0_0
DEBUG[1564236017] $substitutions.$patchVersion                  0
DEBUG[1564236017] $substitutions.$version                       1.0.0
DEBUG[1564236017] $substitutions.$matchTail                     
DEBUG[1564236017] $substitutions.$baseurl                       https://github.com/TestCentric/testcentric-gui/releases/download/1.0.0
DEBUG[1564236017] $substitutions.$buildVersion                  
DEBUG[1564236017] $substitutions.$matchHead                     1.0.0
DEBUG[1564236017] $substitutions.$preReleaseVersion             1.0.0
DEBUG[1564236017] $substitutions.$minorVersion                  0
DEBUG[1564236017] $hashfile_url = $null -> /root/scoop/lib/autoupdate.ps1:184:5
Downloading testcentric-gui.1.0-1.0.0.nupkg to compute hashes!
The remote server returned an error: (404) Not Found.
URL https://github.com/TestCentric/testcentric-gui/releases/download/1.0.0/testcentric-gui.1.0-1.0.0.nupkg is not valid
Could not find hash!
ERROR Could not update testcentric