### PR TITLE
DDU@18.0.1.7: update hash

### DIFF
--- a/bucket/ddu.json
+++ b/bucket/ddu.json
@@ -4,7 +4,7 @@
     "description": "Driver removal utility that can help you completely uninstall AMD/NVIDIA graphics card drivers and packages from your system, without leaving leftovers behind (including registry keys, folders and files, driver store)",
     "license": "Unknown",
     "url": "https://www.wagnardsoft.com/DDU/download/DDU%20v18.0.1.7.exe#/dl.7z",
-    "hash": "sha1:20591a49debfa6aa3eb6e3f72323c6ad05a3498f",
+    "hash": "sha1:ee61b693543b277cb24dedd35542c35eb6748c40",
     "extract_dir": "DDU v18.0.1.7",
     "shortcuts": [
         [


### PR DESCRIPTION
```
Download: (OK):download completed.
Checking hash of DDU%20v18.0.1.7.exe ... ERROR Hash check failed!
App:         extras/ddu
URL:         https://www.wagnardsoft.com/DDU/download/DDU%20v18.0.1.7.exe#/dl.7z
First bytes: 4D 5A 90 00 03 00 00 00
Expected:    20591a49debfa6aa3eb6e3f72323c6ad05a3498f
Actual:      ee61b693543b277cb24dedd35542c35eb6748c40

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=ddu%4018.0.1.7%3a+hash+check+failed
```

https://www.wagnardsoft.com/content/display-driver-uninstaller-ddu-v18017-released

```
ChangeLog:

-Fixed the cleaning of the "OpenGLShExt" and "NvAppShExt" happening when it's not expected

Known issues:
-
For a guide , check : Guide
SHA1: EE61B693543B277CB24DEDD35542C35EB6748C40
```