### PR TITLE
wumgr: Update to version 1.1b (manually)

### DIFF
--- a/bucket/wumgr.json
+++ b/bucket/wumgr.json
@@ -16,7 +16,7 @@
     ],
     "checkver": {
         "github": "https://github.com/DavidXanatos/wumgr",
-        "regex": "WuMgr_v([\\d.]+\\w?)\\.zip"
+        "regex": "WuMgr_v([\\w.]+)\\.zip"
     },
     "autoupdate": {
         "url": "https://github.com/DavidXanatos/wumgr/releases/download/v$matchHead/WuMgr_v$version.zip"

--- a/bucket/wumgr.json
+++ b/bucket/wumgr.json
@@ -1,10 +1,10 @@
 {
     "homepage": "https://github.com/DavidXanatos/wumgr",
-    "description": "Manage updates of Microsoft products on the Windows operating system.",
-    "version": "1.0",
+    "description": "Manage updates of Microsoft products.",
+    "version": "1.1b",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/DavidXanatos/wumgr/releases/download/1.0/WuMgr_v1.0.zip",
-    "hash": "34c5ae2faaddde529c59d478cc0205637feaabdefcc4207039c7db5193cf0ce2",
+    "url": "https://github.com/DavidXanatos/wumgr/releases/download/v1.1/WuMgr_v1.1b.zip",
+    "hash": "585f10d7d75779b8a74859a9b70a925370f593b239ecf8b8c328ed59c71b276a",
     "bin": "wumgr.exe",
     "pre_install": "if(!(Test-Path \"$persist_dir\\wumgr.ini\")) { New-Item \"$dir\\wumgr.ini\" -Type File | Out-Null }",
     "persist": "wumgr.ini",
@@ -15,10 +15,10 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/DavidXanatos/wumgr/",
-        "regex": "tag/([\\w.]+)"
+        "github": "https://github.com/DavidXanatos/wumgr",
+        "regex": "WuMgr_v([\\d.]+\\w?)\\.zip"
     },
     "autoupdate": {
-        "url": "https://github.com/DavidXanatos/wumgr/releases/download/$version/WuMgr_v$version.zip"
+        "url": "https://github.com/DavidXanatos/wumgr/releases/download/v$matchHead/WuMgr_v$version.zip"
     }
 }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

The latest version is `1.1b`, but it is put under the tag `v1.1`.

See https://github.com/DavidXanatos/wumgr/releases and https://github.com/DavidXanatos/wumgr/compare/v1.1...master for details.