### PR TITLE
FileZilla-Server: Fix persist

### DIFF
--- a/bucket/filezilla-server.json
+++ b/bucket/filezilla-server.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-or-later",
     "url": "https://download.filezilla-project.org/server/FileZilla_Server-0_9_60_2.exe#/dl.7z",
     "hash": "sha512:0e0a92f3693d31d09341354ce212f42e1941743cf5f49bffe58b0c05cbc04865470e96c145ae0ffeea060a86d618da2a7de78a38946a9c3a2dcb956d0f2b3cfa",
-    "notes": "Run 'filezilla_server' as Admin to configure FileZilla Server.",
+    "notes": "Run 'filezilla-server' as Admin to configure FileZilla Server.",
     "installer": {
         "script": [
             "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\source\", \"$dir\\`$R1\", \"$dir\\Uninstall.exe.nsis\" -Recurse",
-            "if(!(Test-Path \"$dir\\FileZilla Server.xml\")) {Set-Content \"$dir\\FileZilla Server.xml\" $null}"
+            "if(!(Test-Path \"$persist_dir\\FileZilla Server.xml\")) {Set-Content \"$dir\\FileZilla Server.xml\" '<FileZillaServer></FileZillaServer>'}"
         ]
     },
     "uninstaller": {
@@ -23,7 +23,7 @@
         "FileZilla Server.exe",
         [
             "FileZilla Server.exe",
-            "filezilla_server"
+            "filezilla-server"
         ]
     ],
     "shortcuts": [


### PR DESCRIPTION
* Change the target of *Test-Path* from `$dir` to `$persist_dir`.

* **FileZilla Server** cannot handle the empty `FileZilla Server.xml`, which results in an error when saving user settings. (`protocol error: Invalid data, could not import account settings. Could not change account settings`) This fixes the problem by adding required fields to `FileZilla Server.xml`.

* Rename the shim-exe from `filezilla_server` to `filezilla-server`. (more intuitive, because it's the same name as package name `filezilla-server`)
