### PR TITLE
chromium-dev-nosync: fix autoupdate issues

### DIFF
--- a/bucket/chromium-dev-nosync.json
+++ b/bucket/chromium-dev-nosync.json
@@ -6,7 +6,7 @@
     "checkver": {
         "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=dev-codecs-nosync&out=json",
         "jsonpath": "$.chromium.windows.download",
-        "regex": "v(?<version>[\\d.]+-r\\d+)-Win64"
+        "regex": "v([\\d.]+-r\\d+)-Win64"
     },
     "bin": "chrome.exe",
     "shortcuts": [

--- a/bucket/chromium-dev-nosync.json
+++ b/bucket/chromium-dev-nosync.json
@@ -4,8 +4,9 @@
     "license": "BSD-3-Clause",
     "homepage": "https://www.chromium.org",
     "checkver": {
-        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=dev-codecs-nosync&out=string",
-        "re": "v([\\d.]+-r(?:\\d+))-win64"
+        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=dev-codecs-nosync&out=json",
+        "jsonpath": "$.chromium.windows.download",
+        "regex": "v(?<version>[\\d.]+-r\\d+)-Win64"
     },
     "bin": "chrome.exe",
     "extract_dir": "chrome-win32",
@@ -19,19 +20,12 @@
         "64bit": {
             "url": "https://github.com/henrypp/chromium/releases/download/v68.0.3424.0-r556419-win64/chromium-nosync.zip",
             "hash": "db68298721b73b8025bb2aa8c4c01819e7ecd3a4f9ff5553f8f45f2238e885ef"
-        },
-        "32bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v68.0.3424.0-r556419-win32/chromium-nosync.zip",
-            "hash": "1c7740e99073be2214600090cd848c588ff0455d6faf514d88b9bd3122c19ea0"
         }
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win64/chromium-nosync.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win32/chromium-nosync.zip"
+                "url": "https://github.com/macchrome/chromium/releases/download/v$version-Win64/Chrome-bin.7z"
             }
         }
     }

--- a/bucket/chromium-dev-nosync.json
+++ b/bucket/chromium-dev-nosync.json
@@ -1,5 +1,5 @@
 {
-    "version": "68.0.3424.0-r556419",
+    "version": "79.0.3917.0-r697525",
     "description": "An open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
     "license": "BSD-3-Clause",
     "homepage": "https://www.chromium.org",
@@ -9,7 +9,6 @@
         "regex": "v(?<version>[\\d.]+-r\\d+)-Win64"
     },
     "bin": "chrome.exe",
-    "extract_dir": "chrome-win32",
     "shortcuts": [
         [
             "chrome.exe",
@@ -18,8 +17,9 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v68.0.3424.0-r556419-win64/chromium-nosync.zip",
-            "hash": "db68298721b73b8025bb2aa8c4c01819e7ecd3a4f9ff5553f8f45f2238e885ef"
+            "url": "https://github.com/macchrome/chromium/releases/download/v79.0.3917.0-r697525-Win64/Chrome-bin.7z",
+            "hash": "5ad8983d6378699b7f3341df838fd370221a243fca00f15368cc41203381fa5d",
+            "extract_dir": "Chrome-bin"
         }
     },
     "autoupdate": {


### PR DESCRIPTION
Repository for this app changed to https://github.com/macchrome/chromium.
Owner of the new repo uses different naming scheme for releases.

Changed checkver to use JSON API, instead of raw string parsing.

Removed 32-bit version because only 64-bit builds are available now.

Related: #2308.