### PR TITLE
Now-cli: remove autoupdate

### DIFF
--- a/bucket/now-cli.json
+++ b/bucket/now-cli.json
@@ -14,15 +14,5 @@
             "now-win.exe",
             "now"
         ]
-    ],
-    "checkver": {
-        "github": "https://github.com/zeit/now-cli"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/zeit/now-cli/releases/download/$version/now-win.exe.gz"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
https://github.com/lukesampson/scoop-extras/issues/2308
See https://github.com/zeit/now/issues/3074#issuecomment-536098630
Should we add a note or remove this manifest?