### PR TITLE
Update autoupdate paths for notepadplusplus.json

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://notepad-plus-plus.org/",
     "description": "A free source code editor and Notepad replacement that supports several languages.",
-    "version": "7.7.1",
+    "version": "7.8.1",
     "license": "GPL-2.0-only",
     "notes": "The following page explains how to add explorer context menu entries for notepad++. http://docs.notepad-plus-plus.org/index.php/Explorer_Context_Menu",
     "architecture": {
         "64bit": {
-            "url": "https://notepad-plus-plus.org/repository/7.x/7.7.1/npp.7.7.1.bin.x64.7z",
-            "hash": "528ec2bf90fd409b4bf914c198b93db28cecd4fa2a8cdf6180f1b9cded7f8dfa"
+            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.1/npp.7.8.1.bin.x64.7z",
+            "hash": "3c858379762e4bf8882b5799c887dbae4c96d8b8bedb404bbf7e2165507efd18"
         },
         "32bit": {
-            "url": "https://notepad-plus-plus.org/repository/7.x/7.7.1/npp.7.7.1.bin.7z",
-            "hash": "f0af67993bd5f420ef0d9268f9667d628090491899f6529a7a75f60244700ef1"
+            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.1/npp.7.8.1.bin.7z",
+            "hash": "3a422d7fb6fb93392bacf005eba5753b6e085a2329697c65652738122bd63b55"
         }
     },
     "checkver": "/downloads/v([\\d.]+)/",
@@ -40,14 +40,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.x64.7z"
+                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.x64.7z"
             },
             "32bit": {
-                "url": "https://notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.7z"
+                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.7z"
             }
         },
         "hash": {
-            "url": "https://notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.sha1.md5.digest.txt"
+            "url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/tag/v$version"
         }
     }
 }


### PR DESCRIPTION
Notepad++ download repository path has changed.
This commit updates it to the new path.

P.S. There does not seem to be an https path for those downloads. A real shame.
This should be changed back to https when it (hopefully) becomes available again.
For now, the hashes could at least be extracted from github instead, using https.