### PR TITLE
k6: Add version 0.25.1

### DIFF
--- a/bucket/k6.json
+++ b/bucket/k6.json
@@ -1,0 +1,45 @@
+{
+    "homepage": "https://k6.io/",
+    "description": "K6: developer centric open source load and performance regression testing tool",
+    "version": "0.25.1",
+    "license": "AGPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/loadimpact/k6/releases/download/v0.25.1/k6-v0.25.1-win64.zip",
+            "hash": "4c1f9c4a669eceeda0c6d8864673fe7dc7fa481b514905f700c6946687b44a8f",
+            "extract_dir": "k6-v0.25.1-win64"
+        },
+        "32bit": {
+            "url": "https://github.com/loadimpact/k6/releases/download/v0.25.1/k6-v0.25.1-win32.zip",
+            "hash": "6776890125143bf9d9bea97597230601a581cccd2be7be0f97cfae2422519d65",
+            "extract_dir": "k6-v0.25.1-win32"
+        }
+    },
+    "bin": [
+        "k6.exe"
+    ],
+    "shortcuts": [
+        [
+            "k6.exe",
+            "K6 Load Testing"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/loadimpact/k6"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win64.zip",
+                "extract_dir": "k6-v$version-win64",
+            },
+            "32bit": {
+                "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win32.zip",
+                "extract_dir": "k6-v$version-win32",
+            }
+        },
+        "hash": {
+            "url": "$baseurl/k6-v$version-checksums.txt"
+        }
+    }
+}

--- a/bucket/k6.json
+++ b/bucket/k6.json
@@ -15,9 +15,7 @@
             "extract_dir": "k6-v0.25.1-win32"
         }
     },
-    "bin": [
-        "k6.exe"
-    ],
+    "bin": "k6.exe",
     "shortcuts": [
         [
             "k6.exe",
@@ -31,11 +29,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win64.zip",
-                "extract_dir": "k6-v$version-win64",
+                "extract_dir": "k6-v$version-win64"
             },
             "32bit": {
                 "url": "https://github.com/loadimpact/k6/releases/download/v$version/k6-v$version-win32.zip",
-                "extract_dir": "k6-v$version-win32",
+                "extract_dir": "k6-v$version-win32"
             }
         },
         "hash": {


### PR DESCRIPTION
Adding k6.io, resolves #3220

~~It's my first time creating a scoop manifest, I'm not sure how to test the autoupdate~~ nvm, one needs to always read the whole wiki before opening their mouth. Autoupdate tested and works.