### PR TITLE
CodeBlocks: Add version 17.12

### DIFF
--- a/bucket/codeblocks-mingw.json
+++ b/bucket/codeblocks-mingw.json
@@ -17,6 +17,6 @@
         "regex": "Binaries/([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/$version/Windows/codeblocks-$versionmingw-nosetup.zip"
+        "url": "https://downloads.sourceforge.net/project/codeblocks/Binaries/$version/Windows/codeblocks-$versionmingw-nosetup.zip"
     }
 }

--- a/bucket/codeblocks-mingw.json
+++ b/bucket/codeblocks-mingw.json
@@ -1,0 +1,22 @@
+{
+    "version": "17.12",
+    "description": "Free open-source C/C++/Fortran IDE (includes additional GCC/G++ compiler and GDB debugger)",
+    "license": "GPL-3.0-only",
+    "homepage": "http://www.codeblocks.org",
+    "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/17.12/Windows/codeblocks-17.12mingw-nosetup.zip",
+    "hash": "sha1:4d9ca5304fd135894384453c82e472861c61f67a",
+    "bin": "codeblocks.exe",
+    "shortcuts": [
+        [
+            "codeblocks.exe",
+            "CodeBlocks"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/",
+        "regex": "Binaries/([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/$version/Windows/codeblocks-$versionmingw-nosetup.zip"
+    }
+}

--- a/bucket/codeblocks.json
+++ b/bucket/codeblocks.json
@@ -21,6 +21,6 @@
         "regex": "Binaries/([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/$version/Windows/codeblocks-$version-nosetup.zip"
+        "url": "https://downloads.sourceforge.net/project/codeblocks/Binaries/$version/Windows/codeblocks-$version-nosetup.zip"
     }
 }

--- a/bucket/codeblocks.json
+++ b/bucket/codeblocks.json
@@ -5,10 +5,10 @@
     "homepage": "http://www.codeblocks.org",
     "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/17.12/Windows/codeblocks-17.12-nosetup.zip",
     "hash": "sha1:7ca7bae6945cfbf40aeaecd461df35e03ce1f9a1",
-	"notes": [
-		"This is the standalone version of the Code::Blocks IDE (does not include compilers/debuggers)",
-		"Check 'codeblocks-mingw' for Code::Blocks with integrated compilers/debuggers"
-	],
+    "notes": [
+        "This is the standalone version of the Code::Blocks IDE (does not include compilers/debuggers)",
+        "Check 'codeblocks-mingw' for Code::Blocks with integrated compilers/debuggers"
+    ],
     "bin": "codeblocks.exe",
     "shortcuts": [
         [

--- a/bucket/codeblocks.json
+++ b/bucket/codeblocks.json
@@ -1,0 +1,26 @@
+{
+    "version": "17.12",
+    "description": "Free open-source C/C++/Fortran IDE (standalone version)",
+    "license": "GPL-3.0-only",
+    "homepage": "http://www.codeblocks.org",
+    "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/17.12/Windows/codeblocks-17.12-nosetup.zip",
+    "hash": "sha1:7ca7bae6945cfbf40aeaecd461df35e03ce1f9a1",
+	"notes": [
+		"This is the standalone version of the Code::Blocks IDE (does not include compilers/debuggers)",
+		"Check 'codeblocks-mingw' for Code::Blocks with integrated compilers/debuggers"
+	],
+    "bin": "codeblocks.exe",
+    "shortcuts": [
+        [
+            "codeblocks.exe",
+            "CodeBlocks"
+        ]
+    ],
+    "checkver": {
+        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/",
+        "regex": "Binaries/([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://sourceforge.net/projects/codeblocks/files/Binaries/$version/Windows/codeblocks-$version-nosetup.zip"
+    }
+}


### PR DESCRIPTION
**Code::Blocks** ([homepage](http://http://www.codeblocks.org)) is an open-source C/C++/Fortran IDE.

Notes:
* licenses: I marked the license as `GPL-3.0-only` according to https://github.com/lukesampson/scoop/issues/3546 (**Calinou**'s comment) and [the licensing page](http://www.codeblocks.org/license) from Code::Block's official site.

Please let me know if there are any problems. Thanks.