### PR TITLE
archi: Update to version 4.6.0

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -1,12 +1,12 @@
 {
     "homepage": "https://www.archimatetool.com",
     "description": "ArchiMate model editor.",
-    "version": "4.5.1",
+    "version": "4.6.0",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/4.5.1/Archi-Win64-4.5.1.zip",
-            "hash": "md5:63d78b2d8ef298b0ed111691417d1339"
+            "url": "https://www.archimatetool.com/downloads/34f64c6b31095ef09/Archi-Win64-4.6.0.zip",
+            "hash": "md5:78f2f45b32386154bbf28bef512c9e78"
         }
     },
     "extract_dir": "Archi",
@@ -20,16 +20,5 @@
     "checkver": {
         "url": "https://github.com/archimatetool/archi/releases",
         "regex": "release_([\\d.]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://www.archimatetool.com/downloads/$version/Archi-Win64-$version.zip"
-            }
-        },
-        "hash": {
-            "url": "$url.MD5",
-            "regex": "MD5 \\($basename\\) = $md5"
-        }
     }
 }


### PR DESCRIPTION
As the download path know seems to contain some unknowable hash, I've removed the `autoupdate` stanza