### PR TITLE
keepass-plugin-yafd: Add version 1.2.2.0

### DIFF
--- a/bucket/keepass-plugin-YetAnotherFaviconDownloader.json
+++ b/bucket/keepass-plugin-YetAnotherFaviconDownloader.json
@@ -4,7 +4,7 @@
     "license": "MIT License",
     "version": "1.2.2.0",
     "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v1.2.2.0/YetAnotherFaviconDownloader.plgx",
-    "hash": "71e96081cfc03f54d1ccb21b9eb1ec49fa4b51d4c0e20b7c985e49cac320fb70",
+    "hash": "C90B496D1C3FA90BEE4A751ACCFE59F6A78714F3AFAA432420B7C7D7ABAE5668",
     "depends": "extras/keepass",
     "checkver": {
         "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/latest",

--- a/bucket/keepass-plugin-YetAnotherFaviconDownloader.json
+++ b/bucket/keepass-plugin-YetAnotherFaviconDownloader.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases",
+    "description": "Yet Another Favicon Downloader (YAFD for short) is a plugin for KeePass 2.x that allows you to quickly download favicons for your password entries.",
+    "license": "MIT License",
+    "version": "1.2.2.0",
+    "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v1.2.2.0/YetAnotherFaviconDownloader.plgx",
+    "hash": "71e96081cfc03f54d1ccb21b9eb1ec49fa4b51d4c0e20b7c985e49cac320fb70",
+    "depends": "extras/keepass",
+    "checkver": {
+        "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/latest",
+        "re": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v(?<version>[\\d.]+)/YetAnotherFaviconDownloader.plgx"
+    },
+    "autoupdate": {
+        "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v$version/YetAnotherFaviconDownloader.plgx"
+    },
+    "installer": {
+        "script": "Copy-Item \"$dir\\YetAnotherFaviconDownloader.plgx\" \"$(appdir keepass $global)\\current\\Plugins\""
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$(appdir keepass $global)\\current\\Plugins\\YetAnotherFaviconDownloader.plgx\""
+    }
+}

--- a/bucket/keepass-plugin-yafd.json
+++ b/bucket/keepass-plugin-yafd.json
@@ -1,15 +1,12 @@
 {
-    "homepage": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases",
+    "homepage": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader",
     "description": "Yet Another Favicon Downloader (YAFD for short) is a plugin for KeePass 2.x that allows you to quickly download favicons for your password entries.",
-    "license": "MIT License",
+    "license": "MIT",
     "version": "1.2.2.0",
     "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v1.2.2.0/YetAnotherFaviconDownloader.plgx",
-    "hash": "C90B496D1C3FA90BEE4A751ACCFE59F6A78714F3AFAA432420B7C7D7ABAE5668",
+    "hash": "c90b496d1c3fa90bee4a751accfe59f6a78714f3afaa432420b7c7d7abae5668",
     "depends": "extras/keepass",
-    "checkver": {
-        "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/latest",
-        "re": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v(?<version>[\\d.]+)/YetAnotherFaviconDownloader.plgx"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases/download/v$version/YetAnotherFaviconDownloader.plgx"
     },


### PR DESCRIPTION
Added https://github.com/navossoc/KeePass-Yet-Another-Favicon-Downloader/releases to the list of keepass plugin extras. 