### PR TITLE
azuredatastudio-insiders: download nightly instead of stable

### DIFF
--- a/bucket/azuredatastudio-insiders.json
+++ b/bucket/azuredatastudio-insiders.json
@@ -3,12 +3,7 @@
     "version": "nightly",
     "description": "A cross-platform database tool for data professionals using the Microsoft family of on-premises and cloud data platforms.",
     "license": "MIT",
-    "bin": [
-        [
-            "bin\\azuredatastudio-insiders.cmd",
-            "azuredatastudio-insiders"
-        ]
-    ],
+    "bin": "bin\\azuredatastudio-insiders.cmd",
     "shortcuts": [
         [
             "azuredatastudio-insiders.exe",

--- a/bucket/azuredatastudio-insiders.json
+++ b/bucket/azuredatastudio-insiders.json
@@ -3,13 +3,13 @@
     "version": "nightly",
     "description": "A cross-platform database tool for data professionals using the Microsoft family of on-premises and cloud data platforms.",
     "license": "MIT",
+    "url": "https://azuredatastudio-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.7z",
+    "extract_dir": "azuredatastudio-windows",
     "bin": "bin\\azuredatastudio-insiders.cmd",
     "shortcuts": [
         [
             "azuredatastudio-insiders.exe",
             "Azure Data Studio - Insiders"
         ]
-    ],
-    "url": "https://azuredatastudio-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.7z",
-    "extract_dir": "azuredatastudio-windows"
+    ]
 }

--- a/bucket/azuredatastudio-insiders.json
+++ b/bucket/azuredatastudio-insiders.json
@@ -1,22 +1,20 @@
 {
     "homepage": "https://docs.microsoft.com/en-us/sql/azure-data-studio",
-    "version": "1.12.2",
+    "version": "nightly",
     "description": "A cross-platform database tool for data professionals using the Microsoft family of on-premises and cloud data platforms.",
     "license": "MIT",
-    "bin": "bin\\azuredatastudio.cmd",
-    "shortcuts": [
+    "bin": [
         [
-            "azuredatastudio.exe",
-            "Azure Data Studio"
+            "bin\\azuredatastudio-insiders.cmd",
+            "azuredatastudio-insiders"
         ]
     ],
-    "url": "https://github.com/Microsoft/azuredatastudio/releases/download/1.12.2/azuredatastudio-windows-1.12.2.zip",
-    "hash": "89c0b9ef1223f6010802556524ee3b5042e7ebfa5e5513412bc35cbeac707b7f",
-    "extract_dir": "azuredatastudio-windows",
-    "checkver": {
-        "github": "https://github.com/Microsoft/azuredatastudio"
-    },
-    "autoupdate": {
-        "url": "https://github.com/Microsoft/azuredatastudio/releases/download/$version/azuredatastudio-windows-$version.zip"
-    }
+    "shortcuts": [
+        [
+            "azuredatastudio-insiders.exe",
+            "Azure Data Studio - Insiders"
+        ]
+    ],
+    "url": "https://azuredatastudio-update.azurewebsites.net/latest/win32-x64-archive/insider#/dl.7z",
+    "extract_dir": "azuredatastudio-windows"
 }


### PR DESCRIPTION
URL was pointing to the stable version of Azure Data Studio. Updated to correctly download the Insiders edition and updated file and shortcut names as appropriate.