### PR TITLE
calibre: fix url

### DIFF
--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -3,7 +3,7 @@
     "version": "4.3.0",
     "description": "Powerful and easy to use e-book manager.",
     "license": "GPL-3.0-only",
-    "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-4.3.0.exe",
+    "url": "https://download.calibre-ebook.com/4.3.0/calibre-portable-installer-4.3.0.exe",
     "hash": "b2dcf0fd348156f87043d004de8f0eadb22a891a679b91d1c38b664e8e6b7285",
     "persist": [
         "Calibre Portable/Calibre Library",
@@ -24,6 +24,6 @@
         "regex": "softwareVersion\">([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/Calibre.html/calibre-portable-installer-$version.exe"
+        "url": "https://download.calibre-ebook.com/$version/calibre-portable-installer-$version.exe"
     }
 }


### PR DESCRIPTION
Some time ago (calibre v4.1.0) I noticed failure during downloading from fosshub. I assume they changed their URL(s) for downloading?
First I checked if it is possible to correct the URL on fosshub itself but I realized that there is always website overhead since fosshub's downloads work via query parameter.
So finally I changed the url to `download.calibre-ebook.com` which seems to work pretty well.

Is there some testing pipeline to check my new change because I mainly tested downloading with curl?

regards