### PR TITLE
Chromium: Fix checkver/autoupdate

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -32,7 +32,7 @@
             "64bit": {
                 "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x64.7z",
                 "hash": {
-                    "url": "https://github.com/macchrome/winchrome/releases/latest",
+                    "url": "https://github.com/macchrome/winchrome/releases/v$version-Win64",
                     "regex": "(?sm)$basename \\(64-bit\\)<br>\\nSHA1 $sha1</p>"
                 },
                 "extract_dir": "Chromium-$matchMain-x64"
@@ -40,7 +40,7 @@
             "32bit": {
                 "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x86.7z",
                 "hash": {
-                    "url": "https://github.com/macchrome/winchrome/releases/latest",
+                    "url": "https://github.com/macchrome/winchrome/releases/v$version-Win64",
                     "regex": "(?sm)$basename \\(32-bit\\)<br>\\nSHA1 $sha1</p>"
                 },
                 "extract_dir": "Chromium-$matchMain-x86"

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -25,25 +25,25 @@
     ],
     "checkver": {
         "github": "https://github.com/macchrome/winchrome",
-        "regex": "v((?<main>[\\d.]+)-r\\d+)-Win64"
+        "regex": "v([\\d.]+-r\\d+)-Win64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x64.7z",
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchHead.$buildVersion-x64.7z",
                 "hash": {
                     "url": "https://github.com/macchrome/winchrome/releases/v$version-Win64",
                     "regex": "(?sm)$basename \\(64-bit\\)<br>\\nSHA1 $sha1</p>"
                 },
-                "extract_dir": "Chromium-$matchMain-x64"
+                "extract_dir": "Chromium-$matchHead.$buildVersion-x64"
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x86.7z",
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchHead.$buildVersion-x86.7z",
                 "hash": {
                     "url": "https://github.com/macchrome/winchrome/releases/v$version-Win64",
                     "regex": "(?sm)$basename \\(32-bit\\)<br>\\nSHA1 $sha1</p>"
                 },
-                "extract_dir": "Chromium-$matchMain-x86"
+                "extract_dir": "Chromium-$matchHead.$buildVersion-x86"
             }
         }
     }

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,7 +1,7 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
     "version": "76.0.3809.100-r665002",
-    "description": "Open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
+    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "license": "BSD-3-Clause",
     "homepage": "https://www.chromium.org",
     "architecture": {

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,37 +1,49 @@
 {
-    "version": "75.0.3770.142-r652427",
-    "description": "An open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
+    "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
+    "version": "76.0.3809.100-r665002",
+    "description": "Open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
     "license": "BSD-3-Clause",
     "homepage": "https://www.chromium.org",
-    "checkver": {
-        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=stable-codecs-sync&out=string",
-        "re": "v([\\d.]+-r(?:\\d+))-win64"
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/macchrome/winchrome/releases/download/v76.0.3809.100-r665002-Win64/Chromium-76.0.3809.100-x64.7z",
+            "hash": "sha1:67fda51228441ec59bdbfa4de046f4ea4f4d551b",
+            "extract_dir": "Chromium-76.0.3809.100-x64"
+        },
+        "32bit": {
+            "url": "https://github.com/macchrome/winchrome/releases/download/v76.0.3809.100-r665002-Win64/Chromium-76.0.3809.100-x86.7z",
+            "hash": "sha1:b3a9c7bfaf220ba2f0868047e1043b74246a9c96",
+            "extract_dir": "Chromium-76.0.3809.100-x86"
+        }
     },
     "bin": "chrome.exe",
-    "extract_dir": "chrome-win32",
     "shortcuts": [
         [
             "chrome.exe",
             "Chromium"
         ]
     ],
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v75.0.3770.142-r652427-win64/chromium-sync.zip",
-            "hash": "9b70c145471e8bcd4d717e0c6d736e1cb94c9710f18a5638f5cc1175418d9e0b"
-        },
-        "32bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v75.0.3770.142-r652427-win32/chromium-sync.zip",
-            "hash": "bc33cf72da162dc90374957ed2d4e9e8026b51caca1290122a4e0cba218d04cb"
-        }
+    "checkver": {
+        "github": "https://github.com/macchrome/winchrome",
+        "regex": "v((?<main>[\\d.]+)-r\\d+)-Win64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win64/chromium-sync.zip"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x64.7z",
+                "hash": {
+                    "url": "https://github.com/macchrome/winchrome/releases/latest",
+                    "regex": "(?sm)$basename \\(64-bit\\)<br>\\nSHA1 $sha1</p>"
+                },
+                "extract_dir": "Chromium-$matchMain-x64"
             },
             "32bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win32/chromium-sync.zip"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-Win64/Chromium-$matchMain-x86.7z",
+                "hash": {
+                    "url": "https://github.com/macchrome/winchrome/releases/latest",
+                    "regex": "(?sm)$basename \\(32-bit\\)<br>\\nSHA1 $sha1</p>"
+                },
+                "extract_dir": "Chromium-$matchMain-x86"
             }
         }
     }

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -16,7 +16,13 @@
             "extract_dir": "Chromium-76.0.3809.100-x86"
         }
     },
-    "bin": "chrome.exe",
+    "bin": [
+        "chrome.exe",
+        [
+            "chrome.exe",
+            "chromium"
+        [
+    ],
     "shortcuts": [
         [
             "chrome.exe",

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -21,7 +21,7 @@
         [
             "chrome.exe",
             "chromium"
-        [
+        ]
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
#2308 (Outstanding Excavator Issues)

Notes:

* Modify download URL from https://github.com/henrypp/chromium/ to https://github.com/macchrome/winchrome/.

* Track new versions from https://github.com/macchrome/winchrome/ (remove dependency of API from https://chromium.woolyss.com)


Some issues for `-dev`, `-nosync` and `-dev-nosync` packages:
* For `chromium-nosync`, [the release channel](https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=stable-codecs-nosync&out=string) is empty. (maybe discontinued?) Should we replace it by the **Ungoogled** version from https://github.com/macchrome/winchrome/releases ?

* For `chromium-dev-nosync`, [the 64-bit version and 32-bit version are released separately](https://github.com/RobRich999/Chromium_Clang/releases/) (they will not have the same version number). Is there a way to handle this? or, should we separate 64-bit and 32-bit version into 2 packages?