### PR TITLE
piriform: Fix download.url and checkver

### DIFF
--- a/bucket/ccleaner.json
+++ b/bucket/ccleaner.json
@@ -37,8 +37,8 @@
     ],
     "persist": "ccleaner.ini",
     "checkver": {
-        "url": "https://www.ccleaner.com/ccleaner/download",
-        "regex": "<strong>v([\\d.]+)</strong>"
+        "url": "https://www.ccleaner.com/ccleaner/version-history",
+        "regex": ">v([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://download.ccleaner.com/portable/ccsetup$majorVersion$minorVersion.zip"

--- a/bucket/defraggler.json
+++ b/bucket/defraggler.json
@@ -3,8 +3,8 @@
     "version": "2.22.995",
     "license": "Freeware",
     "description": "Speed up your PC with quick & easy defragmentation.",
-    "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.zip",
-    "hash": "2edfa974fc2e8e34c0b8c152077da9c3a4ab28cad81a4ced463f0cf6634a0f01",
+    "url": "https://download.ccleaner.com/dfsetup222.exe#/dl.7z",
+    "hash": "b53eb82d6a46c812171ca878b7342e1939a0afecc277b0b57c708eef8fc700de",
     "architecture": {
         "64bit": {
             "bin": [
@@ -38,16 +38,18 @@
         }
     },
     "pre_install": [
+        "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst.exe\" -Recurse -Force",
         "if(!(Test-Path \"$persist_dir\\Defraggler.ini\")) {",
         "   Set-Content \"$dir\\Defraggler.ini\" (@('[Software\\Piriform\\Defraggler]', 'UpdateCheck=0') -join \"`r`n\") -Encoding ASCII",
         "}"
     ],
     "persist": "Defraggler.ini",
     "checkver": {
-        "url": "https://www.ccleaner.com/defraggler/download",
-        "regex": "Latest version: <b>([\\d.]+)</b>"
+        "url": "https://www.ccleaner.com/defraggler/version-history",
+        "regex": ">v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/defraggler/download/portable/downloadfile#/dl.zip"
+        "url": "https://download.ccleaner.com/dfsetup$majorVersion$minorVersion.exe#/dl.7z"
     }
 }

--- a/bucket/recuva.json
+++ b/bucket/recuva.json
@@ -3,8 +3,8 @@
     "version": "1.53.1087",
     "license": "Freeware",
     "description": "Recover your deleted files quickly and easily.",
-    "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/dl.zip",
-    "hash": "997a082fb03fcdf272d58c25aba488a136cf115a1e1b53930339fb5ef95bf91f",
+    "url": "https://download.ccleaner.com/rcsetup153.exe#/dl.7z",
+    "hash": "75155568d64e958d8003f9fbb36839fc9a53bfab3b51a8a1106a78e5be98b2e9",
     "architecture": {
         "64bit": {
             "bin": [
@@ -31,16 +31,18 @@
         }
     },
     "pre_install": [
+        "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst.exe\" -Recurse -Force",
         "if(!(Test-Path \"$persist_dir\\recuva.ini\")) {",
         "   Set-Content \"$dir\\recuva.ini\" (@('[Software\\Piriform\\Recuva]', 'UpdateCheck=0') -join \"`r`n\") -Encoding ASCII",
         "}"
     ],
     "persist": "recuva.ini",
     "checkver": {
-        "url": "https://www.ccleaner.com/recuva/download",
-        "regex": "Latest version: <b>([\\d.]+)</b>"
+        "url": "https://www.ccleaner.com/recuva/version-history",
+        "regex": ">v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/recuva/download/portable/downloadfile#/dl.zip"
+        "url": "https://download.ccleaner.com/rcsetup$majorVersion$minorVersion.exe#/dl.7z"
     }
 }

--- a/bucket/speccy.json
+++ b/bucket/speccy.json
@@ -3,8 +3,8 @@
     "version": "1.32.740",
     "license": "Freeware",
     "description": "Fast, lightweight, advanced system information tool for your PC.",
-    "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/dl.zip",
-    "hash": "1a662d847f16850658216634eda7c98ce06b0c861017de16e8dc8ff12a412abe",
+    "url": "https://download.ccleaner.com/spsetup132.exe#/dl.7z",
+    "hash": "64a5ba6d65e0b73ae6987c561c86b1e2338a1f337ab5bd5a87c9eeba4963cc3f",
     "architecture": {
         "64bit": {
             "bin": [
@@ -31,16 +31,18 @@
         }
     },
     "pre_install": [
+        "Set-Content \"$dir\\portable.dat\" '#PORTABLE#' -Encoding ASCII",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst.exe\" -Recurse -Force",
         "if(!(Test-Path \"$persist_dir\\Speccy.ini\")) {",
         "   Set-Content \"$dir\\Speccy.ini\" (@('[Software\\Piriform\\Speccy]', 'NeedUpdate=0') -join \"`r`n\") -Encoding ASCII",
         "}"
     ],
     "persist": "Speccy.ini",
     "checkver": {
-        "url": "https://www.ccleaner.com/speccy/download",
-        "regex": "Latest version: <b>([\\d.]+)</b>"
+        "url": "https://www.ccleaner.com/speccy/version-history",
+        "regex": ">v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.ccleaner.com/speccy/download/portable/downloadfile#/dl.zip"
+        "url": "https://download.ccleaner.com/spsetup$majorVersion$minorVersion.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
Fix #2951 

Piriform has changed its download url, and portable archives are not found anymore.