### PR TITLE
gatling: Add version 3.3.1

### DIFF
--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -13,7 +13,7 @@
     "persist": [
         "conf",
         "results",
-        "user-files"        
+        "user-files"
     ],
     "env_set": {
         "GATLING_HOME": "$dir"

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -10,6 +10,10 @@
         "gatling.bat",
         "recorder.bat"
     ],
+    "persist": [
+        "user-files",
+        "results"
+    ],
     "shortcuts": [
         [
             "recorder.bat",

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://gatling.io",
-    "description": "Async Scala-Akka-Netty based Load Test Tool",
+    "description": "Async load test tool for web applications",
     "version": "3.3.1",
     "license": "Apache-2.0",
     "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.3.1/gatling-charts-highcharts-bundle-3.3.1-bundle.zip",
     "hash": "sha1:6d9630ef1c3af22b217bb7cef3c6179924886469",
     "extract_dir": "gatling-charts-highcharts-bundle-3.3.1",
     "bin": [
-        "gatling.bat",
-        "recorder.bat"
+        "bin\\gatling.bat",
+        "bin\\recorder.bat"
     ],
     "persist": [
         "user-files",

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -11,8 +11,9 @@
         "bin\\recorder.bat"
     ],
     "persist": [
-        "user-files",
-        "results"
+        "conf",
+        "results",
+        "user-files"        
     ],
     "env_set": {
         "GATLING_HOME": "$dir"

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://gatling.io",
+    "description": "Async Scala-Akka-Netty based Load Test Tool",
+    "version": "3.3.1",
+    "license": "Apache-2.0",
+    "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/3.3.1/gatling-charts-highcharts-bundle-3.3.1-bundle.zip",
+    "hash": "sha1:6d9630ef1c3af22b217bb7cef3c6179924886469",
+    "extract_dir": "gatling-charts-highcharts-bundle-3.3.1",
+    "bin": [
+        "gatling.bat",
+        "recorder.bat"
+    ],
+    "shortcuts": [
+        [
+            "recorder.bat",
+            "Gatling Recorder"
+        ]
+    ],
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    },
+    "checkver": {
+        "url": "https://search.maven.org/solrsearch/select/?q=g:io.gatling.highcharts+AND+a:gatling-charts-highcharts-bundle",
+        "jp": "$.response.docs[0].latestVersion"
+    },
+    "autoupdate": {
+        "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$version/gatling-charts-highcharts-bundle-$version-bundle.zip",
+        "extract_dir": "gatling-charts-highcharts-bundle-$version",
+        "hash": {
+            "url": "$baseurl/gatling-charts-highcharts-bundle-$version-bundle.zip.sha1"
+        }
+    }
+}

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -24,13 +24,13 @@
     },
     "checkver": {
         "url": "https://search.maven.org/solrsearch/select/?q=g:io.gatling.highcharts+AND+a:gatling-charts-highcharts-bundle",
-        "jp": "$.response.docs[0].latestVersion"
+        "jsonpath": "$.response.docs[0].latestVersion"
     },
     "autoupdate": {
         "url": "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$version/gatling-charts-highcharts-bundle-$version-bundle.zip",
         "extract_dir": "gatling-charts-highcharts-bundle-$version",
         "hash": {
-            "url": "$baseurl/gatling-charts-highcharts-bundle-$version-bundle.zip.sha1"
+            "url": "$url.sha1"
         }
     }
 }

--- a/bucket/gatling.json
+++ b/bucket/gatling.json
@@ -14,9 +14,12 @@
         "user-files",
         "results"
     ],
+    "env_set": {
+        "GATLING_HOME": "$dir"
+    },
     "shortcuts": [
         [
-            "recorder.bat",
+            "bin\\recorder.bat",
             "Gatling Recorder"
         ]
     ],


### PR DESCRIPTION
Adds gatling version 3.3.1

Closes #3217

Gatling DEPENDS on Java, but I added it as a "suggest" because it doesn't look like "depends" can allow the user to choose whether to use the oracle version or openjdk version.

Also, I've put it here in extras instead of main because gatling recorder is not a commandline tool and pops a window application open (unlike k6)