### PR TITLE
v2rayN 2.30: fix hash

### DIFF
--- a/bucket/v2rayn.json
+++ b/bucket/v2rayn.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
     "url": "https://github.com/2dust/v2rayN/releases/download/2.30/v2rayN.zip",
-    "hash": "ce514de2f6c1d7b505dccacffd35b13ff8c6ad24c7c892ded31561b1231642cb",
+    "hash": "dd893a0ef1fdb7486114a1350a6eda8f911f0bba2d7b7d60d3e64e221be14fc3",
     "extract_dir": "v2rayN",
     "bin": "v2rayN.exe",
     "persist": [


### PR DESCRIPTION
```
Download: Status Legend:
Download: (OK):download completed.
Checking hash of v2rayN.zip ... ERROR Hash check failed!
App:         extras/v2rayn
URL:         https://github.com/2dust/v2rayN/releases/download/2.30/v2rayN.zip
First bytes: 50 4B 03 04 14 00 00 00
Expected:    ce514de2f6c1d7b505dccacffd35b13ff8c6ad24c7c892ded31561b1231642cb
Actual:      dd893a0ef1fdb7486114a1350a6eda8f911f0bba2d7b7d60d3e64e221be14fc3

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=v2rayn%402.30%3a+hash+check+failed
```

I have downloaded twice to make sure it isn't corrupted.