### PR TITLE
snappy-driver-installer-origin: Add version 1.5.6.705

### DIFF
--- a/bucket/snappy-driver-installer-origin.json
+++ b/bucket/snappy-driver-installer-origin.json
@@ -1,19 +1,30 @@
 {
-    "homepage": "https://www.snappy-driver-installer.org/",
-    "description": "Tool to install and update device drivers.",
-    "license": "GPLv3",
     "version": "1.5.6.705",
+    "description": "Device drivers installer and updater.",
+    "homepage": "https://www.snappy-driver-installer.org",
+    "license": "GPL-3.0-or-later",
     "url": "https://snappy-driver-installer.org/downloads/SDIO_1.5.6.705.zip",
     "hash": "b049d6a14689f63f81d088f947096a2c9401d279729a486020944e0edc16fc58",
-    "pre_install": [
-        "mv $dir/*/* $dir",
-        "mv $dir/SDIO_x64_R*.exe $dir/SDIO.exe"
-    ],
+    "extract_dir": "SDIO_1.5.6.705",
+    "architecture": {
+        "64bit": {
+            "pre_install": [
+                "Move-Item \"$dir\\SDIO_x64_*.exe\" \"$dir\\SDIO.exe\"",
+                "Remove-Item \"$dir\\SDIO_*exe\""
+            ]
+        },
+        "32bit": {
+            "pre_install": [
+                "Remove-Item \"$dir\\SDIO_x64_*exe\"",
+                "Move-Item \"$dir\\SDIO_*.exe\" \"$dir\\SDIO.exe\""
+            ]
+        }
+    },
+    "installer": {
+        "script": "if (-not (Test-Path \"$persist_dir\\sdi.cfg\")) { New-Item \"$dir\\sdi.cfg\" | Out-Null }"
+    },
     "bin": [
-        [
-            "SDIO.exe",
-            "SDIO.exe"
-        ],
+        "SDIO.exe",
         [
             "del_old_driverpacks.bat",
             "SDIO_del_old_driverpacks.bat"
@@ -34,10 +45,11 @@
         "sdi.cfg"
     ],
     "checkver": {
-        "url": "https://www.snappy-driver-installer.org/download/",
-        "regex": "SDIO_([\\d.]+).zip"
+        "url": "https://www.snappy-driver-installer.org/download",
+        "regex": "SDIO_([\\d.]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://snappy-driver-installer.org/downloads/SDIO_$version.zip"
+        "url": "https://snappy-driver-installer.org/downloads/SDIO_$version.zip",
+        "extract_dir": "SDIO_$version"
     }
 }

--- a/bucket/snappy-driver-installer-origin.json
+++ b/bucket/snappy-driver-installer-origin.json
@@ -1,0 +1,43 @@
+{
+    "homepage": "https://www.snappy-driver-installer.org/",
+    "description": "Tool to install and update device drivers.",
+    "license": "GPLv3",
+    "version": "1.5.6.705",
+    "url": "https://snappy-driver-installer.org/downloads/SDIO_1.5.6.705.zip",
+    "hash": "b049d6a14689f63f81d088f947096a2c9401d279729a486020944e0edc16fc58",
+    "pre_install": [
+        "mv $dir/*/* $dir",
+        "mv $dir/SDIO_x64_R*.exe $dir/SDIO.exe"
+    ],
+    "bin": [
+        [
+            "SDIO.exe",
+            "SDIO.exe"
+        ],
+        [
+            "del_old_driverpacks.bat",
+            "SDIO_del_old_driverpacks.bat"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "SDIO.exe",
+            "Snappy Driver Installer Origin"
+        ]
+    ],
+    "persist": [
+        "drivers",
+        "indexes",
+        "logs",
+        "scripts",
+        "update",
+        "sdi.cfg"
+    ],
+    "checkver": {
+        "url": "https://www.snappy-driver-installer.org/download/",
+        "regex": "SDIO_([\\d.]+).zip"
+    },
+    "autoupdate": {
+        "url": "https://snappy-driver-installer.org/downloads/SDIO_$version.zip"
+    }
+}


### PR DESCRIPTION
Note that unlike many apps that claim themselves to be a driver installer, SDIO is actually legit.