### PR TITLE
potplayer: fix hash

### DIFF
--- a/bucket/potplayer.json
+++ b/bucket/potplayer.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/20191031_1.7.20977/PotPlayerSetup64.exe#/dl.7z",
-            "hash": "f83b05ce088978b6b4bad1aeeb81bcec60c52c91985318b0362c6fa13e56071e",
+            "hash": "9d747d311df8f8e7a3911daba2aab974f3cff6ef2daafb0d365c33f0deaf7f1a",
             "shortcuts": [
                 [
                     "PotPlayer64.exe",
@@ -23,7 +23,7 @@
         },
         "32bit": {
             "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/20191031_1.7.20977/PotPlayerSetup.exe#/dl.7z",
-            "hash": "f0b32aa87911f54fdba35a8182437b4282a5cd28e68ec298990be6f71379fddf",
+            "hash": "63bb8647f8756185822e34c79225bbae1a7f5779b0726ef6335dea0e7cb4ba05",
             "shortcuts": [
                 [
                     "PotPlayer.exe",


### PR DESCRIPTION
close #3129

Also see https://github.com/lukesampson/scoop-extras/pull/3056#pullrequestreview-306571407
> Maintaners be aware that lots of hash check fail issues will be opened after each release. Usually the release file is chaning twice a day for 4-5 days after release.