### PR TITLE
MobaXterm: Fix path of mobaxterm.exe

### DIFF
--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -11,7 +11,7 @@
     "pre_install": [
         "    # Rename executable",
         "$ex = (Get-ChildItem \"$dir\" 'mobaxterm*.exe')[0]",
-        "Rename-Item \"$dir\\$ex\" \"$dir\\MobaXterm.exe\"",
+        "Rename-Item \"$ex\" \"$dir\\MobaXterm.exe\"",
         "    # Create files for persisting",
         "function PersistsFile([String] $file) {",
         "    if (!(Test-Path \"$persist_dir\\$file\")) {",

--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -10,8 +10,7 @@
     "hash": "489e882ad5ddd7aaa2195d8102ea2bad7e374d8b209260a6d12ee3703229dc8d",
     "pre_install": [
         "    # Rename executable",
-        "$ex = (Get-ChildItem \"$dir\" 'mobaxterm*.exe')[0]",
-        "Rename-Item \"$ex\" \"$dir\\MobaXterm.exe\"",
+        "$ex = Get-ChildItem \"$dir\" 'mobaxterm*.exe' | Select-Object -First 1 | Rename-Item -NewName 'MobaXterm.exe'",
         "    # Create files for persisting",
         "function PersistsFile([String] $file) {",
         "    if (!(Test-Path \"$persist_dir\\$file\")) {",

--- a/bucket/mobaxterm.json
+++ b/bucket/mobaxterm.json
@@ -10,7 +10,7 @@
     "hash": "489e882ad5ddd7aaa2195d8102ea2bad7e374d8b209260a6d12ee3703229dc8d",
     "pre_install": [
         "    # Rename executable",
-        "$ex = Get-ChildItem \"$dir\" 'mobaxterm*.exe' | Select-Object -First 1 | Rename-Item -NewName 'MobaXterm.exe'",
+        "Get-ChildItem \"$dir\" 'mobaxterm*.exe' | Select-Object -First 1 | Rename-Item -NewName 'MobaXterm.exe'",
         "    # Create files for persisting",
         "function PersistsFile([String] $file) {",
         "    if (!(Test-Path \"$persist_dir\\$file\")) {",


### PR DESCRIPTION
$ex is an absolute path of mobaxterm*.exe, so ‘Rename-Item’ will throw an error.

```
Rename-Item : Cannot find path 'D:\local\scoop\apps\mobaxterm\12.1\D:\local\scoop\apps\mobaxterm\12.1\MobaXterm_Personal_12.1.exe' because it does not exist."
```