### PR TITLE
playnite: update to 6.2, fix autoupdate

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -2,9 +2,9 @@
     "homepage": "https://playnite.link/",
     "description": "An open source video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net and Uplay. Includes game emulation support, providing one unified interface for your games.",
     "license": "MIT",
-    "version": "5.8",
-    "url": "https://github.com/JosefNemec/Playnite/releases/download/5.8/Playnite58.zip",
-    "hash": "446e193dcf287423ee2dd7496c9add96dfe7bcc872a5df2e7dc6144040c7e10f",
+    "version": "6.2",
+    "url": "https://playnite.link/update/stable/6.2/Playnite62.zip",
+    "hash": "abd4a1ee84bf3b55ebe8693482d6416bc6d96396db4ed1eddb9e95266f68e19d",
     "bin": "PlayniteUI.exe",
     "shortcuts": [
         [
@@ -18,11 +18,10 @@
         "}"
     ],
     "checkver": {
-        "url": "https://github.com/JosefNemec/Playnite/releases",
-        "regex": "download/([\\d.]+)/Playnite\\d+.zip"
+        "github": "https://github.com/JosefNemec/Playnite"
     },
     "autoupdate": {
-        "url": "https://github.com/JosefNemec/Playnite/releases/download/$version/Playnite$cleanVersion.zip"
+        "url": "https://playnite.link/update/stable/$version/Playnite$cleanVersion.zip"
     },
     "persist": [
         "browsercache",


### PR DESCRIPTION
(binaries no longer hosted on github)

#2308 