### PR TITLE
BPGconv: Add version 2.5

### DIFF
--- a/bucket/bpgconv.json
+++ b/bucket/bpgconv.json
@@ -14,8 +14,6 @@
         ]
     ],
     "checkver": "<span itemprop=\"softwareVersion\">([\\d.]+)",
-        "regex": "<span itemprop=\"softwareVersion\">([\\d.]+)"
-    },
     "autoupdate": {
         "url": "http://www.romeolight.com/download/BPGconvPortable.zip"
     }

--- a/bucket/bpgconv.json
+++ b/bucket/bpgconv.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "http://www.romeolight.com/products/bpgconv/",
+    "description": "Batch conversion tool for BPG images",
+    "version": "2.5",
+    "license": "BSD-2-Clause",
+    "url": "http://www.romeolight.com/download/BPGconvPortable.zip",
+    "hash": "94528b44368bbe1e02f7bac37d0f433bca5e3701465b63c6f3eb892ee72cbe90",
+    "extract_dir": "BPGconvPortable",
+    "bin": "BPGconv.exe",
+    "shortcuts": [
+        [
+            "BPGconv.exe",
+            "BPGconv"
+        ]
+    ],
+    "checkver": {
+        "regex": "<span itemprop=\"softwareVersion\">([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://www.romeolight.com/download/BPGconvPortable.zip"
+    }
+}

--- a/bucket/bpgconv.json
+++ b/bucket/bpgconv.json
@@ -13,7 +13,7 @@
             "BPGconv"
         ]
     ],
-    "checkver": {
+    "checkver": "<span itemprop=\"softwareVersion\">([\\d.]+)",
         "regex": "<span itemprop=\"softwareVersion\">([\\d.]+)"
     },
     "autoupdate": {


### PR DESCRIPTION
**BPGconv** ([homepage](http://www.romeolight.com/products/bpgconv/)) is a batch conversion tool for [BPG images](https://en.wikipedia.org/wiki/Better_Portable_Graphics).

Notes:
* The `BSD-2-Clause` license is contained in `license.txt`.

* The config file is named as `Romeolight BPGconv_2.5.0.0.config`. I could not find a simple way to "persist" the config file (other than using install/uninstall script, which can be very messy.)

* The website(www.romeolight.com) does not support HTTPS.

