### PR TITLE
mkvtoolnix@41.0.0: Change download URl

### DIFF
--- a/bucket/mkvtoolnix.json
+++ b/bucket/mkvtoolnix.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://www.fosshub.com/MKVToolNix.html/mkvtoolnix-64-bit-41.0.0.7z",
+            "url": "https://mkvtoolnix.download/windows/releases/41.0.0/mkvtoolnix-64-bit-41.0.0.7z",
             "hash": "sha512:6ac3bb49229967dd3b8397bf74779792b43960dee60990a190af4c4ac5a5ae6f2d82ff14b84d01f478a7588776ddaf48f253eecee7014c308482e9f75be71d8e"
         },
         "32bit": {
-            "url": "https://www.fosshub.com/MKVToolNix.html/mkvtoolnix-32-bit-41.0.0.7z",
+            "url": "https://mkvtoolnix.download/windows/releases/41.0.0/mkvtoolnix-32-bit-41.0.0.7z",
             "hash": "sha512:d68086377e1082dc789917bbe5959116fb970d5d74fad488a68504328996f4f95a72986850636088e3af4ec686479f741af5ea995eb2e1ce28f79b268f147a1e"
         }
     },
@@ -50,14 +50,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.fosshub.com/MKVToolNix.html/mkvtoolnix-64-bit-$version.7z"
+                "url": "https://mkvtoolnix.download/windows/releases/$version/mkvtoolnix-64-bit-$version.7z"
             },
             "32bit": {
-                "url": "https://www.fosshub.com/MKVToolNix.html/mkvtoolnix-32-bit-$version.7z"
+                "url": "https://mkvtoolnix.download/windows/releases/$version/mkvtoolnix-32-bit-$version.7z"
             }
         },
         "hash": {
-            "url": "https://mkvtoolnix.download/windows/releases/$version/sha512sums.txt"
+            "url": "$baseurl/sha512sums.txt"
         }
     }
 }


### PR DESCRIPTION
- Closes #3323 

The previous link is deprecated. I also found a better place for the permanent resource link 
https://mkvtoolnix.download/windows/releases for all platforms, releases & versions. 
New json file is verified. Please see the following attachment.

![image](https://user-images.githubusercontent.com/2989428/70349870-9ad97d00-18a0-11ea-9c5d-8e7311ce8522.png)

![image](https://user-images.githubusercontent.com/2989428/70349909-a6c53f00-18a0-11ea-9511-eba02d728668.png)