### PR TITLE
Add butterflow-ui

### DIFF
--- a/bucket/butterflow-ui.json
+++ b/bucket/butterflow-ui.json
@@ -7,10 +7,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/wagesj45/butterflow-ui/releases/download/1.1.0/butterflow_ui.setup.msi",
-            "hash": "2bfc590281746cac65161b156b93f764f96d261a899e1daa95bc2b04c0a241bf",
-            "extract_dir": "butterflow-ui"
+            "hash": "2bfc590281746cac65161b156b93f764f96d261a899e1daa95bc2b04c0a241bf"
         }
     },
+    "extract_dir": "butterflow-ui",
     "bin": [
         "butterflow-ui.exe",
         "ThirdPartyCompiled\\butterflow.exe"

--- a/bucket/butterflow-ui.json
+++ b/bucket/butterflow-ui.json
@@ -3,7 +3,6 @@
     "description": "Graphical user interface for butterflow, a video manipulation tool.",
     "homepage": "https://github.com/wagesj45/butterflow-ui",
     "license": "MIT",
-    "notes": "butterflow is packaged with butterflow-ui and does not need to be installed separately.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/wagesj45/butterflow-ui/releases/download/1.1.0/butterflow_ui.setup.msi",
@@ -12,8 +11,7 @@
     },
     "extract_dir": "butterflow-ui",
     "bin": [
-        "butterflow-ui.exe",
-        "ThirdPartyCompiled\\butterflow.exe"
+        "butterflow-ui.exe"
     ],
     "shortcuts": [
         [

--- a/bucket/butterflow-ui.json
+++ b/bucket/butterflow-ui.json
@@ -10,9 +10,7 @@
         }
     },
     "extract_dir": "butterflow-ui",
-    "bin": [
-        "butterflow-ui.exe"
-    ],
+    "bin": "butterflow-ui.exe",
     "shortcuts": [
         [
             "butterflow-ui.exe",

--- a/bucket/butterflow-ui.json
+++ b/bucket/butterflow-ui.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.1.0",
+    "description": "Graphical user interface for butterflow, a video manipulation tool.",
+    "homepage": "https://github.com/wagesj45/butterflow-ui",
+    "license": "MIT",
+    "notes": "butterflow is packaged with butterflow-ui and does not need to be installed separately.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wagesj45/butterflow-ui/releases/download/1.1.0/butterflow_ui.setup.msi",
+            "hash": "2bfc590281746cac65161b156b93f764f96d261a899e1daa95bc2b04c0a241bf",
+            "extract_dir": "butterflow-ui"
+        }
+    },
+    "bin": [
+        "butterflow-ui.exe",
+        "ThirdPartyCompiled\\butterflow.exe"
+    ],
+    "shortcuts": [
+        [
+            "butterflow-ui.exe",
+            "butterflow-ui"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wagesj45/butterflow-ui/releases/download/$version/butterflow_ui.setup.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
butterflow-ui is a graphical user interface for [butterflow](https://github.com/ScoopInstaller/Main/pull/491). It comes packaged with butterflow, so butterflow does not need to be installed separately.