### PR TITLE
todotxt-net: Add version 3.3.0

### DIFF
--- a/bucket/todotxt-net.json
+++ b/bucket/todotxt-net.json
@@ -2,7 +2,7 @@
     "homepage": "https://benrhughes.github.io/todotxt.net/",
     "description": "Implementation of todo.txt for Windows using the .NET framework",
     "version": "3.3.0",
-    "license": "BSD-3-Clause",
+    "license": "BSD-2-Clause-FreeBSD",
     "url": "https://github.com/benrhughes/todotxt.net/releases/download/v3.3.0/todotxt-portable.zip",
     "hash": "1c0fe0d37d5519af0e701aebcd47ee17a39751386b18f8e216976c8f75bcf636",
     "extract_dir": "ProgramFiles",

--- a/bucket/todotxt-net.json
+++ b/bucket/todotxt-net.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "http://benrhughes.github.io/todotxt.net/",
+    "description": "Implementation of todo.txt for Windows using the .NET framework",
+    "version": "3.3.0",
+    "license": "BSD-3-Clause",
+    "url": "https://github.com/benrhughes/todotxt.net/releases/download/v3.3.0/todotxt-portable.zip",
+    "hash": "1c0fe0d37d5519af0e701aebcd47ee17a39751386b18f8e216976c8f75bcf636",
+    "extract_dir": "ProgramFiles",
+    "bin": "todotxt.exe",
+    "shortcuts": [
+        [
+            "todotxt.exe",
+            "todotxt.net"
+        ]
+    ],
+    "persist": "todotxt.exe.config",
+    "checkver": {
+        "github": "https://github.com/benrhughes/todotxt.net/"
+    },
+    "autoupdate": {
+        "url": "https://github.com/benrhughes/todotxt.net/releases/download/v$version/todotxt-portable.zip"
+    }
+}

--- a/bucket/todotxt-net.json
+++ b/bucket/todotxt-net.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://benrhughes.github.io/todotxt.net/",
+    "homepage": "https://benrhughes.github.io/todotxt.net/",
     "description": "Implementation of todo.txt for Windows using the .NET framework",
     "version": "3.3.0",
     "license": "BSD-3-Clause",


### PR DESCRIPTION
Closes https://github.com/ScoopInstaller/Main/issues/277.

**todotxt.net** ([homepage](http://benrhughes.github.io/todotxt.net/)) is an implementation of *todo.txt* for Windows using the .NET framework.

Please let me know if there are any problems. Thanks.