### PR TITLE
tixati: Add version 2.64

### DIFF
--- a/bucket/tixati.json
+++ b/bucket/tixati.json
@@ -1,0 +1,55 @@
+{
+    "version": "2.64",
+    "homepage": "https://tixati.com/",
+    "description": "BitTorrent client with advanced features",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.tixati.com/tixati_eula.txt"
+    },
+    "bin": [
+        [
+            "persist/tixati.exe",
+            "tixati"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "persist/tixati.exe",
+            "Tixati"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://download1.tixati.com/download/tixati-2.64-1.win64-install.exe#/dl.7z",
+            "hash": "2e6252380971cf13e04c43334b5ed30edfbc2c17f4d4c45bac7e01fe4d3229d8"
+        },
+        "32bit": {
+            "url": "https://download1.tixati.com/download/tixati-2.64-1.win32-install.exe#/dl.7z",
+            "hash": "997808b1d252e44508db50c284935c6012835076445fbeba6de8f989edddc0fb"
+        }
+    },
+    "persist": "persist",
+    "pre_install": [
+        "New-Item -ItemType Directory -Force -Path $dir/persist/downloads | Out-Null",
+        "Add-Content $dir/persist/tixati_portable_mode.txt $null",
+        "Add-Content $dir/persist/tixati.exe $null"
+    ],
+    "post_install": [
+        "Get-Item $dir/*~ | Rename-Item -NewName tixati.exe",
+        "Copy-Item -Force $dir/tixati.exe $dir/persist/"
+    ],
+    "checkver": {
+        "url": "https://www.tixati.com/download/windows64.html",
+        "re": "Download Tixati v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download1.tixati.com/download/tixati-$version-1.win64-install.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://download1.tixati.com/download/tixati-$version-1.win32-install.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/tixati.json
+++ b/bucket/tixati.json
@@ -1,23 +1,11 @@
 {
     "version": "2.64",
-    "homepage": "https://tixati.com/",
     "description": "BitTorrent client with advanced features",
+    "homepage": "https://tixati.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.tixati.com/tixati_eula.txt"
     },
-    "bin": [
-        [
-            "persist/tixati.exe",
-            "tixati"
-        ]
-    ],
-    "shortcuts": [
-        [
-            "persist/tixati.exe",
-            "Tixati"
-        ]
-    ],
     "architecture": {
         "64bit": {
             "url": "https://download1.tixati.com/download/tixati-2.64-1.win64-install.exe#/dl.7z",
@@ -28,19 +16,30 @@
             "hash": "997808b1d252e44508db50c284935c6012835076445fbeba6de8f989edddc0fb"
         }
     },
-    "persist": "persist",
-    "pre_install": [
-        "New-Item -ItemType Directory -Force -Path $dir/persist/downloads | Out-Null",
-        "Add-Content $dir/persist/tixati_portable_mode.txt $null",
-        "Add-Content $dir/persist/tixati.exe $null"
+    "installer": {
+        "script": [
+            "New-Item \"$dir\\tixati_portable_mode.txt\" | Out-Null",
+            "Rename-Item \"$dir\\*~\" 'tixati.exe'",
+            "if (Test-Path \"$persist_dir\") { Copy-Item \"$persist_dir\\*\" \"$dir\" -Force }"
+        ]
+    },
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\*.dat\" \"$persist_dir\" -Force"
+    },
+    "bin": "tixati.exe",
+    "shortcuts": [
+        [
+            "tixati.exe",
+            "Tixati"
+        ]
     ],
-    "post_install": [
-        "Get-Item $dir/*~ | Rename-Item -NewName tixati.exe",
-        "Copy-Item -Force $dir/tixati.exe $dir/persist/"
+    "persist": [
+        "downloads",
+        "incomplete-pieces"
     ],
     "checkver": {
-        "url": "https://www.tixati.com/download/windows64.html",
-        "re": "Download Tixati v([\\d.]+)"
+        "url": "https://www.tixati.com/download",
+        "regex": "Download Tixati v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Tixati is very stubborn and disregards current working folder, randomly dropping config files around the .exe as you edit settings. Creating empty files in their place does not work, as Tixati errors out on loading an empty config file.

Thus this solution just copies the .exe file into the persisted folder and runs it from there.