### PR TITLE
manictime: Add version 4.4.4

### DIFF
--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://www.manictime.com",
+    "description": "a time tracking software",
+    "version": "4.4.4",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.manictime.com/pricing"
+    },
+    "url": "https://cdn.manictime.com/setup/v4_4_4_0/ManicTimeUsb.zip",
+    "hash": "80c60f51e1070dcdfb70daa7d5ae61b7085d932163a18a02fbb040946ba0bba8",
+    "shortcuts": [
+        [
+            "ManicTimeClient.exe",
+            "ManicTime"
+        ]
+    ],
+    "persist": "Data",
+    "checkver": {
+        "url": "https://www.manictime.com/Releases",
+        "regex": "ManicTime v([\\d.]+)"
+    },
+    "autoupdate": {
+        "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",
+        "url": "https://cdn.manictime.com/setup/v$underscoreVersion_0/ManicTimeUsb.zip"
+    }
+}

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -16,7 +16,7 @@
     ],
     "persist": "Data",
     "checkver": {
-        "url": "https://www.manictime.com/Releases",
+        "url": "http://services.manictime.com/Versions/GetLatestVersionNumber",
         "regex": "ManicTime v([\\d.]+)"
     },
     "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -1,7 +1,7 @@
 {
     "homepage": "https://www.manictime.com",
     "description": "A time tracking software",
-    "version": "4.4.4",
+    "version": "4.4.4.0",
     "license": {
         "identifier": "Proprietary",
         "url": "https://www.manictime.com/pricing"
@@ -19,8 +19,7 @@
         "url": "http://services.manictime.com/Versions/GetLatestVersionNumber",
         "jsonpath": "$.Version"
     },
-    "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",
     "autoupdate": {
-        "url": "https://cdn.manictime.com/setup/v$underscoreVersion_0/ManicTimeUsb.zip"
+        "url": "https://cdn.manictime.com/setup/v$underscoreVersion/ManicTimeUsb.zip"
     }
 }

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -19,8 +19,8 @@
         "url": "https://www.manictime.com/Releases",
         "regex": "ManicTime v([\\d.]+)"
     },
+    "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",
     "autoupdate": {
-        "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",
         "url": "https://cdn.manictime.com/setup/v$underscoreVersion_0/ManicTimeUsb.zip"
     }
 }

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://www.manictime.com",
-    "description": "a time tracking software",
+    "description": "A time tracking software",
     "version": "4.4.4",
     "license": {
         "identifier": "Proprietary",

--- a/bucket/manictime.json
+++ b/bucket/manictime.json
@@ -17,7 +17,7 @@
     "persist": "Data",
     "checkver": {
         "url": "http://services.manictime.com/Versions/GetLatestVersionNumber",
-        "regex": "ManicTime v([\\d.]+)"
+        "jsonpath": "$.Version"
     },
     "##": "The download url need buildversion, but can't get it when checkver, mostly of the time, this is 0, so, just append it.",
     "autoupdate": {


### PR DESCRIPTION
[ManicTime](https://www.manictime.com/): A time tracking software

License: Proprietary
There is a free plan, so we can use it freely with limited function.