### PR TITLE
altools@1.0: Hash fix

### DIFF
--- a/bucket/altools.json
+++ b/bucket/altools.json
@@ -4,7 +4,7 @@
     "version": "1.0",
     "license": "Unknown",
     "url": "https://download.microsoft.com/download/1/f/0/1f0e9569-3350-4329-b443-822976f29284/ALTools.exe#/dl.7z",
-    "hash": "716718c095ef5ad5724bc8344cbccc176e14fd773de89c517f6c8514cd3ae260",
+    "hash": "b2b439713b9b50f447e07ddbe7a3462f7bc129e8e1e1b49c4352a7c396912381",
     "bin": [
         "ALoInfo.exe",
         "EventCombMT.exe",


### PR DESCRIPTION
Microsoft seems to have modified the self-extractor (license terms perhaps?) but have validated the files it contains are all the same. I have updated the hash to match.

- Closes #3084 