### PR TITLE
flashplayer-sa: Add version 32.0.0.223

### DIFF
--- a/bucket/flashplayer-sa.json
+++ b/bucket/flashplayer-sa.json
@@ -1,0 +1,28 @@
+{
+    "version": "32.0.0.223",
+    "description": "Standalone version of Adobe Flash Player",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.adobe.com/content/dam/acom/en/legal/licenses-terms/pdf/Flash_Player_32_0.pdf"
+    },
+    "homepage": "https://get.adobe.com/flashplayer/",
+    "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flashplayer_32_sa.exe",
+    "hash": "ab682ed56c9518621776fd5f101b0fb44fb6355423ca1ffd6b572651148bd231",
+    "installer": {
+        "script": "Get-ChildItem -Path \"$dir\\flashplayer_*_sa.exe\" | Rename-Item -NewName flashplayer.exe"
+    },
+    "bin": "flashplayer.exe",
+    "shortcuts": [
+        [
+            "flashplayer.exe",
+            "Adobe Flash Player"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.adobe.com/support/flashplayer/debug_downloads.html",
+        "regex": "The latest versions are <span>([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/$majorVersion/flashplayer_$majorVersion_sa.exe"
+    }
+}

--- a/bucket/flashplayer-sa.json
+++ b/bucket/flashplayer-sa.json
@@ -6,11 +6,8 @@
         "url": "https://www.adobe.com/content/dam/acom/en/legal/licenses-terms/pdf/Flash_Player_32_0.pdf"
     },
     "homepage": "https://get.adobe.com/flashplayer/",
-    "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flashplayer_32_sa.exe",
+    "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/32/flashplayer_32_sa.exe#/flashplayer.exe",
     "hash": "ab682ed56c9518621776fd5f101b0fb44fb6355423ca1ffd6b572651148bd231",
-    "installer": {
-        "script": "Get-ChildItem -Path \"$dir\\flashplayer_*_sa.exe\" | Rename-Item -NewName flashplayer.exe"
-    },
     "bin": "flashplayer.exe",
     "shortcuts": [
         [

--- a/bucket/flashplayer-sa.json
+++ b/bucket/flashplayer-sa.json
@@ -23,6 +23,6 @@
         "regex": "The latest versions are <span>([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/$majorVersion/flashplayer_$majorVersion_sa.exe"
+        "url": "https://fpdownload.macromedia.com/pub/flashplayer/updaters/$majorVersion/flashplayer_$majorVersion_sa.exe#/flashplayer.exe"
     }
 }


### PR DESCRIPTION
close #2533.

This is the standalone version of **Adobe Flash Player**.
([download page](https://www.adobe.com/support/flashplayer/debug_downloads.html))

Notes:
* The filename flashplayer_**32**_sa.exe denotes **version 32** rather than 32-bit. See [archived download page from 2016](https://web.archive.org/web/20160217151701/https://www.adobe.com/support/flashplayer/debug_downloads.html) for example.

* Adobe only provides 32-bit standalone binaries for Windows.