### PR TITLE
Krita: Change to exe

### DIFF
--- a/bucket/krita.json
+++ b/bucket/krita.json
@@ -1,47 +1,44 @@
 {
     "version": "4.2.5",
-    "description": "Krita. Professional, FREE and open source painting program.",
+    "description": "A free digital painting application.",
     "homepage": "https://krita.org/",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://docs.krita.org/en/KritaFAQ.html#license-rights-and-the-krita-foundation"
-    },
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://download.kde.org/stable/krita/4.2.5/krita-x64-4.2.5.zip",
-            "hash": "md5:dd663779872d08b80076364a93a0a8b1",
-            "extract_dir": "krita-x64-4.2.5"
+            "url": "https://download.kde.org/stable/krita/4.2.5/krita-x64-4.2.5-setup.exe#/dl.7z",
+            "hash": "73c536423e456d61a2c7959d8eaaf17045440013e121ca146dba3c6ac2285aa2"
         },
         "32bit": {
-            "url": "https://download.kde.org/stable/krita/4.2.5/krita-x86-4.2.5.zip",
-            "hash": "md5:01e0f0ddbaff577eda1eaeba8f702e63",
-            "extract_dir": "krita-x86-4.2.5"
+            "url": "https://download.kde.org/stable/krita/4.2.5/krita-x86-4.2.5-setup.exe#/dl.7z",
+            "hash": "fc257fc0c49dbb6f69d36fa2d8026e674b436e8c3219acc79355610a2039a298"
         }
     },
-    "bin": "bin\\krita.exe",
+    "bin": [
+        "bin\\krita.exe",
+        "bin\\kritarunner.exe"
+    ],
     "shortcuts": [
         [
             "bin\\krita.exe",
             "Krita"
         ]
     ],
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe.nsis\" -Recurse -Force",
     "checkver": {
         "url": "https://krita.org/en/download/krita-desktop/",
-        "regex": "Download Krita\\s+([\\d+\\.]+)"
+        "regex": "Download Krita\\s+([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/krita/$version/krita-x64-$version.zip",
-                "extract_dir": "krita-x64-$version"
+                "url": "https://download.kde.org/stable/krita/$version/krita-x64-$version-setup.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://download.kde.org/stable/krita/$version/krita-x86-$version.zip",
-                "extract_dir": "krita-x86-$version"
+                "url": "https://download.kde.org/stable/krita/$version/krita-x86-$version-setup.exe#/dl.7z"
             }
         },
         "hash": {
-            "url": "$baseurl/md5sum.txt"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
exe file is smaller (104M/140M) and need less time to unzip.