### PR TITLE
msxml4: Add version 4.30.2100.0

### DIFF
--- a/bucket/msxml4.json
+++ b/bucket/msxml4.json
@@ -9,6 +9,6 @@
     },
     "url": "https://download.microsoft.com/download/A/2/D/A2D8587D-0027-4217-9DAD-38AFDB0A177E/msxml.msi#/setup.msi_",
     "hash": "47c2ae679c37815da9267c81fc3777de900ad2551c11c19c2840938b346d70bb",
-    "post_install": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/quiet', '/norestart') -RunAs | Out-Null",
+    "post_install": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\$fname\", '/quiet', '/norestart') -RunAs | Out-Null",
     "notes": "You can now remove this installer with 'scoop uninstall msxml4'"
 }

--- a/bucket/msxml4.json
+++ b/bucket/msxml4.json
@@ -1,0 +1,14 @@
+{
+    "##": "Renaming .msi to .msi_ so that the MSI package will not be automatically extracted by Scoop.",
+    "version": "4.30.2100.0",
+    "description": "Microsoft XML Core Services (MSXML) runtime library",
+    "homepage": "http://msdn.microsoft.com/en-us/library/ms763742.aspx",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
+    },
+    "url": "https://download.microsoft.com/download/A/2/D/A2D8587D-0027-4217-9DAD-38AFDB0A177E/msxml.msi#/setup.msi_",
+    "hash": "47c2ae679c37815da9267c81fc3777de900ad2551c11c19c2840938b346d70bb",
+    "post_install": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\setup.msi_\", '/quiet', '/norestart') -RunAs | Out-Null",
+    "notes": "You can now remove this installer with 'scoop uninstall msxml4'"
+}

--- a/bucket/msxml4.json
+++ b/bucket/msxml4.json
@@ -10,7 +10,7 @@
     "url": "https://download.microsoft.com/download/A/2/D/A2D8587D-0027-4217-9DAD-38AFDB0A177E/msxml.msi#/setup.msi_",
     "hash": "47c2ae679c37815da9267c81fc3777de900ad2551c11c19c2840938b346d70bb",
     "post_install": [
-        "if (-not (is_admin)) { error 'This package requires admin privileges to install'; Exit(1) }",
+        "if (-not (is_admin)) { error 'This package requires admin privileges to install'; break }",
         "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\$fname\", '/quiet', '/norestart') -RunAs | Out-Null"
     ],
     "notes": "You can now remove this installer with 'scoop uninstall msxml4'"

--- a/bucket/msxml4.json
+++ b/bucket/msxml4.json
@@ -9,6 +9,9 @@
     },
     "url": "https://download.microsoft.com/download/A/2/D/A2D8587D-0027-4217-9DAD-38AFDB0A177E/msxml.msi#/setup.msi_",
     "hash": "47c2ae679c37815da9267c81fc3777de900ad2551c11c19c2840938b346d70bb",
-    "post_install": "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\$fname\", '/quiet', '/norestart') -RunAs | Out-Null",
+    "post_install": [
+        "if (-not (is_admin)) { error 'This package requires admin privileges to install'; Exit(1) }",
+        "Invoke-ExternalCommand msiexec -ArgumentList @('/i', \"$dir\\$fname\", '/quiet', '/norestart') -RunAs | Out-Null"
+    ],
     "notes": "You can now remove this installer with 'scoop uninstall msxml4'"
 }


### PR DESCRIPTION
**MSXML 4** ([Wikipedia](https://en.wikipedia.org/wiki/MSXML)) is the runtime library for Microsoft XML Core Services (MSXML) version 4. It is obsolete now, but some old applications/games (e.g. `Age of Mythology`, `Age of Empires 3`, `Rise of Legends`) still need it.

Notes:

* This manifest follows the pattern of [VCRedist packages](https://github.com/lukesampson/scoop-extras/blob/8a1d5cd2d16c5796a30e9f3e07eb755171c0463a/bucket/vcredist2013.json).

* See [this article from Microsoft](https://support.microsoft.com/en-us/help/269238/list-of-microsoft-xml-parser-msxml-versions) about version numbers and compatibility of MSXML.

* **Homepage**: The *MSXML homepage* link on Wikipedia leads to [the documentation](http://msdn.microsoft.com/en-us/library/ms763742.aspx). I guess Microsoft took down the project homepage, and redirected the homepage URL to the documentation since *MSXML* is no longer maintained. **(Should I keep 'homepage' in the manifest, or just remove it?)**


* **Version number** (4.30.2100.0) can be found at *Control Panel -> Applications*, or in the properties tag of `$Env:SystemRoot\SysWOW64\msxml4.dll` after installation.
