### PR TITLE
yapa: Add version 1.2.0

### DIFF
--- a/bucket/yapa.json
+++ b/bucket/yapa.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://lukaszbanasiak.github.io/YAPA/",
+    "description": "A minimalistic desktop timer app for Pomodoro Technique users",
+    "version": "1.2.0",
+    "license": "MIT",
+    "url": "https://github.com/lukaszbanasiak/YAPA/releases/download/v1.2.0/Portable.zip",
+    "hash": "7d2ef32d544853225391a42223ef8e61a644b6024e733b52c738ee4f5571f84a",
+    "extract_dir": "YAPA",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\YAPA.DatabaseContext.sdf\")) { New-Item \"$dir\\YAPA.DatabaseContext.sdf\" | Out-Null }",
+    "shortcuts": [
+        [
+            "YAPA.exe",
+            "YAPA"
+        ]
+    ],
+    "persist": "YAPA.DatabaseContext.sdf",
+    "checkver": {
+        "github": "https://github.com/lukaszbanasiak/YAPA"
+    },
+    "autoupdate": {
+        "url": "https://github.com/lukaszbanasiak/YAPA/releases/download/v$version/Portable.zip"
+    }
+}


### PR DESCRIPTION
[YAPA](http://lukaszbanasiak.github.io/YAPA/): A minimalistic desktop timer app for Pomodoro Technique users

Github: https://github.com/lukaszbanasiak/YAPA
License: MIT

Although it's discontinued, but it still usefull.