### PR TITLE
treesize-free: Fix url and checkver

### DIFF
--- a/bucket/treesize-free.json
+++ b/bucket/treesize-free.json
@@ -1,13 +1,13 @@
 {
     "homepage": "https://www.jam-software.com/treesize_free",
-    "description": "Quickly capture directory sizes and memory guzzlers.",
+    "description": "Capture directory sizes and memory guzzlers.",
     "version": "4.4.1",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.jam-software.de/company/freeware_license.shtml"
     },
-    "url": "http://downloads.jam-software.com/treesize_free/TreeSizeFree-Portable.zip",
-    "hash": "60d0e38550de46e305d7f832e4d2be73adfdb76b6a96ee972268858a7aae498f",
+    "url": "https://downloads.jam-software.de/treesize_free/TreeSizeFree-Portable.zip",
+    "hash": "6c679410fe784bab84ecf536e7b9112a299b4d9b4576c67676f691ecce13fad1",
     "bin": "TreeSizeFree.exe",
     "shortcuts": [
         [
@@ -17,9 +17,9 @@
     ],
     "checkver": {
         "url": "https://www.jam-software.com/treesize_free/changes.shtml",
-        "regex": "Version\\s+([\\d.]+):"
+        "regex": "Version ([\\d.]+)\\</h3\\>"
     },
     "autoupdate": {
-        "url": "http://downloads.jam-software.com/treesize_free/TreeSizeFree-Portable.zip"
+        "url": "https://downloads.jam-software.de/treesize_free/TreeSizeFree-Portable.zip"
     }
 }

--- a/bucket/treesize-free.json
+++ b/bucket/treesize-free.json
@@ -17,7 +17,7 @@
     ],
     "checkver": {
         "url": "https://www.jam-software.com/treesize_free/changes.shtml",
-        "regex": "Version ([\\d.]+)\\</h3\\>"
+        "regex": "Version\\s+([\\d.]+)</h3>"
     },
     "autoupdate": {
         "url": "https://downloads.jam-software.de/treesize_free/TreeSizeFree-Portable.zip"


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* They changed the layout of their website. Therefore `checkver` needs to be modified.

* The **download url** on `downloads.jam-software.com` is not working. Their website provides multiple download locations, but both *North America* and *Europe* leads to `downloads.jam-software.de`.

* Not sure why **hash** value changed. Probably due to some minor updates.