### PR TITLE
dbvis: Update to version 10.0.24 (manually)

### DIFF
--- a/bucket/dbvis.json
+++ b/bucket/dbvis.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.0.23",
+    "version": "10.0.24",
     "homepage": "https://www.dbvis.com/",
     "description": "A universal database tool for developers, DBAs and analysts.",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "http://www.dbvis.com/product_download/dbvis-10.0.23/media/dbvis_windows-x64_10_0_23.zip",
-            "hash": "9d77790aaa65096083620f5143c3d5c6c5b195433ad3f017308ae244f39763d9"
+            "url": "http://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x64_10_0_24.zip",
+            "hash": "6666a7d49c6703c1d25d642a5a6b77014b81c4162d5a0d30b7e17e4f711eb0c9"
         },
         "32bit": {
-            "url": "http://www.dbvis.com/product_download/dbvis-10.0.23/media/dbvis_windows_10_0_23.zip",
-            "hash": "76ba87481a1718a0744f7d2c691366d13d7f380ceb7523d8ba9120ae2f6d315a"
+            "url": "http://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x32_10_0_24.zip",
+            "hash": "7bc68de1ca9c0058dc2d9f02850899f6e69e24bb499402eba78c3a00ecc1192e"
         }
     },
     "suggest": {
@@ -40,7 +40,7 @@
                 "url": "http://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x64_$underscoreVersion.zip"
             },
             "32bit": {
-                "url": "http://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows_$underscoreVersion.zip"
+                "url": "http://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x32_$underscoreVersion.zip"
             }
         }
     }

--- a/bucket/dbvis.json
+++ b/bucket/dbvis.json
@@ -8,7 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "http://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x64_10_0_24.zip",
+            "url": "https://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x64_10_0_24.zip",
             "hash": "6666a7d49c6703c1d25d642a5a6b77014b81c4162d5a0d30b7e17e4f711eb0c9"
         },
         "32bit": {

--- a/bucket/dbvis.json
+++ b/bucket/dbvis.json
@@ -12,7 +12,7 @@
             "hash": "6666a7d49c6703c1d25d642a5a6b77014b81c4162d5a0d30b7e17e4f711eb0c9"
         },
         "32bit": {
-            "url": "http://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x32_10_0_24.zip",
+            "url": "https://www.dbvis.com/product_download/dbvis-10.0.24/media/dbvis_windows-x32_10_0_24.zip",
             "hash": "7bc68de1ca9c0058dc2d9f02850899f6e69e24bb499402eba78c3a00ecc1192e"
         }
     },
@@ -37,10 +37,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x64_$underscoreVersion.zip"
+                "url": "https://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x64_$underscoreVersion.zip"
             },
             "32bit": {
-                "url": "http://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x32_$underscoreVersion.zip"
+                "url": "https://www.dbvis.com/product_download/dbvis-$version/media/dbvis_windows-x32_$underscoreVersion.zip"
             }
         }
     }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

[DBVis](https://www.dbvis.com/download/10.0) added `-x32` to the filename of their 32-bit releases.