### PR TITLE
Archi: Update to 4.5.1 & remove 32bit

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -21,7 +21,6 @@
         "url": "https://www.archimatetool.com/download/",
         "re": "data-version=\"([\\d.]+)\""
     },
-
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -9,11 +9,19 @@
             "hash": "md5:63d78b2d8ef298b0ed111691417d1339"
         }
     },
+    "extract_dir": "Archi",
+    "bin": "archi.exe",
+    "shortcuts": [
+        [
+            "archi.exe",
+            "Archi"
+        ]
+    ],
     "checkver": {
         "url": "https://www.archimatetool.com/download/",
         "re": "data-version=\"([\\d.]+)\""
     },
-    "extract_dir": "Archi",
+
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -24,12 +32,5 @@
             "url": "$url.MD5",
             "find": "MD5 \\($basename\\) = ([A-Fa-f\\d]{32})"
         }
-    },
-    "shortcuts": [
-        [
-            "archi.exe",
-            "Archi"
-        ]
-    ],
-    "bin": "archi.exe"
+    }
 }

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.archimatetool.com/",
     "license": "MIT",
-    "description": "Archi® is a free, open source, cross-platform tool and editor to create ArchiMate models.",
+    "description": "Free, open source, cross-platform tool and editor to create ArchiMate models.",
     "version": "4.5.1",
     "architecture": {
         "64bit": {

--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -2,15 +2,11 @@
     "homepage": "https://www.archimatetool.com/",
     "license": "MIT",
     "description": "Archi® is a free, open source, cross-platform tool and editor to create ArchiMate models.",
-    "version": "4.4.0",
+    "version": "4.5.1",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/4.4.0/Archi-Win64-4.4.0.zip",
-            "hash": "md5:7abae71a730b2dadfa5df560180bb340"
-        },
-        "32bit": {
-            "url": "https://www.archimatetool.com/downloads/4.4.0/Archi-Win32-4.4.0.zip",
-            "hash": "md5:3a60951584467e16c547218f85920f32"
+            "url": "https://www.archimatetool.com/downloads/4.5.1/Archi-Win64-4.5.1.zip",
+            "hash": "md5:63d78b2d8ef298b0ed111691417d1339"
         }
     },
     "checkver": {
@@ -22,9 +18,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://www.archimatetool.com/downloads/$version/Archi-Win64-$version.zip"
-            },
-            "32bit": {
-                "url": "https://www.archimatetool.com/downloads/$version/Archi-Win32-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
https://www.archimatetool.com/downloads/What's%20New%20in%20Archi.pdf

Starting from 4.5, Archi supports only 64-bit versions.

#2308
