### PR TITLE
NetBeans: modify checkver

### DIFF
--- a/bucket/netbeans.json
+++ b/bucket/netbeans.json
@@ -26,7 +26,7 @@
     },
     "checkver": {
         "url": "https://netbeans.apache.org/download/index.html",
-        "re": "Apache NetBeans ([\\d.]+)</h1>"
+        "regex": "\\(NB ([\\d.]+)\\)</h2>"
     },
     "autoupdate": {
         "url": "https://www.apache.org/dist/netbeans/netbeans/$version/netbeans-$version-bin.zip",


### PR DESCRIPTION
This matches the section under "Apache NetBeans Releases" (the green box) instead of the top section of the page (the red box).

It looks like that the top section can be used by some other notifications (other than version update), which may lead to `checkver` error in the future.

![apache](https://user-images.githubusercontent.com/27724471/62030232-4699fe80-b217-11e9-929a-8dffc0665be1.png)