### PR TITLE
ydl-ui: Update to version 2.6.2 (manually)

### DIFF
--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -8,10 +8,10 @@
     "extract_dir": "YDL_UI_v2.6.2_Portable",
     "installer": {
         "script": [
-            "if(!(Test-Path \"$persist_dir\\ydl-ui.json\")){",
+            "if ((!(Test-Path \"$persist_dir\\ydl-ui.json\")) -and (Test-Path \"$dir\\ydl-ui.json\")) {",
             "    $cont = Get-Content \"$dir\\ydl-ui.json\" | ConvertFrom-Json",
             "    $cont.CheckForUpdates = $false",
-            "    $cont | ConvertToPrettyJson | Set-Content \"$dir\\ydl-ui.json\"",
+            "    $cont | ConvertToPrettyJson | Set-Content \"$dir\\ydl-ui.json\" -Encoding Ascii -Force",
             "}"
         ]
     },

--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -6,12 +6,23 @@
     "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v2.6.2/YDL_UI_v2.6.2_Portable.zip",
     "hash": "774a4bf579eaa253f4712d561f7a6b0b545a959fec8e6f17078963a453ef8542",
     "extract_dir": "YDL_UI_v2.6.2_Portable",
+    "installer": {
+        "script": [
+            "if(!(Test-Path \"$persist_dir\\ydl-ui.json\")){",
+            "    (Get-Content \"$dir\\ydl-ui.json\").replace('\"CheckForUpdates\": true', '\"CheckForUpdates\": false') | Set-Content \"$dir\\ydl-ui.json\"",
+            "}"
+        ]
+    },
     "bin": "YDL-UI.exe",
     "shortcuts": [
         [
             "YDL-UI.exe",
             "YDL-UI"
         ]
+    ],
+    "persist":[
+        "download-list.json",
+        "ydl-ui.json"
     ],
     "checkver": "github",
     "autoupdate": {

--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -2,10 +2,10 @@
     "homepage": "https://github.com/Maxstupo/ydl-ui",
     "description": "A UI for the command-line video downloader youtube-dl",
     "license": "MIT",
-    "version": "2.6.1",
-    "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v2.6.1/YDL-UI_Portable_v2.6.1.zip",
-    "hash": "acc5dce425df07fab5d9b59190f2720cd5b18f2852f424900abd06252281bfa1",
-    "extract_dir": "YDL_UI_v2.6.1_Portable",
+    "version": "2.6.2",
+    "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v2.6.2/YDL_UI_v2.6.2_Portable.zip",
+    "hash": "774a4bf579eaa253f4712d561f7a6b0b545a959fec8e6f17078963a453ef8542",
+    "extract_dir": "YDL_UI_v2.6.2_Portable",
     "bin": "YDL-UI.exe",
     "shortcuts": [
         [
@@ -15,7 +15,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v$version/YDL-UI_Portable_v$version.zip",
+        "url": "https://github.com/Maxstupo/ydl-ui/releases/download/v$version/YDL_UI_v$version_Portable.zip",
         "extract_dir": "YDL_UI_v$version_Portable"
     }
 }

--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -9,7 +9,9 @@
     "installer": {
         "script": [
             "if(!(Test-Path \"$persist_dir\\ydl-ui.json\")){",
-            "    (Get-Content \"$dir\\ydl-ui.json\").replace('\"CheckForUpdates\": true', '\"CheckForUpdates\": false') | Set-Content \"$dir\\ydl-ui.json\"",
+            "    $cont = Get-Content \"$dir\\ydl-ui.json\" | ConvertFrom-Json",
+            "    $cont.CheckForUpdates = $false",
+            "    $cont | ConvertToPrettyJson | Set-Content \"$dir\\ydl-ui.json\"",
             "}"
         ]
     },

--- a/bucket/ydl-ui.json
+++ b/bucket/ydl-ui.json
@@ -22,7 +22,7 @@
             "YDL-UI"
         ]
     ],
-    "persist":[
+    "persist": [
         "download-list.json",
         "ydl-ui.json"
     ],


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* [ydl-ui](https://github.com/Maxstupo/ydl-ui/releases) changed their file name back to the original pattern. This fixes the download URL.

* This also adds `download-list.json` and `ydl-ui.json` to *persist*.

* The *installer.script* will modify `ydl-ui.json` to disable update. (if previous persist data does not exist)