### PR TITLE
Add WireGuard

### DIFF
--- a/bucket/wireguard.json
+++ b/bucket/wireguard.json
@@ -1,0 +1,38 @@
+{
+    "homepage": "https://www.wireguard.com",
+    "description": "Simple and fast VPN client.",
+    "version": "0.1.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.wireguard.com/windows-client/wireguard-amd64-0.1.0.msi",
+            "hash": "1bba81cc4e95bf09fcd1d1d63afa0ec19ed204407aee770dcce647e3c3b04262"
+        },
+        "32bit": {
+            "url": "https://download.wireguard.com/windows-client/wireguard-x86-0.1.0.msi",
+            "hash": "cc6f49c8f16dcba3d6998dbfdeb0835e5cc1240a59b92959fef82243c4e03df8"
+        }
+    },
+    "extract_dir": "WireGuard",
+    "bin": "wireguard.exe",
+    "shortcuts": [
+        [
+            "wireguard.exe",
+            "WireGuard"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.wireguard.com/install",
+        "regex": "distro-status-uptodate\">([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.wireguard.com/windows-client/wireguard-amd64-$version.msi"
+            },
+            "32bit": {
+                "url": "https://download.wireguard.com/windows-client/wireguard-x86-$version.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add [WireGuard](https://www.wireguard.com/)

> WireGuard® is an extremely simple yet fast and modern VPN that utilizes state-of-the-art cryptography. It aims to be faster, simpler, leaner, and more useful than IPsec, while avoiding the massive headache. It intends to be considerably more performant than OpenVPN. WireGuard is designed as a general purpose VPN for running on embedded interfaces and super computers alike, fit for many different circumstances. Initially released for the Linux kernel, it is now cross-platform (Windows, macOS, BSD, iOS, Android) and widely deployable. It is currently under heavy development, but already it might be regarded as the most secure, easiest to use, and simplest VPN solution in the industry.