### PR TITLE
milton@1.9.1: Fix extraction

### DIFF
--- a/bucket/milton.json
+++ b/bucket/milton.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/serge-rgb/milton/releases/download/v1.9.1/Milton_1.9.1_Standalone_x64.zip",
             "hash": "5a732d60349c924ac8d7e85716fc4e920a9b6713d2fc741d45a115046e6b8665",
-            "extract_dir": "Standalone"
+            "extract_dir": "Milton_1.9.1_Standalone_x64"
         }
     },
     "bin": "Milton.exe",

--- a/bucket/milton.json
+++ b/bucket/milton.json
@@ -19,6 +19,7 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/serge-rgb/milton/releases/download/v$version/Milton_$version_Standalone_x64.zip"
+        "url": "https://github.com/serge-rgb/milton/releases/download/v$version/Milton_$version_Standalone_x64.zip",
+        "extract_dir": "Milton_$version_Standalone_x64"
     }
 }

--- a/bucket/milton.json
+++ b/bucket/milton.json
@@ -1,7 +1,7 @@
 {
     "version": "1.9.1",
-    "description": "An infinite-canvas paint program.",
-    "homepage": "https://github.com/serge-rgb/milton/",
+    "description": "An infinite-canvas paint program",
+    "homepage": "https://github.com/serge-rgb/milton",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
@@ -19,7 +19,11 @@
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/serge-rgb/milton/releases/download/v$version/Milton_$version_Standalone_x64.zip",
-        "extract_dir": "Milton_$version_Standalone_x64"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/serge-rgb/milton/releases/download/v$version/Milton_$version_Standalone_x64.zip",
+                "extract_dir": "Milton_$version_Standalone_x64"
+            }
+        }
     }
 }


### PR DESCRIPTION
`scoop install milton` failed. With this, it doesn't!