### PR TITLE
geekbench: Fix installer

### DIFF
--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -10,8 +10,8 @@
     "hash": "e6cd79ddc682d836e33cbf7eb4406d261ee71d333eafc22abd23722cdfc3d509",
     "installer": {
         "script": [
-            "Rename-Item \"$dir\\geekbench ?.exe\" 'geekbench_gui.exe'",
-            "Rename-Item \"$dir\\geekbench?.exe\" 'geekbench.exe'",
+            "Get-ChildItem -Path \"$dir\" -Filter \"Geekbench ?.exe\" | Rename-Item -NewName 'geekbench_gui.exe'",
+            "Get-ChildItem -Path \"$dir\" -Filter \"geekbench?.exe\" | Rename-Item -NewName 'geekbench.exe'",
             "Remove-Item \"$dir\\Uninstall*\", \"$dir\\$*\" -Recurse"
         ]
     },

--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -10,8 +10,8 @@
     "hash": "e6cd79ddc682d836e33cbf7eb4406d261ee71d333eafc22abd23722cdfc3d509",
     "installer": {
         "script": [
-            "Get-ChildItem -Path \"$dir\" -Filter \"Geekbench ?.exe\" | Rename-Item -NewName 'geekbench_gui.exe'",
-            "Get-ChildItem -Path \"$dir\" -Filter \"geekbench?.exe\" | Rename-Item -NewName 'geekbench.exe'",
+            "Move-Item \"$dir\\geekbench ?.exe\" 'geekbench_gui.exe'",
+            "Move-Item \"$dir\\geekbench?.exe\" 'geekbench.exe'",
             "Remove-Item \"$dir\\Uninstall*\", \"$dir\\$*\" -Recurse"
         ]
     },

--- a/bucket/geekbench.json
+++ b/bucket/geekbench.json
@@ -10,8 +10,8 @@
     "hash": "e6cd79ddc682d836e33cbf7eb4406d261ee71d333eafc22abd23722cdfc3d509",
     "installer": {
         "script": [
-            "Move-Item \"$dir\\geekbench ?.exe\" 'geekbench_gui.exe'",
-            "Move-Item \"$dir\\geekbench?.exe\" 'geekbench.exe'",
+            "Move-Item \"$dir\\geekbench ?.exe\" \"$dir\\geekbench_gui.exe\"",
+            "Move-Item \"$dir\\geekbench?.exe\" \"$dir\\geekbench.exe\"",
             "Remove-Item \"$dir\\Uninstall*\", \"$dir\\$*\" -Recurse"
         ]
     },


### PR DESCRIPTION
Fix #3337

Wildcard for `Rename-Item` does not work under **Powershell 5.1**. This fixes the problem.