### PR TITLE
prusaslicer: Fix checkver

### DIFF
--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -26,8 +26,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/prusa3d/PrusaSlicer/releases",
-        "regex": "PrusaSlicer-(?<version>[\\d.]+)\\+win64-(?<timestamp>\\d+).zip"
+        "url": "https://github.com/prusa3d/PrusaSlicer/releases/latest",
+        "regex": "PrusaSlicer-(?<version>[\\w-.]+)\\+win64-(?<timestamp>\\d+)\\.zip"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/prusa3d/PrusaSlicer",
+        "url": "https://github.com/prusa3d/PrusaSlicer/releases",
         "regex": "PrusaSlicer-(?<version>[\\d.]+)\\+win64-(?<timestamp>\\d+).zip"
     },
     "autoupdate": {

--- a/bucket/prusaslicer.json
+++ b/bucket/prusaslicer.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/prusa3d/PrusaSlicer/releases/latest",
+        "github": "https://github.com/prusa3d/PrusaSlicer",
         "regex": "PrusaSlicer-(?<version>[\\w-.]+)\\+win64-(?<timestamp>\\d+)\\.zip"
     },
     "autoupdate": {


### PR DESCRIPTION
mentioned in #2308 (Outstanding Excavator issues)

**PrusaSlicer** now put alpha, beta and rc versions in their release tags.
(see: https://github.com/prusa3d/PrusaSlicer/releases)

~This modifies `checkver` to **check all releases** (rather than checking only the latest), so that it will only match the **latest stable release**.~

This modifies `checkver` to allow alpha and RC releases.
