### PR TITLE
infoqube: Update to version 0.9.114q (manually)

### DIFF
--- a/bucket/infoqube.json
+++ b/bucket/infoqube.json
@@ -1,13 +1,13 @@
 {
     "homepage": "http://www.infoqube.biz/",
-    "description": "An Information Management System that provides all the tools you need to simplify your life.",
-    "version": "0.9.113f",
+    "description": "information management system",
+    "version": "0.9.114q",
     "license": {
         "identifier": "Proprietary",
         "url": "https://infoqubeim.com/drupal5/index.php?q=node/632"
     },
-    "url": "https://infoqubeim.com/downloadarea/InfoQube0.9.113fPortable.zip",
-    "hash": "43b1b39fb8a5237f46ef02cef747a92dcb47099ac81bf1010574856cdfd6cc32",
+    "url": "https://infoqubeim.com/downloadarea/InfoQube0.9.114qPortable.zip",
+    "hash": "ba2f64b9ee0c19bd287a3117e66a6d10d1a162e4967d90924fff8b36a6a76e6e",
     "shortcuts": [
         [
             "InfoQube.exe",
@@ -17,7 +17,7 @@
     "persist": "Users",
     "checkver": {
         "url": "http://www.infoqube.biz/download",
-        "re": "InfoQube ([\\d.]+\\w?)"
+        "regex": "InfoQube([\\w.]+)Portable.zip"
     },
     "autoupdate": {
         "url": "https://infoqubeim.com/downloadarea/InfoQube$versionPortable.zip"

--- a/bucket/infoqube.json
+++ b/bucket/infoqube.json
@@ -17,7 +17,7 @@
     "persist": "Users",
     "checkver": {
         "url": "http://www.infoqube.biz/download",
-        "regex": "InfoQube([\\w.]+)Portable.zip"
+        "regex": "InfoQube([\\d.]+\\w?)Portable.zip"
     },
     "autoupdate": {
         "url": "https://infoqubeim.com/downloadarea/InfoQube$versionPortable.zip"

--- a/bucket/infoqube.json
+++ b/bucket/infoqube.json
@@ -17,7 +17,7 @@
     "persist": "Users",
     "checkver": {
         "url": "http://www.infoqube.biz/download",
-        "regex": "InfoQube([\\d.]+\\w?)Portable.zip"
+        "regex": "InfoQube([\\d.]+\\w?)Portable\\.zip"
     },
     "autoupdate": {
         "url": "https://infoqubeim.com/downloadarea/InfoQube$versionPortable.zip"


### PR DESCRIPTION
**infoqube** has changed the layout of their website, causing `checkver` to fail. This fixes the problem.

Also modified `description` to make it briefer.