### PR TITLE
dropit: add a new app

### DIFF
--- a/bucket/dropit.json
+++ b/bucket/dropit.json
@@ -1,0 +1,25 @@
+{
+    "version": "8.5.1",
+    "homepage": "http://www.dropitproject.com/",
+    "description": "Personal assistant to automatically manage your files",
+    "license": "GPL-3.0-only",
+    "url": "https://downloads.sourceforge.net/project/dropit/DropIt/v8.5.1/DropIt_v8.5.1_Portable.zip",
+    "hash": "sha1:882c765830b307d8b2d90b4411e061d39d79a28c",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\settings.ini\")) { New-Item \"$dir\\settings.ini\" -Force | Out-Null }",
+    "extract_dir": "DropIt_v8.5.1_Portable",
+    "shortcuts": [
+        [
+            "DropIt.exe",
+            "DropIt"
+        ]
+    ],
+    "persist": [
+        "Profiles",
+        "settings.ini"
+    ],
+    "checkver": "Latest Version: v([\\d.]+)",
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/dropit/DropIt/v$version/DropIt_v$version_Portable.zip",
+        "extract_dir": "DropIt_v$version_Portable"
+    }
+}


### PR DESCRIPTION
sorry...
I accidentally closed this PR (#2805) when I rebase the commit

auto-update work fine
![image](https://user-images.githubusercontent.com/24669431/64301899-6f9a7580-cfb3-11e9-8757-bee5ad03360e.png)

And the download path has been corrected
```json
{
    "version": "8.5.1",
    "homepage": "http://www.dropitproject.com/",
    "description": "Personal assistant to automatically manage your files",
    "license": "GPL-3.0-only",
    "url": "https://downloads.sourceforge.net/project/dropit/DropIt/v8.5.1/DropIt_v8.5.1_Portable.zip",
    "hash": "sha1:882c765830b307d8b2d90b4411e061d39d79a28c",
    "pre_install": "if (!(Test-Path \"$persist_dir\\settings.ini\")) { New-Item \"$dir\\settings.ini\" -Force | Out-Null }",
    "extract_dir": "DropIt_v8.5.1_Portable",
    "shortcuts": [
        [
            "DropIt.exe",
            "DropIt"
        ]
    ],
    "persist": [
        "Profiles",
        "settings.ini"
    ],
    "checkver": "Latest Version: v([\\d.]+)",
    "autoupdate": {
        "url": "https://downloads.sourceforge.net/project/dropit/DropIt/v$version/DropIt_v$version_Portable.zip",
        "extract_dir": "DropIt_v$version_Portable"
    }
}

```

Thank you for your review.