### PR TITLE
lazydocker: Add version 0.7.5

### DIFF
--- a/bucket/lazydocker.json
+++ b/bucket/lazydocker.json
@@ -1,0 +1,16 @@
+{
+  "homepage": "https://github.com/jesseduffield/lazydocker",
+  "description": "The lazier way to manage everything docker",
+  "license": "MIT",
+  "version": "0.7.5",
+  "url": "https://github.com/jesseduffield/lazydocker/releases/download/v0.7.5/lazydocker_0.7.5_Windows_x86_64.zip",
+  "hash": "4a4e47a4a61a25cbc5e1175adf42c02b8957c1dbdb5e854d306151a08c51acad",
+  "bin": "lazydocker.exe",
+  "checkver": "github",
+  "autoupdate": {
+      "url": "https://github.com/jesseduffield/lazydocker/releases/download/v$version/lazydocker_$version_Windows_x86_64.zip",
+      "hash": {
+          "url": "$baseurl/checksums.txt"
+      }
+  }
+}


### PR DESCRIPTION
`Lazydocker` is "The lazier way to manage everything docker".

It is widely used with >36k downloads and >12k stars on GitHub.

As of version 0.7.5 it supports windows as platform.
See: https://github.com/jesseduffield/lazydocker/releases/tag/v0.7.5