### PR TITLE
yatqa: Update to version 3.9.8.3b (manually)

### DIFF
--- a/bucket/yatqa.json
+++ b/bucket/yatqa.json
@@ -1,13 +1,13 @@
 {
     "homepage": "https://yat.qa/",
     "description": "Manage TeamSpeak 3 servers and instances using a query interface",
-    "version": "3.9.8.3",
+    "version": "3.9.8.3b",
     "license": {
         "identifier": "Freeware",
         "url": "https://referencesource.microsoft.com/license.html"
     },
-    "url": "https://dl.yat.qa/stable/YaTQA-Setup_3.9.8.3.exe",
-    "hash": "1a146e5bc5c8f0c1eebfe40745f24ea6e90497854dc55e1599979e2c10f33a31",
+    "url": "https://dl.yat.qa/stable/YaTQA-Setup_3.9.8.3b.exe",
+    "hash": "b17b4412979f80e2e58bdb003caaeadf36d4c6e5c269c8d121db9850805b1423",
     "bin": "yatqa.exe",
     "persist": "yatqa.ini",
     "shortcuts": [
@@ -22,7 +22,7 @@
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
     "checkver": {
         "url": "https://yat.qa/.update",
-        "regex": "v([\\d.]+)\\s+\\("
+        "regex": "v([\\d.]+\\w?)\\s+\\("
     },
     "autoupdate": {
         "url": "https://dl.yat.qa/stable/YaTQA-Setup_$version.exe"

--- a/bucket/yatqa.json
+++ b/bucket/yatqa.json
@@ -22,7 +22,7 @@
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
     "checkver": {
         "url": "https://yat.qa/.update",
-        "regex": "v([\\d.]+\\w?)\\s+\\("
+        "regex": "v([\\w.]+)\\s+\\("
     },
     "autoupdate": {
         "url": "https://dl.yat.qa/stable/YaTQA-Setup_$version.exe"


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

**yatqa** now include letters (such as 3.9.8.3**b**) in the version number. Therefore `checkver` needs to be modified.