### PR TITLE
Texmaker: fix persist

### DIFF
--- a/bucket/texmaker.json
+++ b/bucket/texmaker.json
@@ -1,19 +1,28 @@
 {
-    "homepage": "http://www.xm1math.net/texmaker/",
-    "description": "A free, modern and cross-platform LaTeX editor that integrates many tools needed to develop documents with LaTeX, in just one application.",
     "version": "5.0.3",
+    "homepage": "https://www.xm1math.net/texmaker/",
+    "description": "A free, modern and cross-platform LaTeX editor that integrates many tools needed to develop documents with LaTeX.",
     "license": "GPL-2.0-only",
-    "url": "http://www.xm1math.net/texmaker/assets/files/texmakerwin64usb.zip",
-    "hash": "64da399a78e17e995cdcb4439ccddb3e25e290ead99e0b1d53eb7faf607f1916",
+    "url": "https://www.xm1math.net/texmaker/assets/files/texmakerwin64usb.zip",
+    "hash": "md5:adddb07b9a9f92b6c530e9d5dc6d4914",
     "extract_dir": "texmakerwin64usb",
-    "pre_install": [
-        "if(!(test-path \"$dir\\texmaker.ini\")) { write-host \"\" | out-file -encoding oem \"$dir\\texmaker.ini\" }",
-        "if(!(test-path \"$dir\\texmakerapp.ini\")) { write-host \"\" | out-file -encoding oem \"$dir\\texmakerapp.ini\" }"
-    ],
-    "persist": [
-        "texmaker.ini",
-        "texmakerapp.ini"
-    ],
+    "installer": {
+        "script": [
+            "foreach ($file in @('texmaker.ini', 'texmakerapp.ini')){",
+            "    if(!(Test-Path \"$persist_dir\\$file\")) {",
+            "        New-Item \"$persist_dir\\$file\" -Force | Out-Null",
+            "    }",
+            "    Copy-Item \"$persist_dir\\$file\" \"$dir\\$file\" -Force",
+            "}"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "foreach ($file in @('texmaker.ini', 'texmakerapp.ini')){",
+            "    Copy-Item \"$dir\\$file\" \"$persist_dir\\$file\" -Force",
+            "}"
+        ]
+    },
     "shortcuts": [
         [
             "texmaker.exe",
@@ -24,10 +33,14 @@
         "MiKTeX": "latex"
     },
     "checkver": {
-        "url": "http://www.xm1math.net/texmaker/version.txt",
-        "re": "([\\d.]+)"
+        "url": "https://www.xm1math.net/texmaker/version.txt",
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://www.xm1math.net/texmaker/assets/files/texmakerwin64usb.zip"
+        "url": "https://www.xm1math.net/texmaker/assets/files/texmakerwin64usb.zip",
+        "hash": {
+            "url": "https://www.xm1math.net/texmaker/download.html",
+            "regex": "(?sm)$basename.*?md5 sum : $md5"
+        }
     }
 }


### PR DESCRIPTION
It seems that texmaker will just delete the symlink and create a new file so persistence does not work. Before the persistence code rework is complete, this is a temporary solution.