### PR TITLE
gcloud: Remove post_install and add notes for init

### DIFF
--- a/bucket/gcloud.json
+++ b/bucket/gcloud.json
@@ -21,7 +21,12 @@
         "bin\\docker-credential-gcloud.cmd",
         "bin\\git-credential-gcloud.cmd"
     ],
-    "post_install": "gcloud init",
+    "notes": [
+        "To initialize Cloud SDK, you will need to run",
+        "",
+        "gcloud init",
+        ""
+    ],
     "checkver": {
         "url": "https://cloud.google.com/sdk/docs/",
         "re": "Install the latest Cloud SDK version \\(([\\d.]+)\\)"


### PR DESCRIPTION
I propose to remove the `post_install` script for Google Cloud SDK mainly for two reasons:
1. Avoid re-initializing Cloud SDK on each update
  Currently the init process must be done on each update otherwise scoop marks the app installation as failed;
2. Allow installing Cloud SDK in an unattended way
  This change allow installing Cloud SDK without user interaction, the user is still able to initialize it manually afterwards with their credentials and settings.

I also added `notes`  field as it is in Git in the main repository.