### PR TITLE
gitea@1.9: fix hash again

### DIFF
--- a/bucket/gitea.json
+++ b/bucket/gitea.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://dl.gitea.io/gitea/1.9/gitea-1.9-windows-4.0-amd64.exe#/gitea.exe",
-            "hash": "a38be091b407b7ade13fa637ea71588ca58c5afebd222c95fd1ba27630e08c47"
+            "hash": "42c91f567914fb165f6e13de10de339e2694da791120a3cc7d6a90489b298bf7"
         },
         "32bit": {
             "url": "https://dl.gitea.io/gitea/1.9/gitea-1.9-windows-4.0-386.exe#/gitea.exe",
-            "hash": "81ff3c007674c41d77653d6d0f5a2da4aa09d42f2bb818f4ab3c49d3ac16481d"
+            "hash": "3f3001753c42a87b3185cec8bf0c2162c2e5449c2015df8c1df9d9efa0ee19bb"
         }
     },
     "post_install": [


### PR DESCRIPTION
They updated binaries again!
```
.\checkver.ps1 gitea -f
gitea: 1.9 (scoop version is 1.9)
Forcing autoupdate!
Autoupdating gitea
Searching hash for gitea-1.9-windows-4.0-386.exe in https://dl.gitea.io/gitea/1.9/gitea-1.9-windows-4.0-386.exe.sha256
Found: 3f3001753c42a87b3185cec8bf0c2162c2e5449c2015df8c1df9d9efa0ee19bb using Extract Mode
Searching hash for gitea-1.9-windows-4.0-amd64.exe in https://dl.gitea.io/gitea/1.9/gitea-1.9-windows-4.0-amd64.exe.sha256
Found: 42c91f567914fb165f6e13de10de339e2694da791120a3cc7d6a90489b298bf7 using Extract Mode
Writing updated gitea manifest
```