### PR TITLE
Add WinAuth

### DIFF
--- a/bucket/winauth.json
+++ b/bucket/winauth.json
@@ -1,7 +1,7 @@
 {
     "version": "3.6.2",
     "description": "Portable and open-source authenticator.",
-    "homepage": "https://github.com/winauth/winauth",
+    "homepage": "https://winauth.github.io/winauth/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/winauth/winauth/releases/download/3.6.2/WinAuth-3.6.2.zip",
     "hash": "3f34eb1ca342ad0783cd57c84f2f73c37df3ea880768dd415f509bfdbf02a785",

--- a/bucket/winauth.json
+++ b/bucket/winauth.json
@@ -1,0 +1,15 @@
+{
+    "version": "3.6.2",
+    "description": "Portable and open-source authenticator.",
+    "homepage": "https://github.com/winauth/winauth",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/winauth/winauth/releases/download/3.6.2/WinAuth-3.6.2.zip",
+    "hash": "3f34eb1ca342ad0783cd57c84f2f73c37df3ea880768dd415f509bfdbf02a785",
+    "bin": "WinAuth.exe",
+    "shortcuts": [
+        [
+            "WinAuth.exe",
+            "WinAuth"
+        ]
+    ]
+}

--- a/bucket/winauth.json
+++ b/bucket/winauth.json
@@ -1,10 +1,10 @@
 {
     "version": "3.6.2",
-    "description": "Portable and open-source authenticator.",
+    "description": "Authenticator for a wide variety of websites and services.",
     "homepage": "https://winauth.github.io/winauth/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/winauth/winauth/releases/download/3.6.2/WinAuth-3.6.2.zip",
-    "hash": "3f34eb1ca342ad0783cd57c84f2f73c37df3ea880768dd415f509bfdbf02a785",
+    "hash": "sha512:8288a970946c149382c1d8919905fda5381d04f24a4ceed1ec4f3fc7fda0a7c8f5c1fc062b7b312dca55531eecf04327ca0743afbb82ff08acedf4c7c9c4ed1f",
     "bin": "WinAuth.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
WinAuth is a portable, open-source authenticator for Windows that provides counter or time-based RFC 6238 authenticators and common implementations. Autoupdate is not necessary as the project is no longer active.