### PR TITLE
Notable: modify license to "Freeware"

### DIFF
--- a/bucket/notable.json
+++ b/bucket/notable.json
@@ -4,7 +4,7 @@
     "version": "1.7.3",
     "license": {
         "identifier": "Freeware",
-        "url":"https://github.com/notable/notable/blob/master/README.md#license"
+        "url": "https://github.com/notable/notable/blob/master/README.md#license"
     },
     "architecture": {
         "64bit": {

--- a/bucket/notable.json
+++ b/bucket/notable.json
@@ -2,7 +2,10 @@
     "homepage": "https://github.com/notable/notable",
     "description": "The markdown-based note-taking app that doesn't suck.",
     "version": "1.7.3",
-    "license": "AGPL-3.0-or-later",
+    "license": {
+        "identifier": "Freeware",
+        "url":"https://github.com/notable/notable/blob/master/README.md#license"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/notable/notable/releases/download/v1.7.3/Notable.Setup.1.7.3.exe#/dl.7z",


### PR DESCRIPTION
close #2766

**Notable** has changed its license terms. See #2766 for more details.