### PR TITLE
mp3directcut: Add version 2.25

### DIFF
--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -11,7 +11,7 @@
             "Remove-Item \"$dir\\mp3DC225.exe\" -Recurse -Force"
         ]
     },
-    "bin: "mp3DirectCut.exe",
+    "bin": "mp3DirectCut.exe",
     "shortcuts": [
         [
             "mp3DirectCut.exe",

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -3,13 +3,24 @@
     "license": "Freeware",
     "version": "2.25",
     "description": "a free, lossless audio editor and recorder for MP3 files",
-    "url": "http://www.winsoftware.de/Startedownload39417",
+    "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
+     "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\mp3DC225.exe\" -Removal",
+            "Remove-Item \"$dir\\mp3DC225.exe\" -Recurse -Force"
+        ]
+    },
+    "bin: "mp3DirectCut.exe",
     "shortcuts": [
         [
             "mp3DirectCut.exe",
             "mp3DirectCut"
         ]
     ],
-    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware"
+    "persist": "mp3DirectCut.ini",
+    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
+    "autoupdate": {
+        "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC$version.exe"
+    }
 }

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -11,5 +11,5 @@
             "mp3DirectCut"
         ]
     ],
-    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
+    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware"
 }

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -1,14 +1,18 @@
 {
+    "##": "Rename to #/dl.7z cannot be used as download is not stripping rename and fosshub cannot handle it",
+    "version": "2.25",
+    "description": "Lossless audio editor and recorder for MP3 files.",
     "homepage": "http://mpesch3.de",
     "license": "Freeware",
-    "version": "2.25",
-    "description": "a free, lossless audio editor and recorder for MP3 files",
-    "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
+    "url": "https://www.fosshub.com/mp3DirectCut.html/mp3DC225.exe",
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
     "installer": {
-      "script": [
-        "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal"
-      ]
+        "script": [
+            "Expand-7zipArchive \"$dir\\$fname\" -Removal",
+            "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
+            "    Set-Content \"$dir\\mp3DirectCut.ini\" '[mp3DirectCut]' | Out-Null }",
+            "}"
+        ]
     },
     "bin": "mp3DirectCut.exe",
     "shortcuts": [
@@ -17,8 +21,13 @@
             "mp3DirectCut"
         ]
     ],
-    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
+    "persist": "mp3DirectCut.ini",
+    "checkver": "Version ([\\d.]+)",
     "autoupdate": {
-        "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC$version.exe"
+        "url": "https://www.fosshub.com/mp3DirectCut.html/mp3DC$cleanVersion.exe",
+        "hash": {
+            "url": "http://mpesch3.de",
+            "regex": "checksum:\\s*$md5"
+        }
     }
 }

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -10,7 +10,7 @@
         "script": [
             "Expand-7zipArchive \"$dir\\$fname\" -Removal",
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
-            "    Set-Content \"$dir\\mp3DirectCut.ini\" '[mp3DirectCut]' | Out-Null }",
+            "    Set-Content \"$dir\\mp3DirectCut.ini\" '[mp3DirectCut]' | Out-Null",
             "}"
         ]
     },

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -7,8 +7,8 @@
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
      "installer": {
         "script": [
-            "Expand-7zipArchive \"$dir\\mp3DC225.exe\" -Removal",
-            "Remove-Item \"$dir\\mp3DC225.exe\" -Recurse -Force"
+            "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal",
+            "Remove-Item \"$dir\\mp3DirectCut.html\" -Recurse -Force"
         ]
     },
     "bin": "mp3DirectCut.exe",

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -3,7 +3,7 @@
     "license": "Freeware",
     "version": "2.25",
     "description": "a free, lossless audio editor and recorder for MP3 files",
-    "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
+    "url": "http://www.winsoftware.de/Startedownload39417",
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
     "shortcuts": [
         [
@@ -12,7 +12,4 @@
         ]
     ],
     "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
-    "autoupdate": {
-        "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe"
-    }
 }

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -5,11 +5,12 @@
     "description": "a free, lossless audio editor and recorder for MP3 files",
     "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
-     "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal",
-            "Remove-Item \"$dir\\mp3DirectCut.html\" -Recurse -Force"
-        ]
+    "pre_install": "if (!(Test-Path \"$persist_dir\\mp3DirectCut.ini\")) { New-Item \"$dir\\mp3DirectCut.ini\" -ItemType File | Out-Null }",
+    "installer": {
+      "script": [
+        "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal",
+        "Remove-Item \"$dir\\mp3DirectCut.html\" -Recurse -Force"
+      ]
     },
     "bin": "mp3DirectCut.exe",
     "shortcuts": [

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -10,7 +10,6 @@
         "script": [
             "Expand-7zipArchive \"$dir\\$fname\" -Removal",
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
-            "    Set-Content \"$dir\\mp3DirectCut.ini\" '[mp3DirectCut]' | Out-Null",
             "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") | Out-Null",
             "} else {",
             "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\"",

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -5,7 +5,6 @@
     "description": "a free, lossless audio editor and recorder for MP3 files",
     "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
     "hash": "md5:872f3923af1982fc39a18d724ffd5904",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\mp3DirectCut.ini\")) { New-Item \"$dir\\mp3DirectCut.ini\" -ItemType File | Out-Null }",
     "installer": {
       "script": [
         "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal"
@@ -18,7 +17,6 @@
             "mp3DirectCut"
         ]
     ],
-    "persist": "mp3DirectCut.ini",
     "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
     "autoupdate": {
         "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC$version.exe"

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -8,8 +8,7 @@
     "pre_install": "if (!(Test-Path \"$persist_dir\\mp3DirectCut.ini\")) { New-Item \"$dir\\mp3DirectCut.ini\" -ItemType File | Out-Null }",
     "installer": {
       "script": [
-        "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal",
-        "Remove-Item \"$dir\\mp3DirectCut.html\" -Recurse -Force"
+        "Expand-7zipArchive \"$dir\\mp3DirectCut.html\" -Removal"
       ]
     },
     "bin": "mp3DirectCut.exe",

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -10,7 +10,7 @@
         "script": [
             "Expand-7zipArchive \"$dir\\$fname\" -Removal",
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
-            "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") | Out-Null",
+            "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") -Encoding Ascii",
             "} else {",
             "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\"",
             "}",

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -12,7 +12,7 @@
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
             "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") -Encoding Ascii",
             "} else {",
-            "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\"",
+            "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\" -Encoding Ascii",
             "}",
             "New-Item \"$dir\\mp3DClocal.ini\" | Out-Null"
         ]

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "http://mpesch3.de",
+    "license": "Freeware",
+    "version": "2.25",
+    "description": "a free, lossless audio editor and recorder for MP3 files",
+    "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe",
+    "hash": "md5:872f3923af1982fc39a18d724ffd5904",
+    "shortcuts": [
+        [
+            "mp3DirectCut.exe",
+            "mp3DirectCut"
+        ]
+    ],
+    "checkver": "Version ([\\d.]+) .* simple installer (sfx zip) · Freeware",
+    "autoupdate": {
+        "url": "https://www.fosshub.com/mp3DirectCut.html?dwl=mp3DC225.exe"
+    }
+}

--- a/bucket/mp3directcut.json
+++ b/bucket/mp3directcut.json
@@ -11,7 +11,11 @@
             "Expand-7zipArchive \"$dir\\$fname\" -Removal",
             "if (-not (Test-Path \"$persist_dir\\mp3DirectCut.ini\")) {",
             "    Set-Content \"$dir\\mp3DirectCut.ini\" '[mp3DirectCut]' | Out-Null",
-            "}"
+            "    Set-Content \"$dir\\mp3DirectCut.ini\" @('[mp3DirectCut]', \"version=$version\") | Out-Null",
+            "} else {",
+            "    (Get-Content \"$persist_dir\\mp3DirectCut.ini\") -replace 'version=.+', \"version=$version\" | Set-Content \"$persist_dir\\mp3DirectCut.ini\"",
+            "}",
+            "New-Item \"$dir\\mp3DClocal.ini\" | Out-Null"
         ]
     },
     "bin": "mp3DirectCut.exe",


### PR DESCRIPTION
Hello,

After first run, the process create mp3DirectCut.ini file that could be persistable. I tried with the persist feature but it creates it as a folder, Any idea how to implement it properly ?