### PR TITLE
foobar2000: portable and no privilege

### DIFF
--- a/bucket/foobar2000-encoders.json
+++ b/bucket/foobar2000-encoders.json
@@ -1,26 +1,23 @@
 {
     "version": "2019-08-04",
+    "homepage": "https://www.foobar2000.org/encoderpack",
     "description": "This pack includes every natively supported free encoder binary for use with the Converter foobar2000 component.",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.foobar2000.org/license"
     },
-    "homepage": "https://www.foobar2000.org/encoderpack",
-    "url": "https://www.videohelp.com/download/Free_Encoder_Pack-2019-08-04.exe",
+    "url": "https://www.videohelp.com/download/Free_Encoder_Pack-2019-08-04.exe#/dl.7z",
     "hash": "32e83fd9e8cdf4d52f0fc8e173c4a80f69fe4cec089d354aaae499f2213eec83",
     "depends": "extras/foobar2000",
-    "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
-        ]
-    },
-    "post_install": "Copy-Item \"$dir\\encoders\" $(versiondir 'foobar2000' 'current' $global) -Recurse -Force",
+    "post_install": [
+        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+        "New-Item \"$(appdir foobar2000 $global)\\current\\encoders\" -ItemType Junction -Target \"$dir\" | Out-Null"
+    ],
     "checkver": {
         "url": "https://www.foobar2000.org/encoderpack",
-        "re": "Free_Encoder_Pack-([\\d-]+)\\.exe"
+        "regex": "Free_Encoder_Pack-([\\d-]+)\\.exe"
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/Free_Encoder_Pack-$version.exe"
+        "url": "https://www.videohelp.com/download/Free_Encoder_Pack-$version.exe#/dl.7z"
     }
 }

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -1,34 +1,58 @@
 {
     "version": "1.4.6",
+    "homepage": "https://www.foobar2000.org/",
     "description": "An advanced freeware audio player for the Windows platform.",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.foobar2000.org/license"
     },
-    "homepage": "https://www.foobar2000.org/",
-    "url": "https://www.videohelp.com/download/foobar2000_v1.4.6.exe",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.4.6.exe#/dl.7z",
     "hash": "94dd5b180928264f6e7504e9a35aa9e38bdbffad37f6af14e9a12e997fdc20a4",
+    "bin": "foobar2000.exe",
     "shortcuts": [
         [
             "foobar2000.exe",
             "Foobar2000"
         ]
     ],
+    "persist": [
+        "configuration",
+        "index-data",
+        "library",
+        "theme.fth"
+    ],
     "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
+        "script": [
+            "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
+            "New-Item \"$dir\\portable_mode_enabled\" -Force | Out-Null",
+            "if(!(Test-Path \"$persist_dir\\playlists\")) {",
+            "    New-Item \"$persist_dir\\playlists\" -ItemType Directory -Force | Out-Null",
+            "    if (Test-Path \"$env:Appdata\\foobar2000\") {",
+            "        Write-Host -F yellow \"Copying old '$env:Appdata\\foobar2000' to '$persist_dir'\"",
+            "        Copy-Item \"$env:Appdata\\foobar2000\\*\" \"$dir\" -Recurse -Force",
+            "    }",
+            "}",
+            "else {",
+            "    $shortVersion = $version.Split('.')[0, 1] -Join '.'",
+            "    Copy-Item \"$persist_dir\\playlists\" \"$dir\\playlist-v$shortVersion\" -Force -Recurse",
+            "}"
         ]
     },
+    "post_install": "if (is_directory \"$dir\\theme.fth\") { Remove-Item \"$dir\\theme.fth\" -Force }",
     "uninstaller": {
-        "file": "uninstall.exe",
-        "args": "/S"
+        "script": [
+            "Copy-Item \"$dir\\playlists-v*\\*\" \"$persist_dir\\playlists\" -Force  -Recurse",
+            "if ((is_directory \"$persist_dir\\theme.fth\") -and (Test-Path \"$dir\\theme.fth\")) {",
+            "    Remove-Item \"$persist_dir\\theme.fth\" -Force",
+            "    Copy-Item \"$dir\\theme.fth\" \"$persist_dir\" -Force",
+            "}"
+        ]
     },
     "checkver": {
         "url": "https://www.foobar2000.org/download",
-        "re": "foobar2000_v([\\d\\.]+)\\."
+        "regex": "foobar2000_v([\\d.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe"
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
     }
 }

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -18,8 +18,7 @@
     "persist": [
         "configuration",
         "index-data",
-        "library",
-        "theme.fth"
+        "library"
     ],
     "installer": {
         "script": [
@@ -35,6 +34,9 @@
             "else {",
             "    $shortVersion = $version.Split('.')[0, 1] -Join '.'",
             "    Copy-Item \"$persist_dir\\playlists\" \"$dir\\playlist-v$shortVersion\" -Force -Recurse",
+            "}",
+            "if (Test-Path \"$persist_dir\\theme.fth\") {",
+            "    Copy-Item \"$persist_dir\\theme.fth\" \"$dir\" -Force",
             "}"
         ]
     },
@@ -42,8 +44,7 @@
     "uninstaller": {
         "script": [
             "Copy-Item \"$dir\\playlists-v*\\*\" \"$persist_dir\\playlists\" -Force  -Recurse",
-            "if ((is_directory \"$persist_dir\\theme.fth\") -and (Test-Path \"$dir\\theme.fth\")) {",
-            "    Remove-Item \"$persist_dir\\theme.fth\" -Force",
+            "if (Test-Path \"$dir\\theme.fth\") {",
             "    Copy-Item \"$dir\\theme.fth\" \"$persist_dir\" -Force",
             "}"
         ]


### PR DESCRIPTION
Persist playlist-v1.4.
Persist theme.fth after first run.
encoders need to be reinstall after foobar update. Maybe just install encoder in foobar manifest is better.
It seems that bucket in depends won't effect.

Didn't see https://github.com/lukesampson/scoop-extras/pull/2076 before...