### PR TITLE
losslesscut: Update to version 2.6.2 (manually)

### DIFF
--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -1,39 +1,26 @@
 {
     "homepage": "https://github.com/mifi/lossless-cut",
-    "description": "Save space by quickly and losslessly trimming video and audio files.",
-    "version": "2.4.0",
+    "description": "Lossless trimming tool for video and audio files.",
+    "version": "2.6.2",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/mifi/lossless-cut/releases/download/v2.4.0/LosslessCut-win32-x64.zip",
-            "hash": "49cf1e1a250fab8dfd42f33ce4e7d4e1de19ebd29caa975ce579cf22e7dc130f",
-            "extract_dir": "LosslessCut-win32-x64"
-        },
-        "32bit": {
-            "url": "https://github.com/mifi/lossless-cut/releases/download/v2.4.0/LosslessCut-win32-ia32.zip",
-            "hash": "0f87bd29d44266f65f30ece2af766347b4d4e16fd9cd753f24bc75ee35252f0b",
-            "extract_dir": "LosslessCut-win32-ia32"
-        }
+    "url": "https://github.com/mifi/lossless-cut/releases/download/v2.6.2/LosslessCut-2.6.2.exe#/dl.7z",
+    "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc",
+    "depends": "7zip",
+    "installer":{
+        "script": [
+            "7z x \"$dir\\`$PLUGINSDIR\\app-64.7z\" -o\"$dir\" | Out-Null",
+            "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+        ]
     },
+    "bin": "LosslessCut.exe",
     "shortcuts": [
         [
             "LosslessCut.exe",
             "LosslessCut"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/mifi/lossless-cut"
-    },
+    "checkver": "github",
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-win32-x64.zip",
-                "extract_dir": "LosslessCut-win32-x64"
-            },
-            "32bit": {
-                "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-win32-ia32.zip",
-                "extract_dir": "LosslessCut-win32-ia32"
-            }
-        }
+        "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-$version.exe#/dl.7z"
     }
 }

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -8,7 +8,7 @@
     "depends": "7zip",
     "installer":{
         "script": [
-            "7z x \"$dir\\`$PLUGINSDIR\\app-64.7z\" -o\"$dir\" | Out-Null",
+            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
             "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
         ]
     },

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -4,16 +4,16 @@
     "version": "2.6.2",
     "license": "MIT",
     "architecture": {
-        "64bit" :{
+        "64bit": {
             "url": "https://github.com/mifi/lossless-cut/releases/download/v2.6.2/LosslessCut-2.6.2.exe#/dl.7z",
-            "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc"
+            "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc",
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" | Out-Null",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
+                ]
+            }
         }
-    },
-    "installer":{
-        "script": [
-            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" | Out-Null",
-            "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
-        ]
     },
     "bin": "LosslessCut.exe",
     "shortcuts": [

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -29,6 +29,5 @@
                 "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-$version.exe#/dl.7z"
             }
         }
-        
     }
 }

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -3,12 +3,15 @@
     "description": "Lossless trimming tool for video and audio files.",
     "version": "2.6.2",
     "license": "MIT",
-    "url": "https://github.com/mifi/lossless-cut/releases/download/v2.6.2/LosslessCut-2.6.2.exe#/dl.7z",
-    "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc",
-    "depends": "7zip",
+    "architecture": {
+        "64bit" :{
+            "url": "https://github.com/mifi/lossless-cut/releases/download/v2.6.2/LosslessCut-2.6.2.exe#/dl.7z",
+            "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc"
+        }
+    },
     "installer":{
         "script": [
-            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+            "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" | Out-Null",
             "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
         ]
     },
@@ -21,6 +24,11 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-$version.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mifi/lossless-cut/releases/download/v$version/LosslessCut-$version.exe#/dl.7z"
+            }
+        }
+        
     }
 }

--- a/bucket/losslesscut.json
+++ b/bucket/losslesscut.json
@@ -9,7 +9,7 @@
             "hash": "2e99be1fe8be6dd6e6a10e7103635cdcd5d52dac1329c3175c68c8026e4048fc",
             "installer": {
                 "script": [
-                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\" | Out-Null",
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
                     "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse"
                 ]
             }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

[Lossless Cut](https://github.com/mifi/lossless-cut/releases/) now use installers instead of ZIP archives.

Also modified `description` to make it more brief.