### PR TITLE
fix(lunacy): Use architecture-specific files

### DIFF
--- a/bucket/lunacy.json
+++ b/bucket/lunacy.json
@@ -8,12 +8,7 @@
     "version": "4.2.0",
     "url": "https://desktop.icons8.com/lunacy/LunacySetup_4.2.0.exe",
     "hash": "abc45f45769d554e578ea8725ce24c8889fc91596c81d4bd1e2aad9207d9c2cd",
-    "bin": [
-        [
-            "Lunacy.exe",
-            "lunacy"
-        ]
-    ],
+    "bin": "Lunacy.exe",
     "shortcuts": [
         [
             "Lunacy.exe",
@@ -21,6 +16,24 @@
         ]
     ],
     "innosetup": true,
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": [
+                    "Get-ChildItem \"$dir\" '*,1.*' | ForEach-Object { Rename-Item $_.Fullname \"$($_.Basename.TrimEnd(',1'))$($_.Extension)\" }",
+                    "Remove-Item \"$dir\\*,2*\""
+                ]
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": [
+                    "Get-ChildItem \"$dir\" '*,2.*' | ForEach-Object { Rename-Item $_.Fullname \"$($_.Basename.TrimEnd(',2'))$($_.Extension)\" }",
+                    "Remove-Item \"$dir\\*,1*\""
+                ]
+            }
+        }
+    },
     "checkver": {
         "url": "https://docs.icons8.com/release-notes/",
         "re": ">([\\d.]+)</h2>"

--- a/bucket/lunacy.json
+++ b/bucket/lunacy.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://icons8.com/lunacy",
-    "description": "Free graphic design software that works offline and supports .sketch files.",
+    "description": "Free Graphic Design Software.",
     "license": {
         "identifier": "Freeware",
         "url": "https://docs.icons8.com/lunacy%20license.md"
@@ -9,13 +9,6 @@
     "url": "https://desktop.icons8.com/lunacy/LunacySetup_4.2.0.exe",
     "hash": "abc45f45769d554e578ea8725ce24c8889fc91596c81d4bd1e2aad9207d9c2cd",
     "bin": "Lunacy.exe",
-    "shortcuts": [
-        [
-            "Lunacy.exe",
-            "Lunacy"
-        ]
-    ],
-    "innosetup": true,
     "architecture": {
         "64bit": {
             "installer": {
@@ -34,6 +27,13 @@
             }
         }
     },
+    "shortcuts": [
+        [
+            "Lunacy.exe",
+            "Lunacy"
+        ]
+    ],
+    "innosetup": true,
     "checkver": {
         "url": "https://docs.icons8.com/release-notes/",
         "re": ">([\\d.]+)</h2>"

--- a/bucket/lunacy.json
+++ b/bucket/lunacy.json
@@ -8,7 +8,7 @@
     "version": "4.2.0",
     "url": "https://desktop.icons8.com/lunacy/LunacySetup_4.2.0.exe",
     "hash": "abc45f45769d554e578ea8725ce24c8889fc91596c81d4bd1e2aad9207d9c2cd",
-    "bin": "Lunacy.exe",
+    "innosetup": true,
     "architecture": {
         "64bit": {
             "installer": {
@@ -27,13 +27,13 @@
             }
         }
     },
+    "bin": "Lunacy.exe",
     "shortcuts": [
         [
             "Lunacy.exe",
             "Lunacy"
         ]
     ],
-    "innosetup": true,
     "checkver": {
         "url": "https://docs.icons8.com/release-notes/",
         "re": ">([\\d.]+)</h2>"


### PR DESCRIPTION
Lunacy manifest has been broken for several months.

It should use architecture-specific files as explained by @Ash258 

- closes #2426 