### PR TITLE
Firefox ESR: fix checkver

### DIFF
--- a/bucket/firefox-esr.json
+++ b/bucket/firefox-esr.json
@@ -1,16 +1,16 @@
 {
     "description": "Extended Support Release of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/organizations/",
-    "version": "68.0.2",
+    "version": "68.1.0",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/68.0.2esr/win64/en-US/Firefox%20Setup%2068.0.2esr.exe#/dl.7z",
-            "hash": "sha512:5f60784c1f71f86c07ccc8a88cda997ac5b88d1ecb7590e58d5ca168800cc48cf68ed7c1c968e239a915b876f7ea811004f53a0cebd7e622d827ecca2e0256f1"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/68.1.0esr/win64/en-US/Firefox%20Setup%2068.1.0esr.exe#/dl.7z",
+            "hash": "sha512:f1db714054f9644c43da67ff102ca9746b52040438d4337beedd7b629e63f85ca7713eed1f0c533c56b04ecfd0603a921e479d77651302d981976963434aa5c0"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/releases/68.0.2esr/win32/en-US/Firefox%20Setup%2068.0.2esr.exe#/dl.7z",
-            "hash": "sha512:2f04e454a0c43086394849868d2bb35cbc6ef8c1e3e2704fa6608da84e609022e24e0e97ac54b8c071faca16824f0a4fa0236df7ce9dc876fda52953eb23b02b"
+            "url": "https://archive.mozilla.org/pub/firefox/releases/68.1.0esr/win32/en-US/Firefox%20Setup%2068.1.0esr.exe#/dl.7z",
+            "hash": "sha512:ccb1622dd84f61f2236a071f17fa6af77c1ac065e7cd9194cb8672ccfe48ed22239f5d9193a1185396fa557ef88422e198bde6cd2f3d0c55803199b971d27b8c"
         }
     },
     "extract_dir": "core",
@@ -27,8 +27,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.mozilla.org/en-US/firefox/organizations/notes/",
-        "regex": "<div class=\"c-release-version\">([\\d.]+)esr</div>"
+        "url": "https://aus5.mozilla.org/update/6/Firefox/68.0/_/WINNT_x86_64-msvc-x64/en-US/esr/_/_/_/_/update.xml",
+        "xpath": "/updates/update/@appVersion"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Because sometimes there are two latest version of firefox esr, we shouldn't checkver from release note. Maybe the A/B test problem can be solved by autoupdating checkver.

https://github.com/lukesampson/scoop-extras/issues/2308