### PR TITLE
cherrytree: fix persist check

### DIFF
--- a/bucket/cherrytree.json
+++ b/bucket/cherrytree.json
@@ -6,13 +6,7 @@
     "url": "https://www.giuspen.com/software/cherrytree_0.38.9_win32_portable.7z",
     "hash": "1a0a37630d47ef230b9278547bf007a8ad77ab0120f4a9938404d546692de115",
     "extract_dir": "cherrytree_0.38.9_win32_portable",
-    "pre_install": [
-        "$file = 'config.cfg'",
-        "if (-not (Test-Path \"$persist_dir\\$file\")) {",
-        "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
-        "    New-Item \"$dir\\bin\\$file\" -Type File | Out-Null",
-        "}"
-    ],
+    "pre_install": "if (-not (Test-Path \"$persist_dir\\bin\\config.cfg\")) { New-Item \"$dir\\bin\\config.cfg\" -Type File | Out-Null }",
     "bin": "bin\\cherrytree.exe",
     "shortcuts": [
         [
@@ -21,11 +15,12 @@
         ]
     ],
     "persist": "bin\\config.cfg",
-    "checkver": "download last version ([\\d\\.]+)",
+    "checkver": "download last version ([\\d.]+)",
     "autoupdate": {
         "url": "https://www.giuspen.com/software/cherrytree_$version_win32_portable.7z",
         "hash": {
-            "url": "https://www.giuspen.com/cherrytree/"
+            "url": "https://www.giuspen.com/cherrytree/",
+            "regex": "$sha256\\s+$basename"
         },
         "extract_dir": "cherrytree_$version_win32_portable"
     }


### PR DESCRIPTION
After persitence tweaks now nested files are created in correct subdirectories instead of root of persist.

Also webpage is not updated with hashes for latest file for some reason.