### PR TITLE
todotxt-net: Fix version 3.1.1 URL

### DIFF
--- a/bucket/todotxt-net.json
+++ b/bucket/todotxt-net.json
@@ -3,7 +3,7 @@
     "description": "Implementation of todo.txt for Windows using the .NET framework",
     "version": "3.3.1",
     "license": "BSD-2-Clause-FreeBSD",
-    "url": "https://github.com/benrhughes/todotxt.net/releases/download/v3.3.1/todotxt-portable.zip",
+    "url": "https://github.com/benrhughes/todotxt.net/releases/download/v3.3.1/todotxt-portable-3.3.1.zip",
     "hash": "1c0fe0d37d5519af0e701aebcd47ee17a39751386b18f8e216976c8f75bcf636",
     "extract_dir": "ProgramFiles",
     "pre_install": [
@@ -21,6 +21,6 @@
         "github": "https://github.com/benrhughes/todotxt.net"
     },
     "autoupdate": {
-        "url": "https://github.com/benrhughes/todotxt.net/releases/download/v$version/todotxt-portable.zip"
+        "url": "https://github.com/benrhughes/todotxt.net/releases/download/v$version/todotxt-portable-$version.zip"
     }
 }

--- a/bucket/todotxt-net.json
+++ b/bucket/todotxt-net.json
@@ -4,7 +4,7 @@
     "version": "3.3.1",
     "license": "BSD-2-Clause-FreeBSD",
     "url": "https://github.com/benrhughes/todotxt.net/releases/download/v3.3.1/todotxt-portable-3.3.1.zip",
-    "hash": "1c0fe0d37d5519af0e701aebcd47ee17a39751386b18f8e216976c8f75bcf636",
+    "hash": "1b85b951595ec1416b5a63553685f3d2a6a25dfea34128c58e93ee184729187c",
     "extract_dir": "ProgramFiles",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\todotxt.settings\")) { New-Item \"$dir\\todotxt.settings\" -ItemType File | Out-Null }"


### PR DESCRIPTION
The last version of Todotxt.NET changed the filename of the zip, which breaks the current JSON.
Maybe the author should be asked if it was done by accident?

Here is the release page:
https://github.com/benrhughes/todotxt.net/releases
