### PR TITLE
onlyoffice-desktopeditors: Update to 5.4.1-2 (Manually)

### DIFF
--- a/bucket/onlyoffice-desktopeditors.json
+++ b/bucket/onlyoffice-desktopeditors.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.3.5",
+    "version": "5.4.1-2",
     "description": "Office suite that combines text, spreadsheet and presentation editors allowing to create, view and edit documents.",
     "homepage": "https://www.onlyoffice.com/apps.aspx",
     "license": "AGPL-3.0-only",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.3.5/DesktopEditors_x64.exe",
-            "hash": "356002deff774aa4bec1b382b3ac7495a34ee8087e02d29d7e1be73091051b96"
+            "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.4.1-2/DesktopEditors_x64.exe",
+            "hash": "0bf65e4c8b19115f1426e1e53b91eb50fcc253d80b89d8dd906a45777cc844d6"
         },
         "32bit": {
-            "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.3.5/DesktopEditors_x86.exe",
-            "hash": "546199e2bf5bb7880ff2762819525f591d0c82626a4fc1729cfd3ca746415565"
+            "url": "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/ONLYOFFICE-DesktopEditors-5.4.1-2/DesktopEditors_x86.exe",
+            "hash": "bab0f8e6a6a466b701f1e047a92fe48440ac177426461d9269a5d11e8cefd5ad"
         }
     },
     "innosetup": true,
@@ -27,7 +27,7 @@
     ],
     "checkver": {
         "github": "https://github.com/ONLYOFFICE/DesktopEditors",
-        "regex": "DesktopEditors-([\\d.]+)"
+        "regex": "tree/ONLYOFFICE-DesktopEditors-([\\d.-]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

[Onlyoffice desktop editors](https://github.com/ONLYOFFICE/DesktopEditors/releases/) now put hyphens in their version tags. (such as ver `5.4.1-2`).