### PR TITLE
dbeaver: Add correct hash from dbeaver.io for version 6.3.0

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://dbeaver.io/files/6.3.0/dbeaver-ce-6.3.0-win32.win32.x86_64.zip",
-            "hash": "9996a3d251c07a0d8636e6ec8078e8c5b03d2cdbd1baa5637e4f0f0461da7fbf"
+            "hash": "960f67be460b9f550619ccf80afdcf916695d35ae43bb1e6c184172122d85fe6"
         }
     },
     "extract_dir": "dbeaver",


### PR DESCRIPTION
related to #3311 