### PR TITLE
msiafterburner: Update to version 4.6.1 and decouple RTSS

### DIFF
--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -19,7 +19,7 @@
     "bin": "MSIAfterburner.exe",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" \"$dir\" -Removal",
-        "Get-ChildItem \"$dir\" -Recurse -Include @('$PLUGINSDIR', 'Uninstall.exe.nsis', '$R0', 'Redist\\*.exe') | Remove-Item -Recurse",
+        "Remove-Item \"$dir\\*\" -Include @('$PLUGINSDIR', 'Uninstall.exe.nsis', '$R0', 'Redist\\*.exe') -Recurse",
     ],
     "post_install": [
         "if(Test-Path \"$persist_dir\\AB_Profiles\") {",

--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -1,52 +1,50 @@
 {
+    "##": "Renaming the downloaded zip to 'sourceforge.net.zip' is a hack for the referer header. See dl()-function in \\lib\\install.ps1",
     "homepage": "https://www.msi.com/page/afterburner",
     "description": "Overclocking utility for graphics cards. Main features include GPU/Shader/Memory clock adjustment, advanced fan speed and GPU voltage control.",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.msi.com/page/website-terms-of-use"
     },
-    "version": "4.6.0",
-    "url": "http://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip#/MSIAfterburnerSetup460.7z",
-    "hash": "dd8be977fdde25343f8db3e318af4a5449aa90453505b78fc8f5975cddd98311",
+    "version": "4.6.1",
+    "url": "https://download-eu2.guru3d.com/afterburner/%5BGuru3D.com%5D-MSIAfterburnerSetup461Build15561.zip#/sourceforge.net.zip",
+    "hash": "4e59da5b73c5f290408851fea6e48b3b37dd6b089ae5598b3ccee43ea11fe603",
     "suggest": {
-        "Visual C++ Redist 2008": "extras/vcredist2008"
+        "Visual C++ Redist 2008": "extras/vcredist2008",
+        "RivaTuner Statistics Server": "extras/rtss",
+        "MSI Kombustor": "extras/msikombustor",
+        "FurMark": "extras/furmark"
     },
-    "persist": [
-        [
-            "Profiles",
-            "AB_Profiles"
-        ],
-        [
-            "RTSS/Profiles",
-            "RTSS_Profiles"
-        ]
-    ],
-    "bin": [
-        "RTSS/RTSS.exe",
-        "MSIAfterburner.exe"
-    ],
+    "persist": "Profiles",
+    "bin": "MSIAfterburner.exe",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" \"$dir\"",
-        "Expand-7zipArchive \"$dir\\Redist\\RTSSSetup.exe\" \"$dir\\RTSS\"",
-        "Get-ChildItem $dir -Recurse -Include @('MSIAfterburnerSetup*.exe', '$PLUGINSDIR', 'Uninstall.exe.nsis', '$R0') | Remove-Item -Recurse",
-        "Move-Item $dir/RTSS/RTSSHooks.dll.copy $dir/RTSS/RTSSHooks.dll",
-        "Move-Item $dir/RTSS/RTSSHooks64.dll.copy $dir/RTSS/RTSSHooks64.dll"
+        "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" \"$dir\" -Removal",
+        "Get-ChildItem \"$dir\" -Recurse -Include @('$PLUGINSDIR', 'Uninstall.exe.nsis', '$R0', 'Redist\\*.exe') | Remove-Item -Recurse",
+    ],
+    "post_install": [
+        "if(Test-Path \"$persist_dir\\AB_Profiles\") {",
+        "    warn 'Migrating Afterburner profiles...'",
+        "    Move-Item -Path \"$persist_dir\\AB_Profiles\\*\" -Destination \"$persist_dir\\Profiles\\\"",
+        "    Remove-Item \"$persist_dir\\AB_Profiles\"",
+        "}"
     ],
     "shortcuts": [
         [
             "MSIAfterburner.exe",
             "MSI Afterburner"
-        ],
-        [
-            "RTSS/RTSS.exe",
-            "RivaTuner Statistics Server"
         ]
     ],
     "checkver": {
-        "url": "http://event.msi.com/afterburner/Update.txt",
-        "re": "ProductBetaVersion\\s+=\\s+0.*\\nProductVersion\\s+=\\s+([\\d\\.]+)"
+        "url": "https://www.guru3d.com/files-details/msi-afterburner-beta-download.html",
+        "regex": "Download ([\\d.]+) Stable/Final",
+        "reverse": true
     },
     "autoupdate": {
-        "url": "http://download.msi.com/uti_exe/vga/MSIAfterburnerSetup.zip#/MSIAfterburnerSetup$cleanVersion.7z"
-    }
+        "url": "https://download-eu2.guru3d.com/afterburner/%5BGuru3D.com%5D-MSIAfterburnerSetup$cleanVersion.zip#/sourceforge.net.zip"
+    },
+    "notes": [
+        "The 'RivaTuner Statistics Server' has been moved to it's own package.",
+        "To install it run 'scoop install extras/rtss'.",
+        "Your profiles will be migrated automatically."
+    ]
 }

--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -18,7 +18,7 @@
     "persist": "Profiles",
     "bin": "MSIAfterburner.exe",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" \"$dir\" -Removal",
+        "Expand-7zipArchive \"$dir\\MSIAfterburnerSetup*.exe\" -Removal",
         "Remove-Item \"$dir\\*\" -Include @('$PLUGINSDIR', 'Uninstall.exe.nsis', '$R0', 'Redist\\*.exe') -Recurse",
     ],
     "post_install": [

--- a/bucket/msiafterburner.json
+++ b/bucket/msiafterburner.json
@@ -25,7 +25,7 @@
         "if(Test-Path \"$persist_dir\\AB_Profiles\") {",
         "    warn 'Migrating Afterburner profiles...'",
         "    Move-Item -Path \"$persist_dir\\AB_Profiles\\*\" -Destination \"$persist_dir\\Profiles\\\"",
-        "    Remove-Item \"$persist_dir\\AB_Profiles\"",
+        "    Remove-Item \"$persist_dir\\AB_Profiles\" -Recurse",
         "}"
     ],
     "shortcuts": [


### PR DESCRIPTION
- Remove RivaTuner Statistics Server
- Use guru3d.com download providing a newer version
- Add script to migrate profiles from old persist structure
- Add missing quotes in scripts