### PR TITLE
Add VBoxVmService (a Virtualbox-related tool)

### DIFF
--- a/bucket/vboxvmservice.json
+++ b/bucket/vboxvmservice.json
@@ -1,0 +1,27 @@
+{
+    "version": "6.0-Pumpkin",
+    "description": "Windows Service to run VirtualBox VMs automatically.",
+    "homepage": "https://github.com/onlyfang/VBoxVmService/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/onlyfang/VBoxVmService/blob/master/doc/Licence.txt"
+    },
+    "url": "https://github.com/onlyfang/VBoxVmService/releases/download/6.0-Pumpkin/VBoxVmService-6.0-Pumpkin.exe",
+    "hash": "24cc6dcf0c5f8c25fca5181952e86c5525d83f981caece6c5de1f3e1ec673546",
+    "innosetup": true,
+    "bin": "VmServiceControl.exe",
+    "shortcuts": [
+        [
+            "VmServiceTray.exe",
+            "VmServiceTray"
+        ]
+    ],
+    "persist": "VBoxVmService.ini",
+    "checkver": {
+        "github": "https://github.com/onlyfang/VBoxVmService/",
+        "regex": "/VBoxVmService-([\\w.-]+)\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://github.com/onlyfang/VBoxVmService/releases/download/$version/VBoxVmService-$version.exe"
+    }
+}


### PR DESCRIPTION
As a side note, the project moved to Github last year:
from https://sourceforge.net/projects/vboxvmservice/
to https://github.com/onlyfang/VBoxVmService/

I didn't manage to disable the installer's shortcut creation so those two shortcuts
are removed in the post_install script.