### PR TITLE
bulk-crap-uninstaller: Change download.url to FossHub

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,10 +1,18 @@
 {
     "homepage": "https://www.bcuninstaller.com/",
-    "description": "FOSS software uninstaller.",
+    "description": "Bulk program uninstaller with advanced automation.",
     "license": "Apache-2.0",
     "version": "4.14",
-    "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v4.14/BCUninstaller_4.14_portable.zip",
+    "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_4.14_portable.zip",
     "hash": "a8bddd341cd79383facee4384f9f7b233e5f21abf21fe355d1c2729655f82162",
+    "bin": [
+        "BCUninstaller.exe",
+        "BCU-console.exe",
+        "StoreAppHelper.exe",
+        "SteamHelper.exe",
+        "OculusHelper.exe",
+        "UninstallerAutomatizer.exe"
+    ],
     "shortcuts": [
         [
             "BCUninstaller.exe",
@@ -16,14 +24,15 @@
         "BCUninstaller.settings"
     ],
     "pre_install": [
-        "if (!(Test-Path(\"$dir/BCUninstaller.settings\"))) {",
-        "   New-Item \"$dir/BCUninstaller.settings\" | Out-Null",
+        "if (!(Test-Path \"$persist_dir\\BCUninstaller.settings\")) {",
+        "   New-Item \"$dir\\BCUninstaller.settings\" -ItemType File | Out-Null",
         "}"
     ],
     "checkver": {
-        "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"
+        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html",
+        "regex": "\"softwareVersion\">([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$version/BCUninstaller_$version_portable.zip"
+        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_4.14_portable.zip"
     }
 }


### PR DESCRIPTION
For hash extraction.