### PR TITLE
TeXmacs 1.99.11: fix hash

### DIFF
--- a/bucket/texmacs.json
+++ b/bucket/texmacs.json
@@ -4,7 +4,7 @@
     "version": "1.99.11",
     "license": "GPL-3.0-or-later",
     "url": "http://www.texmacs.org/Download/ftp/tmftp/windows/TeXmacs-1.99.11-installer.exe",
-    "hash": "205a55196191cdf826f83d83976fb2c71033fcc604679c12f94cc27b24322704",
+    "hash": "e979a8995ad893fc208c091f0f5cd34740f3d4a4fd052bae5665c8976dc67f7d",
     "innosetup": true,
     "bin": "bin\\texmacs.exe",
     "shortcuts": [


### PR DESCRIPTION
```
Download: Status Legend:
Download: (OK):download completed.
Checking hash of TeXmacs-1.99.11-installer.exe ... ERROR Hash check failed!
App:         extras/texmacs
URL:         http://www.texmacs.org/Download/ftp/tmftp/windows/TeXmacs-1.99.11-installer.exe
First bytes: 4D 5A 50 00 02 00 00 00
Expected:    205a55196191cdf826f83d83976fb2c71033fcc604679c12f94cc27b24322704
Actual:      e979a8995ad893fc208c091f0f5cd34740f3d4a4fd052bae5665c8976dc67f7d

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=texmacs%401.99.11%3a+hash+check+failed
```

I have downloaded twice to make sure it isn't corrupted.