### PR TITLE
waifu2x-caffe: Add version 1.2.0.2

### DIFF
--- a/bucket/waifu2x-caffe.json
+++ b/bucket/waifu2x-caffe.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://github.com/lltcggie/waifu2x-caffe",
     "version": "1.2.0.2",
-    "description": "Caffe-based GUI/CLI version of waifu2x, an AI-powered image-upscaling program.",
+    "description": "AI-powered image upscaler.",
     "license": "MIT",
     "architecture": {
         "64bit": {

--- a/bucket/waifu2x-caffe.json
+++ b/bucket/waifu2x-caffe.json
@@ -3,13 +3,6 @@
     "version": "1.2.0.2",
     "description": "Caffe-based GUI/CLI version of waifu2x, an AI-powered image-upscaling program.",
     "license": "MIT",
-    "bin": "waifu2x-caffe-cui.exe",
-    "shortcuts": [
-        [
-            "waifu2x-caffe.exe",
-            "waifu2x-caffe"
-        ]
-    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/1.2.0.2/waifu2x-caffe.zip",
@@ -17,15 +10,19 @@
         }
     },
     "extract_dir": "waifu2x-caffe",
+    "bin": "waifu2x-caffe-cui.exe",
+    "shortcuts": [
+        [
+            "waifu2x-caffe.exe",
+            "waifu2x-caffe"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/$version/waifu2x-caffe.zip"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/waifu2x-caffe.json
+++ b/bucket/waifu2x-caffe.json
@@ -21,7 +21,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/$version/waifu2x-caffe.zip",
+                "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/$version/waifu2x-caffe.zip"
             }
         },
         "hash": {

--- a/bucket/waifu2x-caffe.json
+++ b/bucket/waifu2x-caffe.json
@@ -1,0 +1,31 @@
+{
+    "homepage": "https://github.com/lltcggie/waifu2x-caffe",
+    "version": "1.2.0.2",
+    "description": "Caffe-based GUI/CLI version of waifu2x, an AI-powered image-upscaling program.",
+    "license": "MIT",
+    "bin": "waifu2x-caffe-cui.exe",
+    "shortcuts": [
+        [
+            "waifu2x-caffe.exe",
+            "waifu2x-caffe"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/1.2.0.2/waifu2x-caffe.zip",
+            "hash": "73178769313623e6ff078e1c1a831f3fe1f4aedde3922660dae47c58aa04640f"
+        }
+    },
+    "extract_dir": "waifu2x-caffe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/lltcggie/waifu2x-caffe/releases/download/$version/waifu2x-caffe.zip",
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adding [waifu2x-caffe](https://github.com/lltcggie/waifu2x-caffe) as requested at #1973.