### PR TITLE
cura: Update to 4.4.0

### DIFF
--- a/bucket/cura.json
+++ b/bucket/cura.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.3.0",
+    "version": "4.4.0",
     "license": "LGPL-3.0-only",
     "homepage": "https://ultimaker.com/en/products/ultimaker-cura-software",
     "description": "Model editing tools for 3D printing",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ultimaker/Cura/releases/download/4.3.0/Ultimaker_Cura-4.3.0-win64.exe#/dl.7z",
-            "hash": "bf35a3939776ccf7559e520247b8b4e1e092e876e266ba465ea55b6f63752cd7"
+            "url": "https://github.com/Ultimaker/Cura/releases/download/v4.4.0/Ultimaker.Cura-4.4.0-win64.exe#/dl.7z",
+            "hash": "0a7109a64e0938a77d9a987ef0ae6867d4e98112420642633461598fbd6fa00a"
         }
     },
     "suggest": {
@@ -26,6 +26,6 @@
         "github": "https://github.com/Ultimaker/Cura"
     },
     "autoupdate": {
-        "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker_Cura-$version-win64.exe#/dl.7z"
+        "url": "https://github.com/Ultimaker/Cura/releases/download/v$version/Ultimaker.Cura-$version-win64.exe#/dl.7z"
     }
 }


### PR DESCRIPTION
Correct download path with

#2308 