### PR TITLE
Add Pencil 3.0.4

### DIFF
--- a/bucket/pencil.json
+++ b/bucket/pencil.json
@@ -1,0 +1,36 @@
+{
+    "version": "3.0.4",
+    "description": "GUI prototyping tool.",
+    "homepage": "https://pencil.evolus.vn/",
+    "license": {
+        "identifier": "GPL-2.0-only|Freeware",
+        "url": "https://pencil.evolus.vn/Licensing.html"
+    },
+    "url": "https://pencil.evolus.vn/dl/V3.0.4/Pencil-Setup-3.0.4.exe#/dl.7z",
+    "hash": "sha1:f7763ceb6a48645c09d868d58016ac113b484241",
+    "architecture": {
+        "64bit": {
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\""
+        },
+        "32bit": {
+            "pre_install": "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\""
+        }
+    },
+    "post_install": "@('$*', 'Uninstall*') | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
+    "bin": "Pencil.exe",
+    "shortcuts": [
+        [
+            "Pencil.exe",
+            "Pencil"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/evolus/pencil/"
+    },
+    "autoupdate": {
+        "url": "https://pencil.evolus.vn/dl/V$version/Pencil-Setup-$version.exe#/dl.7z",
+        "hash": {
+            "url": "$baseurl/CHECKSUM"
+        }
+    }
+}


### PR DESCRIPTION
https://pencil.evolus.vn/  
_(https://github.com/evolus/pencil)_

Pencil is built for the purpose of providing a free and open-source GUI prototyping tool that people can easily install and use to create mockups in popular desktop platforms.

Successfully tested locally with both 64-bit and 32-bit.
Might need a quick check with the hashing for the `autoupdate` part. 
Otherwise, the pattern worked properly on a RegExp sandbox <sup>(https://regex101.com/)</sup>.