### PR TITLE
linqpad: remove `depends` on dotnet-sdk

### DIFF
--- a/bucket/linqpad.json
+++ b/bucket/linqpad.json
@@ -8,7 +8,9 @@
     },
     "url": "http://download.linqpad.net/public/LINQPad6.zip",
     "hash": "206117f5b72e4070608200c40784c3bd7852e5dae0788e4caccf0509df931359",
-    "depends": "dotnet-sdk",
+    "suggest": {
+        ".Net SDK": "dotnet-sdk"
+    },
     "pre_install": [
         "$major = $version -split '\\.' | Select-Object -First 1",
         "Get-ChildItem \"$dir\" 'l*.exe' | ForEach-Object {",


### PR DESCRIPTION
- Closes #3200