### PR TITLE
transgui: fix download URL

### DIFF
--- a/bucket/transgui.json
+++ b/bucket/transgui.json
@@ -3,7 +3,7 @@
     "description": "A feature rich cross platform Transmission BitTorrent client. Faster and has more functionality than the built-in web GUI.",
     "version": "5.18.0",
     "license": "GPL-2.0-or-later",
-    "url": "https://github.com/transmission-remote-gui/transgui/releases/download/v5.18.0/transgui-5.18-setup.exe",
+    "url": "https://github.com/transmission-remote-gui/transgui/releases/download/v5.18.0/transgui-5.18.0-setup.exe",
     "hash": "07cc99294c83d2ae429033abbdb99642f5271984966616fb2c319f087448c936",
     "innosetup": true,
     "bin": "transgui.exe",


### PR DESCRIPTION
Fix download URL error (original name transgui-5.18-setup.exe which lost ".0")