### PR TITLE
GeekBench: Add version 4.4.1

### DIFF
--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -10,9 +10,9 @@
     "hash": "be78bd53fc9603ac11cf786850960c8ebe26b2613144ae8c00abcdc2a845ecee",
     "installer": {
         "script": [
-            "$majorVersion = $version.split('.')[0]",
-            "Dir \"$dir\\GeekBench $majorVersion.exe\"| Rename-Item -NewName geekbench_gui.exe",
-            "Dir \"$dir\\GeekBench$majorVersion.exe\"| Rename-Item -NewName geekbench.exe"
+            "Rename-Item \"$dir\\geekbench ?.exe\" 'geekbench_gui.exe'",
+            "Rename-Item \"$dir\\geekbench?.exe\" 'geekbench.exe'",
+            "Remove-Item \"$dir\\Uninstall*\", \"$dir\\$*\" -Recurse"
         ]
     },
     "bin": "geekbench.exe",

--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -3,7 +3,7 @@
     "description": "CPU/GPU benchmark software",
     "version": "4.4.1",
     "license": {
-        "identifier": "proprietary",
+        "identifier": "Proprietary",
         "url": "https://www.primatelabs.com/legal/eula-v4.html"
     },
     "url": "https://cdn.geekbench.com/Geekbench-4.4.1-WindowsSetup.exe#/dl.7z",

--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -1,0 +1,32 @@
+{
+    "homepage": "https://www.geekbench.com/",
+    "description": "CPU/GPU benchmark software",
+    "version": "4.4.1",
+    "license": {
+        "identifier": "proprietary",
+        "url": "https://www.primatelabs.com/legal/eula-v4.html"
+    },
+    "url": "https://cdn.geekbench.com/Geekbench-4.4.1-WindowsSetup.exe#/dl.7z",
+    "hash": "be78bd53fc9603ac11cf786850960c8ebe26b2613144ae8c00abcdc2a845ecee",
+    "installer": {
+        "script": [
+            "$majorVersion = $version.split('.')[0]",
+            "Dir \"$dir\\GeekBench $majorVersion.exe\"| Rename-Item -NewName geekbench_gui.exe",
+            "Dir \"$dir\\GeekBench$majorVersion.exe\"| Rename-Item -NewName geekbench.exe"
+        ]
+    },
+    "bin": "geekbench.exe",
+    "shortcuts": [
+        [
+            "geekbench_gui.exe",
+            "GeekBench"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.geekbench.com/download/windows/",
+        "regex": "Geekbench-([\\d.]+)-WindowsSetup.exe"
+    },
+    "autoupdate": {
+        "url": "https://cdn.geekbench.com/Geekbench-$version-WindowsSetup.exe#/dl.7z"
+    }
+}


### PR DESCRIPTION
**GeekBench** ([homepage](https://www.geekbench.com/)) is a CPU/GPU benchmark software.

Notes:
* Executable names are originally `geekbench4.exe` (console version) and `GeekBench 4.exe` (GUI version). I renamed them as `geekbench.exe` and `geekbench_gui.exe` to avoid error when major version changes (4.x -> 5.x).

* GeekBench is not a free software, but users can still perform benchmarks in "tryout mode". (paid version supports more features)

* I marked the license as **proprietary**. Is this correct?
