### PR TITLE
v2rayn: Fix hash

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
     "url": "https://github.com/2dust/v2rayN/releases/download/2.30/v2rayN.zip",
-    "hash": "ce514de2f6c1d7b505dccacffd35b13ff8c6ad24c7c892ded31561b1231642cb",
+    "hash": "dd893a0ef1fdb7486114a1350a6eda8f911f0bba2d7b7d60d3e64e221be14fc3",
     "extract_dir": "v2rayN",
     "bin": "v2rayN.exe",
     "persist": [


### PR DESCRIPTION
Fix #2548.

It looks like that the developer of **v2rayn** has modified the files without updating the version number.