### PR TITLE
spek: Add version 0.8.2

### DIFF
--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -15,9 +15,5 @@
             "spek.exe",
             "Spek"
         ]
-    ],
-    "checkver": "spek-([\\d.]+)\\.zip",
-    "autoupdate": {
-        "url": "https://github.com/alexkay/spek/releases/download/v$version/spek-$version.zip"
-    }
+    ]
 }

--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -16,7 +16,7 @@
             "Spek"
         ]
     ],
-    "checkver": "spek-([\\d.]+).zip",
+    "checkver": "spek-([\\d.]+)\\.zip",
     "autoupdate": {
         "url": "https://github.com/alexkay/spek/releases/download/v$version/spek-$version.zip"
     }

--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -1,6 +1,6 @@
 {
     "version": "0.8.2",
-    "description": "Help analyse audio files by showing their spectrogram.",
+    "description": "Acoustic Spectrum Analyser",
     "homepage": "http://spek.cc/",
     "license": {
         "identifier": "Freeware",

--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -2,10 +2,7 @@
     "version": "0.8.2",
     "description": "Acoustic Spectrum Analyser",
     "homepage": "http://spek.cc",
-    "license": {
-        "identifier": "Freeware",
-        "url": "https://github.com/alexkay/spek/blob/master/LICENCE.md"
-    },
+    "license": "GPL-3.0-only",
     "url": "https://github.com/alexkay/spek/releases/download/v0.8.2/spek-0.8.2.zip",
     "hash": "bd667bc119bff4e889835c26b93b79e0bf3c19beff1cc7a1f3689a4e2e1331df",
     "extract_dir": "Spek",

--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.8.2",
+    "description": "Help analyse audio files by showing their spectrogram.",
+    "homepage": "http://spek.cc/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/alexkay/spek/blob/master/LICENCE.md"
+    },
+    "url": "https://github.com/alexkay/spek/releases/download/v0.8.2/spek-0.8.2.zip",
+    "hash": "bd667bc119bff4e889835c26b93b79e0bf3c19beff1cc7a1f3689a4e2e1331df",
+    "extract_dir": "Spek",
+    "bin": "spek.exe",
+    "shortcuts": [
+        [
+            "spek.exe",
+            "Spek"
+        ]
+    ],
+    "checkver": "spek-([\\d.]+).zip",
+    "autoupdate": {
+        "url": "https://github.com/alexkay/spek/releases/download/v$version/spek-$version.zip"
+    }
+}

--- a/bucket/spek.json
+++ b/bucket/spek.json
@@ -1,7 +1,7 @@
 {
     "version": "0.8.2",
     "description": "Acoustic Spectrum Analyser",
-    "homepage": "http://spek.cc/",
+    "homepage": "http://spek.cc",
     "license": {
         "identifier": "Freeware",
         "url": "https://github.com/alexkay/spek/blob/master/LICENCE.md"


### PR DESCRIPTION
close #3343

**Spek** ([homepage](http://spek.cc/)) is an acoustic spectrum analyser (helps to analyse your audio files by showing their spectrogram).

Notes:
* ~*Checkver* matches `xxxx.zip` in the homepage instead of using `github: xxx`, because for some versions (for example, version `0.8.3`) there is no Windows binary.~ Remove checkver/autoupdate since Spek has not been updated since 2016.

* Spek stores its user config under `$Env:AppData\Spek`, so there is no need to use *persist*.