### PR TITLE
waterfox: use "classic" branch, add waterfox-current package for "current" branch

### DIFF
--- a/bucket/waterfox-current.json
+++ b/bucket/waterfox-current.json
@@ -18,8 +18,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.waterfox.net/update/win64/56.0/en-US/release/update.xml",
-        "xpath": "updates/update/@version"
+        "url": "https://www.waterfox.net/releases/",
+        "regex": "Waterfox%20Current%20(\\d{4}\\.\\d{1,2})%20Setup.exe"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/waterfox-current.json
+++ b/bucket/waterfox-current.json
@@ -1,0 +1,31 @@
+{
+    "version": "2019.10",
+    "description": "The 100% fresh, free-range, ethical browser.",
+    "homepage": "https://www.waterfox.net",
+    "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Current%202019.10%20Setup.exe#/dl.7z",
+            "hash": "d208a40ad818a526da8b8ab8cb43a084658172fea6393a785b3f7a29c00e1f1a"
+        }
+    },
+    "extract_dir": "core",
+    "bin": "waterfox.exe",
+    "shortcuts": [
+        [
+            "waterfox.exe",
+            "Waterfox"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.waterfox.net/update/win64/56.0/en-US/release/update.xml",
+        "xpath": "updates/update/@version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Current%20$version%20Setup.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/waterfox-current.json
+++ b/bucket/waterfox-current.json
@@ -1,8 +1,14 @@
 {
     "version": "2019.10",
-    "description": "The 100% fresh, free-range, ethical browser.",
+    "description": "The 100% fresh, free-range, ethical browser (current branch).",
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
+    "notes": [
+        "You have installed Waterfox Current. For Waterfox Classic, please install 'waterfox'.",
+        "Waterfox Classic is the legacy branch that supports all the old features, standards and extensions.",
+        "Waterfox Current introduces new features and options, but will not support some of the features of the old versions.",
+        "See https://www.waterfox.net/blog/waterfox-2019.10-release-download/ for details."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Current%202019.10%20Setup.exe#/dl.7z",

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -1,11 +1,12 @@
 {
     "version": "2019.10",
-    "description": "The 100% fresh, free-range, ethical browser.",
+    "description": "The 100% fresh, free-range, ethical browser (classic branch).",
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
     "notes": [
-        "This is the 'classic' version of Waterfox.",
-        "For the 'current' version, please install 'waterfox-current'.",
+        "You have installed Waterfox Classic. For Waterfox Current, please install 'waterfox-current'.",
+        "Waterfox Classic is the legacy branch that supports all the old features, standards and extensions.",
+        "Waterfox Current introduces new features and options, but will not support some of the features of the old versions.",
         "See https://www.waterfox.net/blog/waterfox-2019.10-release-download/ for details."
     ],
     "architecture": {

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -3,6 +3,11 @@
     "description": "The 100% fresh, free-range, ethical browser.",
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
+    "notes": [
+                "This is the 'classic' version of Waterfox.",
+                "For the 'current' version, please install 'waterfox-current'.",
+                "See https://www.waterfox.net/blog/waterfox-2019.10-release-download/ for details."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Classic%202019.10%20Setup.exe#/dl.7z",

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -1,12 +1,12 @@
 {
-    "version": "56.2.14",
+    "version": "2019.10",
     "description": "The 100% fresh, free-range, ethical browser.",
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%2056.2.14%20Setup.exe#/dl.7z",
-            "hash": "818494cea04fe461191ca1a4314dcc3cec32b8a17875353d625dbb21d0c674af"
+            "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Classic%202019.10%20Setup.exe#/dl.7z",
+            "hash": "3f58d5a5b1379323729ccb75374e1213c4ad7b4209f63ead1d5e3c2c0c00538f"
         }
     },
     "extract_dir": "core",
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20$version%20Setup.exe#/dl.7z"
+                "url": "https://storage-waterfox.netdna-ssl.com/releases/win64/installer/Waterfox%20Classic%20$version%20Setup.exe#/dl.7z"
             }
         }
     }

--- a/bucket/waterfox.json
+++ b/bucket/waterfox.json
@@ -4,9 +4,9 @@
     "homepage": "https://www.waterfox.net",
     "license": "MPL-2.0",
     "notes": [
-                "This is the 'classic' version of Waterfox.",
-                "For the 'current' version, please install 'waterfox-current'.",
-                "See https://www.waterfox.net/blog/waterfox-2019.10-release-download/ for details."
+        "This is the 'classic' version of Waterfox.",
+        "For the 'current' version, please install 'waterfox-current'.",
+        "See https://www.waterfox.net/blog/waterfox-2019.10-release-download/ for details."
     ],
     "architecture": {
         "64bit": {
@@ -23,8 +23,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.waterfox.net/update/win64/56.0/en-US/release/update.xml",
-        "xpath": "updates/update/@version"
+        "url": "https://www.waterfox.net/releases/",
+        "regex": "Waterfox%20Classic%20(\\d{4}\\.\\d{1,2})%20Setup.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

**Waterfox** has [split their development into 2 branches](https://www.waterfox.net/blog/waterfox-2019.10-release-download/).

The **classic** branch is the legacy branch that supports all the old standards (it will not be retired, and will be actively maintained). The **current** branch introduces new features and options that the classic version does not support.

https://www.waterfox.net/ has a **download button** on its homepage, and it leads to the classic branch. 

Therefore, I tend to link `waterfox` package to the **classic branch**, and add another `waterfox-current` package for **current branch**. So that users using the `waterfox` package can keep their software updated.

Please tell me if there is a better idea. Thanks!