### PR TITLE
archisteamfarm: Add version 4.0.4.3

### DIFF
--- a/bucket/archisteamfarm.json
+++ b/bucket/archisteamfarm.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/JustArchiNET/ArchiSteamFarm",
+    "version": "4.0.4.3",
+    "description": "C# application with primary purpose of idling Steam cards from multiple accounts simultaneously.",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/4.0.4.3/ASF-win-x64.zip#force.7z",
+            "hash": "111bc51827d7062b972ea116010881f9fc17ebb45e5be1d2ae1d7b0dae5ae51f"
+        }
+    },
+    "bin": "ArchiSteamFarm.exe",
+    "persist": "config",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/$version/ASF-win-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/archisteamfarm.json
+++ b/bucket/archisteamfarm.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/4.0.4.3/ASF-win-x64.zip#force.7z",
+            "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/4.0.4.3/ASF-win-x64.zip#/dl.7z",
             "hash": "111bc51827d7062b972ea116010881f9fc17ebb45e5be1d2ae1d7b0dae5ae51f"
         }
     },
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/$version/ASF-win-x64.zip#force.7z"
+                "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/$version/ASF-win-x64.zip#/dl.7z"
             }
         }
     }

--- a/bucket/archisteamfarm.json
+++ b/bucket/archisteamfarm.json
@@ -1,7 +1,8 @@
 {
-    "homepage": "https://github.com/JustArchiNET/ArchiSteamFarm",
+    "##": "Rename from zip to 7z is needed due to 'unsupported compression method' error.",
     "version": "4.0.4.3",
-    "description": "C# application with primary purpose of idling Steam cards from multiple accounts simultaneously.",
+    "description": "Farm Steam cards from multiple accounts simultaneously.",
+    "homepage": "https://github.com/JustArchiNET/ArchiSteamFarm",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
@@ -10,12 +11,21 @@
         }
     },
     "bin": "ArchiSteamFarm.exe",
-    "persist": "config",
+    "persist": [
+        "config",
+        "plugins"
+    ],
+    "shortcuts": [
+        [
+            "ArchiSteamFarm.exe",
+            "ArchiSteamFarm"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/$version/ASF-win-x64.zip"
+                "url": "https://github.com/JustArchiNET/ArchiSteamFarm/releases/download/$version/ASF-win-x64.zip#force.7z"
             }
         }
     }


### PR DESCRIPTION
Adding [ArchiSteamFarm](https://github.com/davidxuang/scoop-extras/tree/patch/archisteamfarm). Rename `.zip` to `.7z` as PowerShell does not support Deflate64.