### PR TITLE
Extract octant.exe from ZIP file subdirectory

### DIFF
--- a/bucket/octant.json
+++ b/bucket/octant.json
@@ -6,7 +6,8 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/vmware/octant/releases/download/v0.6.0/octant_0.6.0_Windows-64bit.zip",
-            "hash": "ddb05889fb4d82487d9651e5789c51bec235ec40193cc8133560ab7db994bde1"
+            "hash": "ddb05889fb4d82487d9651e5789c51bec235ec40193cc8133560ab7db994bde1",
+            "extract_dir": "octant_0.6.0_Windows-64bit"
         }
     },
     "bin": "octant.exe",
@@ -14,7 +15,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/vmware/octant/releases/download/v$version/octant_$version_Windows-64bit.zip"
+                "url": "https://github.com/vmware/octant/releases/download/v$version/octant_$version_Windows-64bit.zip",
+                "extract_dir": "octant_$version_Windows-64bit"
             }
         },
         "hash": {


### PR DESCRIPTION
Right now shim creation fails for Octant because the binary is contained within a subdirectory. Specify `extract_dir` to work around that.
```
~> scoop install octant                                                                                                 
Installing 'octant' (0.6.0) [64bit]                                                                                     
octant_0.6.0_Windows-64bit.zip (21.1 MB) [====================================================================] 100%    
Checking hash of octant_0.6.0_Windows-64bit.zip ... ok.                                                                 
Extracting octant_0.6.0_Windows-64bit.zip ... done.                                                                     
Linking ~\scoop\apps\octant\current => ~\scoop\apps\octant\0.6.0                                                        
Creating shim for 'octant'.                                                                                             
Can't shim 'octant.exe': File doesn't exist.
```