### PR TITLE
firefox-nightly: fix checkver

### DIFF
--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -1,16 +1,16 @@
 {
     "description": "Nightly builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/nightly/",
-    "version": "72.0a1",
+    "version": "72.0a1.20191105095755",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
             "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-72.0a1.en-US.win64.installer.exe#/dl.7z",
-            "hash": "sha512:a8b1d49338dab7a513adfbfecef0abfb11f78dfd9a419cfd4d59c8cfebeba64d5bf7c4a00523a7572e8dc1e45cbd7aa1605fa8fd207f597248c707b04e335d6d"
+            "hash": "sha512:7b07be0a5121c26acc9c3353a3fc5ec8de481af2d6f61a66efe4f6eb0387cf33642d40448f9f4d62fa8a9128912119b3026210d72bc4d30909b6b3b928fb46a4"
         },
         "32bit": {
             "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-72.0a1.en-US.win32.installer.exe#/dl.7z",
-            "hash": "sha512:e2a1de9bd0ec9dd021a2d7a399571932da23244763afb2e22fefb05b59204e16537bb116030df944cc4069079676bb4f3db2e28336efed96882e9bf2edfaf9a4"
+            "hash": "sha512:04b54b662a5cf94937563b65c1b2c71268908cb9afac6a97f81b75018dca622e377340ad2b1a0f3aaa8d8daf20585c9cb42da93e0dd315bb996aaa919efdb84d"
         }
     },
     "extract_dir": "core",
@@ -28,20 +28,21 @@
     ],
     "checkver": {
         "url": "https://aus5.mozilla.org/update/6/Firefox/60.0/_/WINNT_x86_64-msvc-x64/en-US/nightly/_/_/_/_/update.xml",
-        "xpath": "/updates/update/@appVersion"
+        "regex": "appVersion=\"([\\w.]+)\".*?buildID=\"(\\d+)",
+        "replace": "${1}.${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win64.installer.exe#/dl.7z",
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win64.installer.exe#/dl.7z",
                 "hash": {
-                    "url": "$baseurl/firefox-$version.en-US.win64.checksums"
+                    "url": "$baseurl/firefox-$majorVersion.$minorVersion.en-US.win64.checksums"
                 }
             },
             "32bit": {
-                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$version.en-US.win32.installer.exe#/dl.7z",
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win32.installer.exe#/dl.7z",
                 "hash": {
-                    "url": "$baseurl/firefox-$version.en-US.win32.checksums"
+                    "url": "$baseurl/firefox-$majorVersion.$minorVersion.en-US.win32.checksums"
                 }
             }
         }

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -1,16 +1,16 @@
 {
     "description": "Nightly builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/nightly/",
-    "version": "72.0a1.20191105095755",
+    "version": "72.0a1.20191106215426",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-72.0a1.en-US.win64.installer.exe#/dl.7z",
-            "hash": "sha512:7b07be0a5121c26acc9c3353a3fc5ec8de481af2d6f61a66efe4f6eb0387cf33642d40448f9f4d62fa8a9128912119b3026210d72bc4d30909b6b3b928fb46a4"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-06-21-54-26-mozilla-central/firefox-72.0a1.en-US.win64.installer.exe#/dl.7z",
+            "hash": "sha512:d4083614ead97b522b45860fb97736f4c704144ed5f801d76ddc3e4b079e42ee289c8333e805ada389582f329bea25275efa5c228389cd3e5fa8b2394b35e1e8"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-72.0a1.en-US.win32.installer.exe#/dl.7z",
-            "hash": "sha512:04b54b662a5cf94937563b65c1b2c71268908cb9afac6a97f81b75018dca622e377340ad2b1a0f3aaa8d8daf20585c9cb42da93e0dd315bb996aaa919efdb84d"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-06-21-54-26-mozilla-central/firefox-72.0a1.en-US.win32.installer.exe#/dl.7z",
+            "hash": "sha512:538e6f86e7d9c01c76c915add0d503b9667763ef9113aeb45023fccbaa7f0f54a04f9a63070e2f3fbb7c323d5dd7fbf80dc3d62dc1ecef21b1be62a5b09b5bb2"
         }
     },
     "extract_dir": "core",
@@ -28,19 +28,19 @@
     ],
     "checkver": {
         "url": "https://aus5.mozilla.org/update/6/Firefox/60.0/_/WINNT_x86_64-msvc-x64/en-US/nightly/_/_/_/_/update.xml",
-        "regex": "appVersion=\"([\\w.]+)\".*?buildID=\"(\\d+)",
+        "regex": "appVersion=\"([\\w.]+)\".*?buildID=\"((?<yyyy>\\d{4})(?<mm>\\d{2})(?<dd>\\d{2})(?<hr>\\d{2})(?<mi>\\d{2})(?<se>\\d{2}))",
         "replace": "${1}.${2}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win64.installer.exe#/dl.7z",
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/$matchYyyy/$matchMm/$matchYyyy-$matchMm-$matchDd-$matchHr-$matchMi-$matchSe-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win64.installer.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/firefox-$majorVersion.$minorVersion.en-US.win64.checksums"
                 }
             },
             "32bit": {
-                "url": "https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win32.installer.exe#/dl.7z",
+                "url": "https://archive.mozilla.org/pub/firefox/nightly/$matchYyyy/$matchMm/$matchYyyy-$matchMm-$matchDd-$matchHr-$matchMi-$matchSe-mozilla-central/firefox-$majorVersion.$minorVersion.en-US.win32.installer.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/firefox-$majorVersion.$minorVersion.en-US.win32.checksums"
                 }

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -1,16 +1,16 @@
 {
     "description": "Nightly builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/nightly/",
-    "version": "72.0a1.20191106215426",
+    "version": "72.0a1.20191107215315",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-06-21-54-26-mozilla-central/firefox-72.0a1.en-US.win64.installer.exe#/dl.7z",
-            "hash": "sha512:d4083614ead97b522b45860fb97736f4c704144ed5f801d76ddc3e4b079e42ee289c8333e805ada389582f329bea25275efa5c228389cd3e5fa8b2394b35e1e8"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-07-21-53-15-mozilla-central/firefox-72.0a1.en-US.win64.installer.exe#/dl.7z",
+            "hash": "sha512:a01f5fae02cd8e15f89959fd151358492404f12a6c995eb2ddaf071481ba1a7fe95ff83192ff965a5343cae65fbce69aaa9edf6eb5822381e20fb2368d84a9cf"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-06-21-54-26-mozilla-central/firefox-72.0a1.en-US.win32.installer.exe#/dl.7z",
-            "hash": "sha512:538e6f86e7d9c01c76c915add0d503b9667763ef9113aeb45023fccbaa7f0f54a04f9a63070e2f3fbb7c323d5dd7fbf80dc3d62dc1ecef21b1be62a5b09b5bb2"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2019/11/2019-11-07-21-53-15-mozilla-central/firefox-72.0a1.en-US.win32.installer.exe#/dl.7z",
+            "hash": "sha512:cbdf2bfc4b389f84e2ffc88627baa44a0d49264de154aa1dd672a6f3a9021b9c18d3d9eb86f350683b62040bdaa3fb2414a6e13c1e62163fcef3373a7b495e1f"
         }
     },
     "extract_dir": "core",


### PR DESCRIPTION
https://github.com/lukesampson/scoop-extras/pull/3073#event-2774649732

~~It seems that the update url for nightly version is broken. Checking update in app is also broken. Just wait until it's fixed upstream.~~

Support specifing verison.

close https://github.com/lukesampson/scoop-extras/pull/2124
close https://github.com/lukesampson/scoop-extras/issues/1140