### PR TITLE
utools: Add version 0.8.7-beta

### DIFF
--- a/bucket/utools.json
+++ b/bucket/utools.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://u.tools/",
+    "license": "Proprietary",
+    "version": "0.8.7-beta",
+    "description": "A launcher with rich plugins",
+    "architecture": {
+        "64bit": {
+            "url": "https://resource.u-tools.cn/currentversion/uTools-0.8.7-beta.exe#/dl.7z",
+            "hash": "b13880ff270823bb40d202a3d7d86ebb39ab6f2e4c7aee62589fda9e456882b3",
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        },
+        "32bit": {
+            "url": "https://resource.u-tools.cn/currentversion/uTools-0.8.7-beta-ia32.exe#/dl.7z",
+            "hash": "69424d56055e2e10097657776c232593509c1724de1eca6e781962fc808c43f4",
+            "installer": {
+                "script": [
+                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-32.7z\" \"$dir\"",
+                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
+                ]
+            }
+        }
+    },
+    "shortcuts": [
+        [
+            "uTools.exe",
+            "uTools"
+        ]
+    ],
+    "checkver": {
+        "url": "https://resource.u-tools.cn/currentversion/latest.yml",
+        "regex": "version: ([\\d.]+-\\w+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://resource.u-tools.cn/currentversion/uTools-$version.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://resource.u-tools.cn/currentversion/uTools-$version-ia32.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[utools](https://u.tools/): A launcher with rich plugins

License: Proprietary (currently no paid)
Version: 0.8.7-beta
Language: Chinese (other languages will be add soon)