### PR TITLE
sagemath-installer: fix post_install

### DIFF
--- a/bucket/sagemath-installer.json
+++ b/bucket/sagemath-installer.json
@@ -53,8 +53,7 @@
         "    New-Item \"$dir\\runtime\\$_\" -Force -Type Directory | Out-Null",
         "}",
         "Get-Content \"$dir\\runtime\\etc\\symlinks.lst\" | ForEach-Object {",
-        "    $f = Get-Item $_",
-        "    $f.Attributes = 'System'",
+        "    (Get-Item \"$dir\\runtime\\$_\").Attributes = 'System'",
         "}"
     ],
     "checkver": {


### PR DESCRIPTION
The second step of post_install was failing, as it was using UNIX-style paths, that were misinterpreted as relative to current directory `scoop install` was ran from.