### PR TITLE
persepolis: Fix manifest

### DIFF
--- a/bucket/persepolis.json
+++ b/bucket/persepolis.json
@@ -1,15 +1,15 @@
 {
-    "homepage": "https://persepolisdm.github.io/",
-    "description": "A Free as libre download manager & a GUI for aria2, written in Python",
-    "version": "3.2.0",
+    "version": "3.2.0.0",
+    "description": "Download manager & GUI for aria2.",
+    "homepage": "https://persepolisdm.github.io",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_64bit.exe",
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0_windows_64bit.exe",
             "hash": "3e1d5b1b129fa1b4931a01720230afc88952a33316e0d8927c16fb429188fd20"
         },
         "32bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_32bit.exe",
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0_windows_32bit.exe",
             "hash": "557269eba62eb97a441a718956def6769be9e77264fcf51bf71821ffc343980c"
         }
     },
@@ -27,23 +27,16 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/persepolisdm/persepolis"
+        "github": "https://github.com/persepolisdm/persepolis",
+        "regex": "persepolis_([\\d.]+)_windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/persepolisdm/persepolis/releases/download/$version/persepolis_$underscoreVersion_windows_64bit.exe",
-                "hash": {
-                    "url": "https://github.com/AdmiringWorm/chocolatey-packages/raw/master/automatic/persepolis/legal/VERIFICATION.txt",
-                    "find": "\\s+checksum64:\\s+([a-fA-F\\d]{64})"
-                }
+                "url": "https://github.com/persepolisdm/persepolis/releases/download/$matchHead/persepolis_$version_windows_64bit.exe"
             },
             "32bit": {
-                "url": "https://github.com/persepolisdm/persepolis/releases/download/$version/persepolis_$underscoreVersion_windows_32bit.exe",
-                "hash": {
-                    "url": "https://github.com/AdmiringWorm/chocolatey-packages/raw/master/automatic/persepolis/legal/VERIFICATION.txt",
-                    "find": "\\s+checksum32:\\s+([a-fA-F\\d]{64})"
-                }
+                "url": "https://github.com/persepolisdm/persepolis/releases/download/$matchHead/persepolis_$version_windows_32bit.exe"
             }
         }
     }

--- a/bucket/persepolis.json
+++ b/bucket/persepolis.json
@@ -5,11 +5,11 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0_windows_64bit.exe",
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_64bit.exe",
             "hash": "3e1d5b1b129fa1b4931a01720230afc88952a33316e0d8927c16fb429188fd20"
         },
         "32bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0_windows_32bit.exe",
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_32bit.exe",
             "hash": "557269eba62eb97a441a718956def6769be9e77264fcf51bf71821ffc343980c"
         }
     },

--- a/bucket/persepolis.json
+++ b/bucket/persepolis.json
@@ -5,12 +5,12 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3_2_0_windows_64bit.exe",
-            "hash": "fe1fc842b49daa555af3d1ffce4f8f5a2b664620d5004b96cbb6f177ed7be29f"
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_64bit.exe",
+            "hash": "3e1d5b1b129fa1b4931a01720230afc88952a33316e0d8927c16fb429188fd20"
         },
         "32bit": {
-            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3_2_0_windows_32bit.exe",
-            "hash": "dde3b8b72dc903b369b95af641454f6fe74e8961cd2008fdc5a1427e88b39809"
+            "url": "https://github.com/persepolisdm/persepolis/releases/download/3.2.0/persepolis_3.2.0.0_windows_32bit.exe",
+            "hash": "557269eba62eb97a441a718956def6769be9e77264fcf51bf71821ffc343980c"
         }
     },
     "innosetup": true,


### PR DESCRIPTION
the persepolis release file version part changed from underscored to dotted for 3.2.0, and the hashes were incorrect

- Closes #2923
- Closes #2855
- Closes #2920
- Closes #2925