### PR TITLE
go-ipfs@0.4.22: update hash

### DIFF
--- a/bucket/go-ipfs.json
+++ b/bucket/go-ipfs.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://dist.ipfs.io/go-ipfs/v0.4.22/go-ipfs_v0.4.22_windows-amd64.zip",
-            "hash": "176767dba05669722c875bd983cc0e3baefdc4945ca7299291ac53f9627e346a"
+            "hash": "72fae399e089a7c20f16a300f7d937dc15ea9093a535daef6140cc0a63482c93"
         },
         "32bit": {
             "url": "https://dist.ipfs.io/go-ipfs/v0.4.22/go-ipfs_v0.4.22_windows-386.zip",
-            "hash": "ed37cb3b551e9c575670a5a0150ddbd33e46da55b4a9c52ae6050858a458801f"
+            "hash": "e288a98ef501d2ec2fcb991ed6c52a213e110cd8c6ae3abfbcfaf3cc4d11e765"
         }
     },
     "extract_dir": "go-ipfs",


### PR DESCRIPTION
https://github.com/ipfs/go-ipfs/issues/6506#issuecomment-520883775

```
.\checkver.ps1 go-ipfs -f
go-ipfs: 0.4.22 (scoop version is 0.4.22)
Forcing autoupdate!
Autoupdating go-ipfs
Downloading go-ipfs_v0.4.22_windows-386.zip to compute hashes!
Loading go-ipfs_v0.4.22_windows-386.zip from cache
Computed hash: e288a98ef501d2ec2fcb991ed6c52a213e110cd8c6ae3abfbcfaf3cc4d11e765
Downloading go-ipfs_v0.4.22_windows-amd64.zip to compute hashes!
go-ipfs_v0.4.22_windows-amd64.zip (17.1 MB) [================================================] 100%
Computed hash: 72fae399e089a7c20f16a300f7d937dc15ea9093a535daef6140cc0a63482c93
Writing updated go-ipfs manifest
```