### PR TITLE
ydl-ui: update to version 2.6.1 (manually)

### DIFF
--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -2,10 +2,10 @@
     "homepage": "https://github.com/Maxstupo/ydl-ui",
     "description": "A UI for the command-line video downloader youtube-dl",
     "license": "MIT",
-    "version": "2.6.0",
-    "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v2.6.0/YDL_UI_v2.6.0_Portable.zip",
-    "hash": "d6bb724ee81e45434355e78786ad4f459d2ea996eb388617475a38cec3345de6",
-    "extract_dir": "YDL_UI_v2.6.0_Portable",
+    "version": "2.6.1",
+    "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v2.6.1/YDL-UI_Portable_v2.6.1.zip",
+    "hash": "acc5dce425df07fab5d9b59190f2720cd5b18f2852f424900abd06252281bfa1",
+    "extract_dir": "YDL_UI_v2.6.1_Portable",
     "bin": "YDL-UI.exe",
     "shortcuts": [
         [
@@ -15,7 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v$version/YDL_UI_v$version_Portable.zip",
+        "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v$version/YDL-UI_Portable_v$version.zip",
         "extract_dir": "YDL_UI_v$version_Portable"
     }
 }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

**ydl-ui** has changed its file name pattern from *YDL_UI_v**xxx**_Portable* to *YDL-UI_Portable_v**xxx***.