### PR TITLE
foobar2000: partial revert of recent "improvements" (add portable)

### DIFF
--- a/bucket/foobar2000-portable.json
+++ b/bucket/foobar2000-portable.json
@@ -1,0 +1,59 @@
+{
+    "version": "1.4.8",
+    "homepage": "https://www.foobar2000.org/",
+    "description": "An advanced freeware audio player for the Windows platform.",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.foobar2000.org/license"
+    },
+    "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe#/dl.7z",
+    "hash": "993315168f76d1e91685805f6c746315c1cc34f73cfd44bf6bddab070897c2bf",
+    "bin": "foobar2000.exe",
+    "shortcuts": [
+        [
+            "foobar2000.exe",
+            "Foobar2000"
+        ]
+    ],
+    "persist": [
+        "configuration",
+        "index-data",
+        "library"
+    ],
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
+            "New-Item \"$dir\\portable_mode_enabled\" -Force | Out-Null",
+            "if(!(Test-Path \"$persist_dir\\playlists\")) {",
+            "    New-Item \"$persist_dir\\playlists\" -ItemType Directory -Force | Out-Null",
+            "    if (Test-Path \"$env:Appdata\\foobar2000\") {",
+            "        Write-Host -F yellow \"Copying old '$env:Appdata\\foobar2000' to '$persist_dir'\"",
+            "        Copy-Item \"$env:Appdata\\foobar2000\\*\" \"$dir\" -Recurse -Force",
+            "    }",
+            "}",
+            "else {",
+            "    $shortVersion = $version.Split('.')[0, 1] -Join '.'",
+            "    Copy-Item \"$persist_dir\\playlists\" \"$dir\\playlist-v$shortVersion\" -Force -Recurse",
+            "}",
+            "if (Test-Path \"$persist_dir\\theme.fth\") {",
+            "    Copy-Item \"$persist_dir\\theme.fth\" \"$dir\" -Force",
+            "}"
+        ]
+    },
+    "post_install": "if (is_directory \"$dir\\theme.fth\") { Remove-Item \"$dir\\theme.fth\" -Force }",
+    "uninstaller": {
+        "script": [
+            "Copy-Item \"$dir\\playlists-v*\\*\" \"$persist_dir\\playlists\" -Force  -Recurse",
+            "if (Test-Path \"$dir\\theme.fth\") {",
+            "    Copy-Item \"$dir\\theme.fth\" \"$persist_dir\" -Force",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.foobar2000.org/download",
+        "regex": "foobar2000_v([\\d.]+)\\."
+    },
+    "autoupdate": {
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
+    }
+}

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -23,7 +23,7 @@
     },
     "checkver": {
         "url": "https://www.foobar2000.org/download",
-        "re": "foobar2000_v([\\d\\.]+)\\."
+        "regex": "foobar2000_v([\\d.]+)\\."
     },
     "autoupdate": {
         "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -8,6 +8,12 @@
     },
     "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe#/dl.7z",
     "hash": "993315168f76d1e91685805f6c746315c1cc34f73cfd44bf6bddab070897c2bf",
+    "notes": [
+        "WARNING: foobar2000 package is reverting back to non-portable installation.",
+        "If you still want portable version, use foobar2000-portable instead.",
+        "If you want to migrate persisted data to portable version",
+        "please rename $persist_dir to \"foobar2000-portable\"."
+    ],
     "bin": "foobar2000.exe",
     "shortcuts": [
         [

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://www.foobar2000.org/license"
     },
-    "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe#/dl.7z",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe",
     "hash": "993315168f76d1e91685805f6c746315c1cc34f73cfd44bf6bddab070897c2bf",
     "bin": "foobar2000.exe",
     "shortcuts": [
@@ -15,45 +15,21 @@
             "Foobar2000"
         ]
     ],
-    "persist": [
-        "configuration",
-        "index-data",
-        "library"
-    ],
     "installer": {
-        "script": [
-            "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
-            "New-Item \"$dir\\portable_mode_enabled\" -Force | Out-Null",
-            "if(!(Test-Path \"$persist_dir\\playlists\")) {",
-            "    New-Item \"$persist_dir\\playlists\" -ItemType Directory -Force | Out-Null",
-            "    if (Test-Path \"$env:Appdata\\foobar2000\") {",
-            "        Write-Host -F yellow \"Copying old '$env:Appdata\\foobar2000' to '$persist_dir'\"",
-            "        Copy-Item \"$env:Appdata\\foobar2000\\*\" \"$dir\" -Recurse -Force",
-            "    }",
-            "}",
-            "else {",
-            "    $shortVersion = $version.Split('.')[0, 1] -Join '.'",
-            "    Copy-Item \"$persist_dir\\playlists\" \"$dir\\playlist-v$shortVersion\" -Force -Recurse",
-            "}",
-            "if (Test-Path \"$persist_dir\\theme.fth\") {",
-            "    Copy-Item \"$persist_dir\\theme.fth\" \"$dir\" -Force",
-            "}"
+        "args": [
+            "/S",
+            "/D=$dir"
         ]
     },
-    "post_install": "if (is_directory \"$dir\\theme.fth\") { Remove-Item \"$dir\\theme.fth\" -Force }",
     "uninstaller": {
-        "script": [
-            "Copy-Item \"$dir\\playlists-v*\\*\" \"$persist_dir\\playlists\" -Force  -Recurse",
-            "if (Test-Path \"$dir\\theme.fth\") {",
-            "    Copy-Item \"$dir\\theme.fth\" \"$persist_dir\" -Force",
-            "}"
-        ]
+        "file": "uninstall.exe",
+        "args": "/S"
     },
     "checkver": {
         "url": "https://www.foobar2000.org/download",
-        "regex": "foobar2000_v([\\d.]+)\\."
+        "re": "foobar2000_v([\\d\\.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe"
     }
 }

--- a/bucket/foobar2000.json
+++ b/bucket/foobar2000.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://www.foobar2000.org/license"
     },
-    "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe",
+    "url": "https://www.videohelp.com/download/foobar2000_v1.4.8.exe#/dl.7z",
     "hash": "993315168f76d1e91685805f6c746315c1cc34f73cfd44bf6bddab070897c2bf",
     "bin": "foobar2000.exe",
     "shortcuts": [
@@ -16,20 +16,16 @@
         ]
     ],
     "installer": {
-        "args": [
-            "/S",
-            "/D=$dir"
+        "script": [
+            "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
+            "New-Item \"$dir\\user_profiles_enabled\" -Force | Out-Null"
         ]
-    },
-    "uninstaller": {
-        "file": "uninstall.exe",
-        "args": "/S"
     },
     "checkver": {
         "url": "https://www.foobar2000.org/download",
         "re": "foobar2000_v([\\d\\.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe"
+        "url": "https://www.videohelp.com/download/foobar2000_v$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
tl; dr; It's not enough to persist `configuration`, `index-data` and `library`
folders. This persistence creates more problems than it solves.

foobar2000 config shouldn't be persisted that way. Entire config folder should
be included in persisted folders, because plugins use that folder to store
their files as well.

But this isn't possible, because "portable mode" for foobar2000 means moving
`$APPDATA/Roaming/foobar2000/*` to location where foobar2000 installed, and this
in return means you can't persist contents of every folder because you
don't know beforehand what to persist.