### PR TITLE
Fixed altair config

### DIFF
--- a/bucket/altair.json
+++ b/bucket/altair.json
@@ -5,7 +5,7 @@
     "description": "Beautiful feature-rich GraphQL Client.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/imolorhe/altair/releases/download/v2.3.6/altair-electron_2.3.6_win.exe#/dl.7z",
+            "url": "https://github.com/imolorhe/altair/releases/download/v2.3.6/altair_2.3.6_win.exe#/dl.7z",
             "hash": "sha512:e66dd63875f53eb17b2f494e9918cc7513a78f1375b0bdeb84f86ea68493eef89d2c29223c957c0f5fbba352b3a03d7de91e4136fa08353eb55df038b34875a3",
             "installer": {
                 "script": [

--- a/bucket/altair.json
+++ b/bucket/altair.json
@@ -25,7 +25,7 @@
         "github": "https://github.com/imolorhe/altair"
     },
     "autoupdate": {
-        "url": "https://github.com/imolorhe/altair/releases/download/v$version/altair-electron_$version_win.exe#/dl.7z",
+        "url": "https://github.com/imolorhe/altair/releases/download/v$version/altair_$version_win.exe#/dl.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512: $base64"


### PR DESCRIPTION
The file name in altair is different from v2.3.5 and 2.3.6. This fixes that.