### PR TITLE
gpg4win: fix checkver

### DIFF
--- a/bucket/gpg4win-portable.json
+++ b/bucket/gpg4win-portable.json
@@ -1,7 +1,7 @@
 {
     "version": "3.1.10",
-    "homepage": "https://www.gpg4win.org",
-    "description": "GNU Privacy Guard for Windows is encryption software for files and emails.",
+    "homepage": "https://gpg4win.org",
+    "description": "Encryption software for files and emails.",
     "license": "GPL-2.0-or-later",
     "url": "https://files.gpg4win.org/gpg4win-3.1.10.exe#/dl.7z",
     "hash": "7f3ceaf54bcff0f63716900f6769b93597aae33e188e88792aa484a93d056dc9",
@@ -29,7 +29,7 @@
         ") | Set-Content \"$dir\\bin\\kde.conf\" -Encoding ASCII"
     ],
     "checkver": {
-        "url": "https://www.gpg4win.org/get-gpg4win.html",
+        "url": "https://gpg4win.org/get-gpg4win.html",
         "regex": "Download Gpg4win ([\\d.]+)"
     },
     "autoupdate": {

--- a/bucket/gpg4win.json
+++ b/bucket/gpg4win.json
@@ -1,24 +1,10 @@
 {
     "version": "3.1.10",
-    "homepage": "https://www.gpg4win.org",
-    "description": "GNU Privacy Guard for Windows is encryption software for files and emails.",
+    "homepage": "https://gpg4win.org",
+    "description": "Encryption software for files and emails.",
     "license": "GPL-2.0-or-later",
     "url": "https://files.gpg4win.org/gpg4win-3.1.10.exe",
     "hash": "7f3ceaf54bcff0f63716900f6769b93597aae33e188e88792aa484a93d056dc9",
-    "env_add_path": [
-        "GnuPG\\bin",
-        "Gpg4win\\bin"
-    ],
-    "checkver": {
-        "url": "https://www.gpg4win.org/get-gpg4win.html",
-        "re": "Download Gpg4win ([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://files.gpg4win.org/gpg4win-$version.exe",
-        "hash": {
-            "url": "https://gpg4win.org/package-integrity.html"
-        }
-    },
     "installer": {
         "args": [
             "/S",
@@ -28,5 +14,19 @@
     "uninstaller": {
         "file": "Gpg4win\\gpg4win-uninstall.exe",
         "args": "/S"
+    },
+    "env_add_path": [
+        "GnuPG\\bin",
+        "Gpg4win\\bin"
+    ],
+    "checkver": {
+        "url": "https://gpg4win.org/get-gpg4win.html",
+        "regex": "Download Gpg4win ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://files.gpg4win.org/gpg4win-$version.exe",
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }

--- a/bucket/gpg4win.json
+++ b/bucket/gpg4win.json
@@ -3,17 +3,13 @@
     "homepage": "https://gpg4win.org",
     "description": "Encryption software for files and emails.",
     "license": "GPL-2.0-or-later",
-    "url": "https://files.gpg4win.org/gpg4win-3.1.10.exe",
+    "url": "https://files.gpg4win.org/gpg4win-3.1.10.exe#/gpg4win.exe",
     "hash": "7f3ceaf54bcff0f63716900f6769b93597aae33e188e88792aa484a93d056dc9",
     "installer": {
-        "args": [
-            "/S",
-            "/D=$dir\\Gpg4win"
-        ]
+        "script": "Invoke-ExternalCommand -FilePath \"$dir\\gpg4win.exe\" -ArgumentList \"/S /D=$dir\\Gpg4win\" -RunAs | Out-Null"
     },
     "uninstaller": {
-        "file": "Gpg4win\\gpg4win-uninstall.exe",
-        "args": "/S"
+        "script": "Invoke-ExternalCommand -FilePath \"$dir\\Gpg4win\\gpg4win-uninstall.exe\" -ArgumentList '/S' -RunAs | Out-Null"
     },
     "env_add_path": [
         "GnuPG\\bin",
@@ -24,7 +20,7 @@
         "regex": "Download Gpg4win ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://files.gpg4win.org/gpg4win-$version.exe",
+        "url": "https://files.gpg4win.org/gpg4win-$version.exe#/gpg4win.exe",
         "hash": {
             "url": "$url.sha256"
         }


### PR DESCRIPTION
gpg4win need privilege.

```
ERROR Exception calling "Start" with "0" argument(s): "The requested operation requires elevation" 
Installation aborted. You might need to run 'scoop uninstall gpg4win' before trying again.
```