### PR TITLE
zettlr: Fix hash

### DIFF
--- a/bucket/zettlr.json
+++ b/bucket/zettlr.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Zettlr/Zettlr/releases/download/v1.4.3/Zettlr-win32-x64-1.4.3.exe#/dl.7z",
-            "hash": "94dfb98be729097a2745a0cb42c2f985e961c7bb0fd595815ed3f028b20c0a2b",
+            "hash": "1ff61664d073241368a43e5d718c728402f8ba73fe31773007dd23cdfccd7ddf",
             "installer": {
                 "script": [
                     "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",


### PR DESCRIPTION
Fix #3112

It seems like developer change original file.

https://scoop.r15.ch/extras/mud-20191101-150001.log

https://github.com/Zettlr/Zettlr/releases/download/v1.4.3/SHA256SUMS.txt