### PR TITLE
Fix TeamSpeak shortcut

### DIFF
--- a/bucket/teamspeak3.json
+++ b/bucket/teamspeak3.json
@@ -13,7 +13,7 @@
             "shortcuts": [
                 [
                     "ts3client_win64.exe",
-                    "Team Speak 3"
+                    "TeamSpeak 3"
                 ]
             ]
         },
@@ -23,7 +23,7 @@
             "shortcuts": [
                 [
                     "ts3client_win32.exe",
-                    "Team Speak 3"
+                    "TeamSpeak 3"
                 ]
             ]
         }


### PR DESCRIPTION
"Team Speak" is wrong, the correct name is "TeamSpeak"