### PR TITLE
inky: Add version 0.11.0

### DIFF
--- a/bucket/inky.json
+++ b/bucket/inky.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://www.inklestudios.com/ink/",
+    "description": "An editor for ink: inkle's narrative scripting language",
+    "version": "0.11.0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/inkle/inky/releases/download/0.11.0/Inky_windows_64.zip",
+            "hash": "bdcd518ad7f819ab573ebabbb07ba81c424cef84e84af7d13bb9daddac03e410",
+            "extract_dir": "Inky-win32-x64"
+        },
+        "32bit": {
+            "url": "https://github.com/inkle/inky/releases/download/0.11.0/Inky_windows_32.zip",
+            "hash": "24f80cb416d7790edcf11ece84fe5f387655fc3c2f781f66f842560d2835adae",
+            "extract_dir": "Inky-win32-ia32"
+        }
+    },
+    "shortcuts": [
+        [
+            "Inky.exe",
+            "Inky"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/inkle/inky"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/inkle/inky/releases/download/$version/Inky_windows_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/inkle/inky/releases/download/$version/Inky_windows_32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Inky](https://www.inklestudios.com/ink/): is a editor for ink, inkle's markup language for writing interactive narrative in games, as used in 80 Days. 

Github: https://github.com/inkle/inky
License: MIT