### PR TITLE
psiphon3: fix version

### DIFF
--- a/bucket/psiphon3.json
+++ b/bucket/psiphon3.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://s3.amazonaws.com/psiphon/web/60l3-nnss-6gsn/index.html",
     "description": "A centrally managed, geographically diverse network of thousands of proxy servers, using a performance-oriented, single hop architecture, for Internet censorship circumvention",
-    "version": "136",
+    "version": "nightly",
     "license": "GPL-3.0-only",
     "url": "https://s3.amazonaws.com/psiphon/web/60l3-nnss-6gsn/psiphon3.exe",
     "bin": "psiphon3.exe",


### PR DESCRIPTION
It's not a nightly app but we can't find its version on website. Change the version to nightly can help users update it.