### PR TITLE
FastCopy: modify license to Freeware

### DIFF
--- a/bucket/fastcopy.json
+++ b/bucket/fastcopy.json
@@ -2,7 +2,10 @@
     "version": "3.84",
     "description": "The Fastest copy/backup software.",
     "homepage": "https://fastcopy.jp/en/",
-    "license": "GPL-3.0-only",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://fastcopy.jp/help/fastcopy_eng.htm#license"
+    },
     "url": "https://fastcopy.jp/archive/FastCopy384.zip",
     "hash": "c18a53db52922123cd02ca6062afde6614097c33bce3afaa7d0c8b72dbfd5d78",
     "pre_install": [


### PR DESCRIPTION
close #2732

FastCopy has modified its license terms on its [official website](https://fastcopy.jp/help/fastcopy_eng.htm#license).

> ~This program is free software. You can redistribute it and/or modify it under the GNU General Public License version 3.~
(Due to various circumstances, distribution of the source code is temporarily suspended ... Please use FastCopy as freeware with no guarantee)

This modifies **FastCopy**'s license from `GPL-3.0-only` to `Freeware`.

