### PR TITLE
linqpad: fix file names

### DIFF
--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -9,33 +9,41 @@
     "url": "http://download.linqpad.net/public/LINQPad6.zip",
     "hash": "d9995e26e11faa9f03c1916d7a0382f59055c8aeef318abe8b783a47f24e458f",
     "depends": "dotnet-sdk",
+    "pre_install": [
+        "$major = $version -split '\\.' | Select-Object -First 1",
+        "Get-ChildItem \"$dir\" 'l*.exe' | ForEach-Object {",
+        "         # $1 is needed to not remove character",
+        "    $newName = $_.Basename -replace \"([^8])$major\", '$1'",
+        "    Rename-Item $_.Fullname ($newName + $_.Extension)",
+        "}"
+    ],
     "architecture": {
         "64bit": {
             "bin": [
-                "lprun6.exe",
-                "linqpad6.exe",
-                "lprun6-x86.exe",
-                "linqpad6-x86.exe"
+                "lprun.exe",
+                "linqpad.exe",
+                "lprun-x86.exe",
+                "linqpad-x86.exe"
             ],
             "shortcuts": [
                 [
-                    "linqpad6.exe",
+                    "linqpad.exe",
                     "LINQPad"
                 ],
                 [
-                    "linqpad6-x86.exe",
+                    "linqpad-x86.exe",
                     "LINQPad x86"
                 ]
             ]
         },
         "32bit": {
             "bin": [
-                "lprun6-x86.exe",
-                "linqpad6-x86.exe"
+                "lprun-x86.exe",
+                "linqpad-x86.exe"
             ],
             "shortcuts": [
                 [
-                    "linqpad6-x86.exe",
+                    "linqpad-x86.exe",
                     "LINQPad"
                 ]
             ]

--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -12,30 +12,30 @@
     "architecture": {
         "64bit": {
             "bin": [
-                "lprun.exe",
-                "linqpad.exe",
-                "lprun-x86.exe",
-                "linqpad-x86.exe"
+                "lprun6.exe",
+                "linqpad6.exe",
+                "lprun6-x86.exe",
+                "linqpad6-x86.exe"
             ],
             "shortcuts": [
                 [
-                    "linqpad.exe",
+                    "linqpad6.exe",
                     "LINQPad"
                 ],
                 [
-                    "linqpad-x86.exe",
+                    "linqpad6-x86.exe",
                     "LINQPad x86"
                 ]
             ]
         },
         "32bit": {
             "bin": [
-                "lprun-x86.exe",
-                "linqpad-x86.exe"
+                "lprun6-x86.exe",
+                "linqpad6-x86.exe"
             ],
             "shortcuts": [
                 [
-                    "linqpad-x86.exe",
+                    "linqpad6-x86.exe",
                     "LINQPad"
                 ]
             ]


### PR DESCRIPTION
Fixes error `Can't shim 'lprun.exe': File doesn't exist.`