### PR TITLE
Updated wsl-ssh-pageant version to 20190527.1

### DIFF
--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -2,7 +2,7 @@
     "homepage": "https://github.com/benpye/wsl-ssh-pageant/",
     "description": "A Pageant -> TCP bridge for use with WSL, allowing for Pageant to be used as an ssh-ageant within the WSL environment.",
     "license": "BSD-2-Clause",
-    "version": "20190513.14",
+    "version": "20190527.1",
     "bin": [
         "wsl-ssh-pageant.exe",
         "wsl-ssh-pageant-gui.exe"
@@ -10,22 +10,22 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190527.1/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190527.1/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
-                "84b926fd8737cb509bba9ff5c51a01838088dadaa9513addccb5a8ace4a7f7dc",
-                "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
+                "97871dc03f78ef5cbfbecf1275ad6cb05486c43d22d4ba8db9a37147306991d0",
+                "f6be8588df1dabed06da4b28935d32560b5cd5239ee7992f527cfdaed7811f92"
             ]
         },
         "32bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190527.1/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190527.1/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
-                "85d923a911b9604ab457219318264c776969990cf9d49ce60882c83835a8591d",
-                "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
+                "73997f937be12be4610fe642a89fff48cb09fe2c1f30ab18a521e4846fcf2c04",
+                "f6be8588df1dabed06da4b28935d32560b5cd5239ee7992f527cfdaed7811f92"
             ]
         }
     }


### PR DESCRIPTION
Updated wsl-ssh-pageant to newer version.

This has the `-force` option, which comes in handy for autostarting the daemon.