### PR TITLE
stern: Add version 1.11.0

### DIFF
--- a/bucket/stern.json
+++ b/bucket/stern.json
@@ -1,0 +1,19 @@
+{
+    "homepage": "https://github.com/wercker/stern",
+    "description": "Multi pod and container log tailing for Kubernetes",
+    "license": "Apache-2.0",
+    "version": "1.11.0",
+    "url": "https://github.com/wercker/stern/releases/download/1.11.0/stern_windows_amd64.exe",
+    "hash": "75708b9acf6ef0eeffbe1f189402adc0405f1402e6b764f1f5152ca288e3109e",
+    "bin": "stern_windows_amd64.exe",
+    "shortcuts": [
+        [
+            "stern_windows_amd64.exe",
+            "stern"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/wercker/stern/releases/download/v$version/stern_windows_amd64.exe"
+    }
+}


### PR DESCRIPTION
This pull request adds stern - a log tailing console app for kubernetes. Would this fit in the extras repository?