### PR TITLE
altair: Fix url

### DIFF
--- a/bucket/altair.json
+++ b/bucket/altair.json
@@ -5,7 +5,7 @@
     "description": "Beautiful feature-rich GraphQL Client.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/imolorhe/altair/releases/download/v2.3.1/altair-setup-2.3.1.exe#/dl.7z",
+            "url": "https://github.com/imolorhe/altair/releases/download/v2.3.1/altair_2.3.1_win.exe#/dl.7z",
             "hash": "sha512:2fff16c5e9a3e318b90f0a5388e5eec1fa9434fc2f028daec18206bbdaa0844158de4b61c2b3ec4e1b66fabe1dd0111df91d69b066ed692ad2871e482803f31f",
             "installer": {
                 "script": [
@@ -25,7 +25,7 @@
         "github": "https://github.com/imolorhe/altair"
     },
     "autoupdate": {
-        "url": "https://github.com/imolorhe/altair/releases/download/v$version/altair-setup-$version.exe#/dl.7z",
+        "url": "https://github.com/imolorhe/altair/releases/download/v$version/altair_$version_win.exe#/dl.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512: $base64"


### PR DESCRIPTION
I confirmed the `artifactName` config in [electron-builder.yml](https://github.com/imolorhe/altair/commit/cbf8594eb7e674a6e621e4feb711a9e6540f71fc#diff-16c2a798a0e2b6675d5675ff89ece034R21) has changed.