### PR TITLE
Update persepolis.json

### DIFF
--- a/bucket/persepolis.json
+++ b/bucket/persepolis.json
@@ -5,12 +5,12 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3_2_0_windows_64bit.exe",
-            "hash": "fe1fc842b49daa555af3d1ffce4f8f5a2b664620d5004b96cbb6f177ed7be29f"
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_64bit.exe",
+            "hash": "3e1d5b1b129fa1b4931a01720230afc88952a33316e0d8927c16fb429188fd20"
         },
         "32bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3_2_0_windows_32bit.exe",
-            "hash": "dde3b8b72dc903b369b95af641454f6fe74e8961cd2008fdc5a1427e88b39809"
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_32bit.exe",
+            "hash": "557269eba62eb97a441a718956def6769be9e77264fcf51bf71821ffc343980c"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
Scoop cannot download Persepolis files. I guess the name of the files to download has changed (https://github.com/persepolisdm/persepolis/releases), so I made this pull request. And I generate a new hash for both files (_persepolis_3.2.0.0_windows_32bit.exe_ and _persepolis_3.2.0.0_windows_64bit.exe_).

I think this pull request will resolve issue #2920 and maybe #2855