### PR TITLE
claws-mail: Change download URL

### DIFF
--- a/bucket/claws-mail.json
+++ b/bucket/claws-mail.json
@@ -3,8 +3,8 @@
     "description": "An email client (and news reader), based on GTK+.",
     "version": "3.17.4-1",
     "license": "GPL-3.0-or-later",
-    "url": "https://www.claws-mail.org//win32/claws-mail-3.17.3-1-32bit.exe#/dl.7z",
-    "hash": "cd69c32f9dbe975c351041bf2f9228273a90d5ebd68f0eee18b22bacf9600e56",
+    "url": "https://www.claws-mail.org//win32/claws-mail-3.17.4-1-32bit.exe#/dl.7z",
+    "hash": "6d0560b9a4f8e99d56d286bd9cd113803cf59b0972ec3e93c481d0cc67999d27",
     "bin": "claws-mail.exe",
     "post_install": [
         "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force | Out-Null",

--- a/bucket/claws-mail.json
+++ b/bucket/claws-mail.json
@@ -1,15 +1,20 @@
 {
-    "homepage": "https://www.claws-mail.org/",
-    "description": "An email client (and news reader), based on GTK+.",
+    "homepage": "https://www.claws-mail.org",
+    "description": "An email client and news reader",
     "version": "3.17.4-1",
     "license": "GPL-3.0-or-later",
-    "url": "https://www.claws-mail.org//win32/claws-mail-3.17.4-1-32bit.exe#/dl.7z",
-    "hash": "6d0560b9a4f8e99d56d286bd9cd113803cf59b0972ec3e93c481d0cc67999d27",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.claws-mail.org/win32/claws-mail-3.17.4-1-64bit.exe#/dl.7z",
+            "hash": "05d123a7aad5140f2ba58eaecceec098564e2734a5df56d918909f6fb514bc8c"
+        },
+        "32bit": {
+            "url": "https://www.claws-mail.org/win32/claws-mail-3.17.4-1-32bit.exe#/dl.7z",
+            "hash": "6d0560b9a4f8e99d56d286bd9cd113803cf59b0972ec3e93c481d0cc67999d27"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\claws-mail-uninstall.exe\" -Force",
     "bin": "claws-mail.exe",
-    "post_install": [
-        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force | Out-Null",
-        "Remove-Item \"$dir\\claws-mail-uninstall.exe\" -Force | Out-Null"
-    ],
     "shortcuts": [
         [
             "claws-mail.exe",
@@ -21,6 +26,13 @@
         "regex": "claws-mail-([\\d.-]+)-32bit.exe"
     },
     "autoupdate": {
-        "url": "https://www.claws-mail.org//win32/claws-mail-3.17.3-1-32bit.exe#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://www.claws-mail.org/win32/claws-mail-$version-64bit.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://www.claws-mail.org/win32/claws-mail-$version-32bit.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
The update commit for claws-mail was missing the new url and file hash for the installer