### PR TITLE
windows-terminal: Add version 0.6.2951.0

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -1,0 +1,44 @@
+{
+    "homepage": "https://github.com/microsoft/terminal",
+    "description": "The new Windows Terminal, and the original Windows console host - all in the same place!",
+    "version": "0.6.2951.0",
+    "license": "MIT",
+    "url": "https://github.com/microsoft/terminal/releases/download/v0.6.2951.0/Microsoft.WindowsTerminal_0.6.2951.0_8wekyb3d8bbwe.msixbundle#/dl.7z",
+    "hash": "1e55cd46043ad5613242aae3bceb528b81a181a8b388015ebe7767000102d06a",
+    "architecture": {
+        "64bit": {
+            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x64.msix | rm -Recurse -Force"
+        },
+        "32bit": {
+            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x32.msix | rm -Recurse -Force"
+        }
+    },
+    "installer": {
+        "script": [
+            "$WindowsVersion=[Environment]::OSVersion.Version",
+            "if ($WindowsVersion.Major -ne \"10\") {",
+            "  throw \"This package requires Windows 10.\"",
+            "}",
+            "#The .msixbundle format is not supported on Windows 10 version 1709 and 1803. https://docs.microsoft.com/en-us/windows/msix/msix-1709-and-1803-support",
+            "$IsCorrectBuild=[Environment]::OSVersion.Version.Build",
+            "if ($IsCorrectBuild -lt \"18362\") {",
+            "  throw \"This package requires at least Windows 10 version 1903/OS build 18362.x.\"",
+            "}",
+            "Expand-7zipArchive -Path \"$($dir)\\CascadiaPackage_$($version)_x64.msix\" -Removal"
+        ]
+    },
+    "bin": "WindowsTerminal.exe",
+    "shortcuts": [
+        [
+            "WindowsTerminal.exe",
+            "Windows Terminal (Preview)"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/microsoft/terminal/releases",
+        "regex": "Microsoft\\.WindowsTerminal_(.+)_(.*)\\.msixbundle"
+    },
+    "autoupdate": {
+        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminal_$version_$match2.msixbundle#/dl.7z"
+    }
+}

--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -24,7 +24,7 @@
     "shortcuts": [
         [
             "WindowsTerminal.exe",
-            "Windows Terminal (Preview)"
+            "Windows Terminal"
         ]
     ],
     "checkver": {

--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -7,25 +7,17 @@
     "hash": "1e55cd46043ad5613242aae3bceb528b81a181a8b388015ebe7767000102d06a",
     "architecture": {
         "64bit": {
-            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x64.msix | rm -Recurse -Force"
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"
         },
         "32bit": {
-            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x86.msix | rm -Recurse -Force"
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x86.msix' | Remove-Item -Force -Recurse"
         }
     },
     "installer": {
         "script": [
-            "$WindowsVersion=[Environment]::OSVersion.Version",
-            "if ($WindowsVersion.Major -ne \"10\") {",
-            "  throw \"This package requires Windows 10.\"",
-            "}",
-            "#The .msixbundle format is not supported on Windows 10 version 1709 and 1803. https://docs.microsoft.com/en-us/windows/msix/msix-1709-and-1803-support",
-            "$IsCorrectBuild=[Environment]::OSVersion.Version.Build",
-            "if ($IsCorrectBuild -lt \"18362\") {",
-            "  throw \"This package requires at least Windows 10 version 1903/OS build 18362.x.\"",
-            "}",
-            "$arch=if ($architecture -eq \"64bit\") { \"x64\" } else { \"x86\" }",
-            "Expand-7zipArchive -Path \"$($dir)\\CascadiaPackage_$($version)_$($arch).msix\" -Removal"
+            "$winVer = [Environment]::OSVersion.Version",
+            "if (($winver.Major -lt '10') -or ($winVer.Build -lt 18362)) { error 'At least Windows 10 18362 is required.'; break }",
+            "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
         ]
     },
     "bin": "WindowsTerminal.exe",
@@ -37,9 +29,9 @@
     ],
     "checkver": {
         "url": "https://github.com/microsoft/terminal/releases",
-        "regex": "Microsoft\\.WindowsTerminal_(.+)_(.*)\\.msixbundle"
+        "regex": "WindowsTerminal_([\\d.]+)_8wekyb3d8bbwe\\.msixbundle"
     },
     "autoupdate": {
-        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminal_$version_$match2.msixbundle#/dl.7z"
+        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminal_$version_8wekyb3d8bbwe.msixbundle#/dl.7z"
     }
 }

--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -10,7 +10,7 @@
             "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x64.msix | rm -Recurse -Force"
         },
         "32bit": {
-            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x32.msix | rm -Recurse -Force"
+            "pre_install": "gci $dir -Exclude CascadiaPackage_$($version)_x86.msix | rm -Recurse -Force"
         }
     },
     "installer": {
@@ -24,7 +24,8 @@
             "if ($IsCorrectBuild -lt \"18362\") {",
             "  throw \"This package requires at least Windows 10 version 1903/OS build 18362.x.\"",
             "}",
-            "Expand-7zipArchive -Path \"$($dir)\\CascadiaPackage_$($version)_x64.msix\" -Removal"
+            "$arch=if ($architecture -eq \"64bit\") { \"x64\" } else { \"x86\" }",
+            "Expand-7zipArchive -Path \"$($dir)\\CascadiaPackage_$($version)_$($arch).msix\" -Removal"
         ]
     },
     "bin": "WindowsTerminal.exe",

--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -1,10 +1,10 @@
 {
-    "homepage": "https://github.com/microsoft/terminal",
+    "version": "0.7.3382.0",
     "description": "The new Windows Terminal, and the original Windows console host - all in the same place!",
-    "version": "0.6.2951.0",
+    "homepage": "https://github.com/microsoft/terminal",
     "license": "MIT",
-    "url": "https://github.com/microsoft/terminal/releases/download/v0.6.2951.0/Microsoft.WindowsTerminal_0.6.2951.0_8wekyb3d8bbwe.msixbundle#/dl.7z",
-    "hash": "1e55cd46043ad5613242aae3bceb528b81a181a8b388015ebe7767000102d06a",
+    "url": "https://github.com/microsoft/terminal/releases/download/v0.7.3382.0/Microsoft.WindowsTerminal_0.7.3382.0_8wekyb3d8bbwe.msixbundle#/cosi.7z",
+    "hash": "8998f7c00ad7b9ce66a75c02fd9a830465f54038d22fb6a0744c8de5f46c1ef2",
     "architecture": {
         "64bit": {
             "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"


### PR DESCRIPTION
- Closes #2921
- Closes #3320 

Adds Windows Terminal

Install script and autoupdate regex adapted from the unofficial chocolatey package.