### PR TITLE
ds4windows: Persist profiles and settings

### DIFF
--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -18,7 +18,6 @@
     "pre_install": [
         "'Actions.xml', 'Profiles.xml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
-        "    }",
         "}",
         "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",
         "    Set-Content \"$dir\\Auto Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?><Programs />' -Encoding Ascii",

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -1,38 +1,60 @@
 {
-    "homepage": "https://ryochan7.github.io/ds4windows-site/",
-    "description": "Portable program that allows you to get the best experience while using a DualShock 4 on your PC.",
-    "version": "1.7.23",
-    "license": "Unknown",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x64.zip",
-            "hash": "602fee01c42e9a3847c82c8379999711a16a64e2fee1ad65b61312748c344401"
-        },
-        "32bit": {
-            "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x86.zip",
-            "hash": "089f5cabf9686f588a9c29ff93863e6d29acf0955f5e3a1d2ae859e7c04f0ba9"
-        }
-    },
-    "bin": "DS4Windows.exe",
-    "extract_dir": "DS4Windows",
-    "post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
-    "shortcuts": [
-        [
-            "DS4Windows.exe",
-            "DS4Windows"
-        ]
-    ],
-    "checkver": {
-        "github": "https://github.com/Ryochan7/DS4Windows"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x64.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x86.zip"
-            }
-        }
-    }
+	"homepage": "https://ryochan7.github.io/ds4windows-site/",
+	"description": "Portable program that allows you to get the best experience while using a DualShock 4 on your PC.",
+	"version": "1.7.23",
+	"license": "MIT",
+	"architecture": {
+		"64bit": {
+			"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x64.zip",
+			"hash": "602fee01c42e9a3847c82c8379999711a16a64e2fee1ad65b61312748c344401"
+		},
+		"32bit": {
+			"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x86.zip",
+			"hash": "089f5cabf9686f588a9c29ff93863e6d29acf0955f5e3a1d2ae859e7c04f0ba9"
+		}
+	},
+	"bin": "DS4Windows.exe",
+	"extract_dir": "DS4Windows",
+	"installer": {
+		"script": [
+			"$FILE = 'Actions.xml'",
+			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+			"}",
+			"$FILE = 'Auto Profiles.xml'",
+			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+			"}",
+			"$FILE = 'Profiles.xml'",
+			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+			"}"
+		]
+	},
+	"persist": [
+		"Profiles",
+		"Actions.xml",
+		"Auto Profiles.xml",
+		"Profiles.xml"
+	],
+	"post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
+	"shortcuts": [
+		[
+			"DS4Windows.exe",
+			"DS4Windows"
+		]
+	],
+	"checkver": {
+		"github": "https://github.com/Ryochan7/DS4Windows"
+	},
+	"autoupdate": {
+		"architecture": {
+			"64bit": {
+				"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x64.zip"
+			},
+			"32bit": {
+				"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x86.zip"
+			}
+		}
+	}
 }

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -17,7 +17,7 @@
     "extract_dir": "DS4Windows",
     "pre_install": [
         "'Actions.xml', 'Profiles.xml' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "        New-Item \"$dir\\$_\" | Out-Null",
         "    }",
         "}",

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -1,60 +1,60 @@
 {
-	"homepage": "https://ryochan7.github.io/ds4windows-site/",
-	"description": "Portable program that allows you to get the best experience while using a DualShock 4 on your PC.",
-	"version": "1.7.23",
-	"license": "MIT",
-	"architecture": {
-		"64bit": {
-			"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x64.zip",
-			"hash": "602fee01c42e9a3847c82c8379999711a16a64e2fee1ad65b61312748c344401"
-		},
-		"32bit": {
-			"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x86.zip",
-			"hash": "089f5cabf9686f588a9c29ff93863e6d29acf0955f5e3a1d2ae859e7c04f0ba9"
-		}
-	},
-	"bin": "DS4Windows.exe",
-	"extract_dir": "DS4Windows",
-	"installer": {
-		"script": [
-			"$FILE = 'Actions.xml'",
-			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-			"}",
-			"$FILE = 'Auto Profiles.xml'",
-			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-			"}",
-			"$FILE = 'Profiles.xml'",
-			"if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-			"    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-			"}"
-		]
-	},
-	"persist": [
-		"Profiles",
-		"Actions.xml",
-		"Auto Profiles.xml",
-		"Profiles.xml"
-	],
-	"post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
-	"shortcuts": [
-		[
-			"DS4Windows.exe",
-			"DS4Windows"
-		]
-	],
-	"checkver": {
-		"github": "https://github.com/Ryochan7/DS4Windows"
-	},
-	"autoupdate": {
-		"architecture": {
-			"64bit": {
-				"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x64.zip"
-			},
-			"32bit": {
-				"url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x86.zip"
-			}
-		}
-	}
+    "homepage": "https://ryochan7.github.io/ds4windows-site/",
+    "description": "Portable program that allows you to get the best experience while using a DualShock 4 on your PC.",
+    "version": "1.7.23",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x64.zip",
+            "hash": "602fee01c42e9a3847c82c8379999711a16a64e2fee1ad65b61312748c344401"
+        },
+        "32bit": {
+            "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v1.7.23/DS4Windows_1.7.23_x86.zip",
+            "hash": "089f5cabf9686f588a9c29ff93863e6d29acf0955f5e3a1d2ae859e7c04f0ba9"
+        }
+    },
+    "bin": "DS4Windows.exe",
+    "extract_dir": "DS4Windows",
+    "installer": {
+        "script": [
+            "$FILE = 'Actions.xml'",
+            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "}",
+            "$FILE = 'Auto Profiles.xml'",
+            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "}",
+            "$FILE = 'Profiles.xml'",
+            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
+            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
+            "}"
+        ]
+    },
+    "persist": [
+        "Profiles",
+        "Actions.xml",
+        "Auto Profiles.xml",
+        "Profiles.xml"
+    ],
+    "post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
+    "shortcuts": [
+        [
+            "DS4Windows.exe",
+            "DS4Windows"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Ryochan7/DS4Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Ryochan7/DS4Windows/releases/download/v$version/DS4Windows_$version_x86.zip"
+            }
+        }
+    }
 }

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -15,29 +15,22 @@
     },
     "bin": "DS4Windows.exe",
     "extract_dir": "DS4Windows",
-    "installer": {
-        "script": [
-            "$FILE = 'Actions.xml'",
-            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-            "}",
-            "$FILE = 'Auto Profiles.xml'",
-            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-            "}",
-            "$FILE = 'Profiles.xml'",
-            "if (!(Test-Path \"$persist_dir\\$FILE\")) {",
-            "    New-Item \"$dir\\$FILE\" -Type File | Out-Null",
-            "}"
-        ]
-    },
+    "pre_install": [
+        "'Actions.xml', 'Profiles.xml' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) {",
+        "        New-Item \"$dir\\$_\" | Out-Null",
+        "    }",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",
+        "   Set-Content -Path \"$dir\\Auto Profiles.xml\" -Value '<?xml version=\"1.0\" encoding=\"utf-8\"?><Programs />'",
+        "}"
+    ],
     "persist": [
         "Profiles",
         "Actions.xml",
         "Auto Profiles.xml",
         "Profiles.xml"
     ],
-    "post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
     "shortcuts": [
         [
             "DS4Windows.exe",

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -18,7 +18,6 @@
     "pre_install": [
         "'Actions.xml', 'Profiles.xml' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
-        "        New-Item \"$dir\\$_\" | Out-Null",
         "    }",
         "}",
         "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -16,11 +16,14 @@
     "bin": "DS4Windows.exe",
     "extract_dir": "DS4Windows",
     "pre_install": [
-        "'Actions.xml', 'Profiles.xml' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "if (!(Test-Path \"$persist_dir\\Profiles.xml\")) {",
+        "    Set-Content \"$dir\\Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>' -Encoding Ascii",
         "}",
         "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",
-        "    Set-Content \"$dir\\Auto Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?><Programs />' -Encoding Ascii",
+        "    Set-Content \"$dir\\Auto Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Programs />' -Encoding Ascii",
+        "}",
+        "if (!(Test-Path \"$persist_dir\\Actions.xml\")) {",
+        "    Set-Content \"$dir\\Actions.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Actions>\n\t<Action Name=\"Disconnect Controller\">\n\t\t<Trigger>PS/Options</Trigger>\n\t\t<Type>DisconnectBT</Type>\n\t\t<Details>0</Details>\n\t</Action>\n</Actions>' -Encoding Ascii",
         "}"
     ],
     "persist": [
@@ -35,6 +38,7 @@
             "DS4Windows"
         ]
     ],
+    "post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
     "checkver": {
         "github": "https://github.com/Ryochan7/DS4Windows"
     },

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -22,7 +22,7 @@
         "    }",
         "}",
         "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",
-        "   Set-Content -Path \"$dir\\Auto Profiles.xml\" -Value '<?xml version=\"1.0\" encoding=\"utf-8\"?><Programs />'",
+        "    Set-Content \"$dir\\Auto Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?><Programs />' -Encoding Ascii",
         "}"
     ],
     "persist": [

--- a/bucket/ds4windows.json
+++ b/bucket/ds4windows.json
@@ -13,18 +13,24 @@
             "hash": "089f5cabf9686f588a9c29ff93863e6d29acf0955f5e3a1d2ae859e7c04f0ba9"
         }
     },
-    "bin": "DS4Windows.exe",
     "extract_dir": "DS4Windows",
     "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\Profiles.xml\")) {",
-        "    Set-Content \"$dir\\Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>' -Encoding Ascii",
+        "$conf = @(",
+        "    @{'Profiles.xml' = '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Profile>\n\t<CheckWhen>0</CheckWhen>\n</Profile>'}",
+        "    @{'Auto Profiles.xml' = '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Programs />'}",
+        "    @{'Actions.xml' = '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Actions>\n\t<Action Name=\"Disconnect Controller\">\n\t\t<Trigger>PS/Options</Trigger>\n\t\t<Type>DisconnectBT</Type>\n\t\t<Details>0</Details>\n\t</Action>\n</Actions>'}",
+        ")",
+        "foreach ($k in $conf.Keys) {",
+        "    if (-not (Test-Path \"$persist_dir\\$k\")) { Set-Content \"$dir\\$k\" $conf.$k -Encoding Ascii }",
         "}",
-        "if (!(Test-Path \"$persist_dir\\Auto Profiles.xml\")) {",
-        "    Set-Content \"$dir\\Auto Profiles.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Programs />' -Encoding Ascii",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\Actions.xml\")) {",
-        "    Set-Content \"$dir\\Actions.xml\" '<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Actions>\n\t<Action Name=\"Disconnect Controller\">\n\t\t<Trigger>PS/Options</Trigger>\n\t\t<Type>DisconnectBT</Type>\n\t\t<Details>0</Details>\n\t</Action>\n</Actions>' -Encoding Ascii",
-        "}"
+        "if (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }"
+    ],
+    "bin": "DS4Windows.exe",
+    "shortcuts": [
+        [
+            "DS4Windows.exe",
+            "DS4Windows"
+        ]
     ],
     "persist": [
         "Profiles",
@@ -32,13 +38,6 @@
         "Auto Profiles.xml",
         "Profiles.xml"
     ],
-    "shortcuts": [
-        [
-            "DS4Windows.exe",
-            "DS4Windows"
-        ]
-    ],
-    "post_install": "If (Test-Path \"$dir\\DS4Updater.exe\") { Remove-Item \"$dir\\DS4Updater.exe\" -Force }",
     "checkver": {
         "github": "https://github.com/Ryochan7/DS4Windows"
     },


### PR DESCRIPTION
Also added the license.
Users that picked %appdata% to keep their settings will be prompted by the program to move the settings files, and others who picked the program folder will notice their profiles now stick, or do not have to manually migrate them every update.