### PR TITLE
wsltty: Fix manifest and update to 3.1.0.2

### DIFF
--- a/bucket/wsltty.json
+++ b/bucket/wsltty.json
@@ -29,7 +29,7 @@
             "& .\\uninstall.bat",
             "Pop-Location"
         ]
-    },    
+    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {

--- a/bucket/wsltty.json
+++ b/bucket/wsltty.json
@@ -2,9 +2,9 @@
     "homepage": "https://github.com/mintty/wsltty",
     "description": "Mintty as a terminal for WSL (Windows Subsystem for Linux).",
     "license": "GPL-3.0-or-later",
-    "version": "3.1.0",
-    "url": "https://github.com/mintty/wsltty/releases/download/3.1.0/wsltty-3.1.0-install-x86_64.exe#/dl.7z",
-    "hash": "a85816783c9321aeded45f0de151886a7a7527b3e9b900d1993bcae307744e80",
+    "version": "3.1.0.2",
+    "url": "https://github.com/mintty/wsltty/releases/download/3.1.0.2/wsltty-3.1.0.2-install-x86_64.exe#/dl.7z",
+    "hash": "bedc400ec9ca86aed1b051f84a30e6158f02b6e0cd1c3b1d4eef3d2e4f7ce2a4",
     "extract_to": "installer",
     "installer": {
         "script": [

--- a/bucket/wsltty.json
+++ b/bucket/wsltty.json
@@ -1,21 +1,29 @@
 {
-    "version": "3.0.6",
+    "homepage": "https://github.com/mintty/wsltty",
     "description": "Mintty as a terminal for WSL (Windows Subsystem for Linux).",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/mintty/wsltty/releases/download/3.0.6/wsltty-3.0.6-install.exe#/dl.7z",
-    "homepage": "https://github.com/mintty/wsltty",
-    "hash": "90b0bb924969d5d831fe47b95d39c07039c9c7d93a354dd356770df4a79fe1dd",
-    "checkver": {
-        "github": "https://github.com/mintty/wsltty"
+    "version": "3.1.0",
+    "url": "https://github.com/mintty/wsltty/releases/download/3.1.0/wsltty-3.1.0-install-x86_64.exe#/dl.7z",
+    "hash": "a85816783c9321aeded45f0de151886a7a7527b3e9b900d1993bcae307744e80",
+    "extract_to": "installer",
+    "installer": {
+        "script": [
+            "Push-Location \"$dir\\installer\"",
+            "& .\\install.bat \"$dir\" \"$dir\\config\"",
+            "Pop-Location"
+        ]
     },
+    "post_install": "Remove-Item -LiteralPath \"$dir\\installer\" -Force -Recurse",
+    "uninstaller": {
+        "script": [
+            "$env:installdir = $dir",
+            "Push-Location \"$dir\"",
+            "& .\\uninstall.bat",
+            "Pop-Location"
+        ]
+    },    
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install.exe#/dl.7z"
-    },
-    "installer": {
-        "file": "install.bat",
-        "keep": true
-    },
-    "uninstaller": {
-        "file": "uninstall.bat"
     }
 }

--- a/bucket/wsltty.json
+++ b/bucket/wsltty.json
@@ -1,10 +1,18 @@
 {
-    "homepage": "https://github.com/mintty/wsltty",
-    "description": "Mintty as a terminal for WSL (Windows Subsystem for Linux).",
-    "license": "GPL-3.0-or-later",
     "version": "3.1.0.2",
-    "url": "https://github.com/mintty/wsltty/releases/download/3.1.0.2/wsltty-3.1.0.2-install-x86_64.exe#/dl.7z",
-    "hash": "bedc400ec9ca86aed1b051f84a30e6158f02b6e0cd1c3b1d4eef3d2e4f7ce2a4",
+    "description": "Mintty as a terminal for WSL (Windows Subsystem for Linux).",
+    "homepage": "https://github.com/mintty/wsltty",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mintty/wsltty/releases/download/3.1.0.2/wsltty-3.1.0.2-install-i686.exe#/dl.7z",
+            "hash": "c0726db869c17c49361d143d6ff1566754ef7d45faa3d784cd7f7523958fd1e7"
+        },
+        "32bit": {
+            "url": "https://github.com/mintty/wsltty/releases/download/3.1.0.2/wsltty-3.1.0.2-install-x86_64.exe#/dl.7z",
+            "hash": "bedc400ec9ca86aed1b051f84a30e6158f02b6e0cd1c3b1d4eef3d2e4f7ce2a4"
+        }
+    },
     "extract_to": "installer",
     "installer": {
         "script": [
@@ -21,9 +29,16 @@
             "& .\\uninstall.bat",
             "Pop-Location"
         ]
-    },
+    },    
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install.exe#/dl.7z"
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install-i686.exe#/dl.7z"
+            },
+            "64bit": {
+                "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install-x86_64.exe#/dl.7z"
+            }
+        }
     }
 }

--- a/bucket/wsltty.json
+++ b/bucket/wsltty.json
@@ -21,7 +21,7 @@
             "& .\\uninstall.bat",
             "Pop-Location"
         ]
-    },    
+    },
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/mintty/wsltty/releases/download/$version/wsltty-$version-install.exe#/dl.7z"


### PR DESCRIPTION
- Closes #4640
- Closes #3146
- Closes #2318

This one has been broken for quite some time now.

This manifest seems to work for me, but I'm not sure if I got the auto-updating stuff correct.

Also, there's still a bug where most of the start menu shortcuts don't work as expected. They're created to point to scoop's custom installation folder, but the applications themselves still expect to be in the default location (%AppData\wsltty). But I think that's outside the scope of scoop. That's something they need to resolve on their end.