### PR TITLE
feat(github): Present GithubActions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows/* @Ash258
+/.github/workflows/ @Ash258

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows/* @Ash258

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -12,5 +12,5 @@ jobs:
       uses: Ash258/Scoop-GithubActions@stable
       if: startsWith(github.event.comment.body, '/verify')
       env:
-        GITH_EMAIL: r15ch13+git@gmail.com
+        GITH_EMAIL: cabera.jakub@gmail.com
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,0 +1,16 @@
+on:
+  issue_comment:
+    types: [ created ]
+name: Commented Pull Request
+jobs:
+  pullRequestHandler:
+    name: PullRequestHandler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: PullRequestHandler
+      uses: Ash258/Scoop-GithubActions@stable
+      if: startsWith(github.event.comment.body, '/verify')
+      env:
+        GITH_EMAIL: r15ch13+git@gmail.com
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,5 +12,5 @@ jobs:
       uses: Ash258/Scoop-GithubActions@stable
       if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))
       env:
-        GITH_EMAIL: r15ch13+git@gmail.com
+        GITH_EMAIL: cabera.jakub@gmail.com
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,16 @@
+on:
+  issues:
+    types: [ opened, labeled ]
+name: Issues
+jobs:
+  issueHandler:
+    name: IssueHandler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: IssueHandler
+      uses: Ash258/Scoop-GithubActions@stable
+      if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))
+      env:
+        GITH_EMAIL: r15ch13+git@gmail.com
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,5 +11,5 @@ jobs:
     - name: PullRequestHandler
       uses: Ash258/Scoop-GithubActions@stable
       env:
-        GITH_EMAIL: r15ch13+git@gmail.com
+        GITH_EMAIL: cabera.jakub@gmail.com
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+on:
+  pull_request:
+    types: [ opened ]
+name: Pull Requests
+jobs:
+  pullRequestHandler:
+    name: PullRequestHandler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: PullRequestHandler
+      uses: Ash258/Scoop-GithubActions@stable
+      env:
+        GITH_EMAIL: r15ch13+git@gmail.com
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github actions hit 1.0.0 today and from my testing are capable of general repeated tasks.
There are totally use cases/actions/problems which I missed/cannot property test/need to implement, but in general they are working.

~~@r15ch13 I added your email, as you have push access to all scoop wide repositories. Please review it and if you have some problem with it, I can add myself or new machine user could be created.~~

Examples:

- Issues
	- Hash check fails
		- First issue: https://github.com/Ash258/GithubActionsBucketForTesting/issues/182
		- Duplicated issue: https://github.com/Ash258/GithubActionsBucketForTesting/issues/184
		- PR: https://github.com/Ash258/GithubActionsBucketForTesting/pull/183
	- Download failed
		- https://github.com/Ash258/GithubActionsBucketForTesting/issues/194
		- https://github.com/Ash258/GithubActionsBucketForTesting/issues/193
- Pull requests
	- Local: https://github.com/Ash258/GithubActionsBucketForTesting/pull/197
	- Forks: https://github.com/Ash258/GithubActionsBucketForTesting/pull/196

https://github.com/Ash258/Scoop-GithubActions/releases/tag/1.0.0
https://github.com/marketplace/actions/bucket-minion

All actions are deployed on all buckets I run.

https://github.com/Ash258/scoop-Ash258/pulls?utf8=%E2%9C%93&q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+hash+fix

I am pretty confident with current state and also I need more lab rats for testing.

Collaborators: I highly suggest you configure notification settings to receive them only on failed actions or never.