### PR TITLE
Wincdemu: fix download link, remove autoupdate & checkver (development dead)

### DIFF
--- a/bucket/wincdemu.json
+++ b/bucket/wincdemu.json
@@ -3,7 +3,7 @@
     "description": "WinCDEmu is an open-source CD/DVD/BD emulator - a tool that allows you to mount optical disc images by simply clicking on them in Windows Explorer. ",
     "license": "LGPL-3.0-only",
     "version": "4.0",
-    "url": "https://sysprogs.com/files/WinCDEmu/PortableWinCDEmu-4.0.exe#/WinCDEmu.exe",
+    "url": "https://github.com/sysprogs/WinCDEmu/releases/download/v4.1/PortableWinCDEmu-4.0.exe#/WinCDEmu.exe",
     "hash": "c11fd7daa78fb946512f0f7c9ad26247192a6d556819bc73fc22f09007321d6d",
     "bin": "WinCDEmu.exe",
     "shortcuts": [
@@ -11,12 +11,5 @@
             "WinCDEmu.exe",
             "WinCDEmu"
         ]
-    ],
-    "checkver": {
-        "url": "http://wincdemu.sysprogs.org/portable/",
-        "re": "PortableWinCDEmu-([\\d.]+).exe"
-    },
-    "autoupdate": {
-        "url": "https://sysprogs.com/files/WinCDEmu/PortableWinCDEmu-$version.exe#/WinCDEmu.exe"
-    }
+    ]
 }


### PR DESCRIPTION
Closes #3273 
Download was removed from the main site, just redirects to github instead.
Unfortunately, the portable version used in the manifest is on 4.0 and is under the 4.1 tag on releases.
This breaks the checkver and autoupdate, but it is likely safe to remove them anyway, since the last commit is almost 1 year old.