### PR TITLE
ao: Add version 6.9.0

### DIFF
--- a/bucket/ao.json
+++ b/bucket/ao.json
@@ -1,0 +1,28 @@
+{
+    "version": "6.9.0",
+    "description": "Elegant Microsoft To Do desktop app.",
+    "homepage": "https://klaussinani.tech/ao/",
+    "license": "MIT",
+    "url": "https://github.com/klaussinani/ao/releases/download/v6.9.0/ao-6.9.0.exe/#dl.7z",
+    "hash": "171a29295264c16e11bb35ae31326d92a81bc77a35561a71fafbc192224c855c",
+    "extract_dir": "$PLUGINSDIR",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\app-$(if ($architecture -eq '64bit') { '64' } else { '86' }).7z\" \"$dir\"",
+            "Remove-Item \"$dir\\app-*.7z\""
+        ]
+    },
+    "bin": "Ao.exe",
+    "shortcuts": [
+        [
+            "Ao.exe",
+            "Ao"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/klaussinani/ao"
+    },
+    "autoupdate": {
+        "url": "https://github.com/klaussinani/ao/releases/download/v$version/ao-$version.exe/#dl.7z"
+    }
+}

--- a/bucket/ao.json
+++ b/bucket/ao.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "url": "https://github.com/klaussinani/ao/releases/download/v6.9.0/ao-6.9.0.exe/#dl.7z",
     "hash": "171a29295264c16e11bb35ae31326d92a81bc77a35561a71fafbc192224c855c",
-    "extract_dir": "$PLUGINSDIR",
     "architecture": {
         "64bit": {
             "installer": {

--- a/bucket/ao.json
+++ b/bucket/ao.json
@@ -6,11 +6,23 @@
     "url": "https://github.com/klaussinani/ao/releases/download/v6.9.0/ao-6.9.0.exe/#dl.7z",
     "hash": "171a29295264c16e11bb35ae31326d92a81bc77a35561a71fafbc192224c855c",
     "extract_dir": "$PLUGINSDIR",
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\app-$(if ($architecture -eq '64bit') { '64' } else { '86' }).7z\" \"$dir\"",
-            "Remove-Item \"$dir\\app-*.7z\""
-        ]
+    "architecture": {
+        "64bit": {
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        },
+        "32bit": {
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        }
     },
     "bin": "Ao.exe",
     "shortcuts": [

--- a/bucket/ao.json
+++ b/bucket/ao.json
@@ -3,7 +3,7 @@
     "description": "Elegant Microsoft To Do desktop app.",
     "homepage": "https://klaussinani.tech/ao/",
     "license": "MIT",
-    "url": "https://github.com/klaussinani/ao/releases/download/v6.9.0/ao-6.9.0.exe/#dl.7z",
+    "url": "https://github.com/klaussinani/ao/releases/download/v6.9.0/ao-6.9.0.exe#/dl.7z",
     "hash": "171a29295264c16e11bb35ae31326d92a81bc77a35561a71fafbc192224c855c",
     "architecture": {
         "64bit": {
@@ -34,6 +34,6 @@
         "github": "https://github.com/klaussinani/ao"
     },
     "autoupdate": {
-        "url": "https://github.com/klaussinani/ao/releases/download/v$version/ao-$version.exe/#dl.7z"
+        "url": "https://github.com/klaussinani/ao/releases/download/v$version/ao-$version.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
Ao is an elegant Microsoft To Do desktop app. I wasn't sure if I should wrap the installer script in `architecture`.