### PR TITLE
libreoffice: Extract hash from $url.sha256

### DIFF
--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -44,7 +44,7 @@
     ],
     "checkver": {
         "url": "https://www.libreoffice.org/download/download/",
-        "regex": "libreoffice-([\\d\\.]+)\\.tar\\.xz"
+        "regex": "libreoffice-([\\d.]+)\\.tar\\.xz"
     },
     "autoupdate": {
         "architecture": {
@@ -56,7 +56,7 @@
             }
         },
         "hash": {
-            "mode": "metalink"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
It seems that libreoffice is the only manifest using metalink. `$url.sha256` is more clear. We can deprecate metalink mode.