### PR TITLE
vidi: Update to version 0.2.5.5 (manually)

### DIFF
--- a/bucket/vidi.json
+++ b/bucket/vidi.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://hshrzd.wordpress.com/vidi-visual-disassembler/",
     "description": "A tool for static analysis of PE files, based on bearparser & capstone",
-    "version": "0.2.5.6",
+    "version": "0.2.5.5",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.6/vidi_0.2.5.6_x64_win.zip",
-            "hash": "833fb9c19f0899d3491f8bd61a8173af1206bba3e2ce37a1fee9a5163b8ef4fc"
+            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.5/vidi_0.2.5.5_x64_win.zip",
+            "hash": "487f27e9df14c4da167caab3556a45cc0900028adde3100433be9cf0a64439d9"
         },
         "32bit": {
-            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.6/vidi_0.2.5.6_x86_win.zip",
-            "hash": "8e4dfa8b4ea0b98a71a3d79f3d0dc30a9db8006914fd5b2f5898313a7c018284"
+            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.5/vidi_0.2.5.5_x86_win.zip",
+            "hash": "62053d88415f5f5061231280d8614b03603f59e980548ea297d1ecb82c0c3b28"
         }
     },
     "bin": "vidi.exe",
@@ -25,15 +25,5 @@
     },
     "checkver": {
         "github": "https://github.com/hasherezade/ViDi"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_$version_x64_win.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_$version_x86_win.zip"
-            }
-        }
     }
 }

--- a/bucket/vidi.json
+++ b/bucket/vidi.json
@@ -21,7 +21,7 @@
         ]
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2015"
+        "vcredist": "extras/vcredist2019"
     },
     "checkver": {
         "github": "https://github.com/hasherezade/ViDi"

--- a/bucket/vidi.json
+++ b/bucket/vidi.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://hshrzd.wordpress.com/vidi-visual-disassembler/",
     "description": "A tool for static analysis of PE files, based on bearparser & capstone",
-    "version": "0.2.5.4",
+    "version": "0.2.5.6",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.4/vidi_x64.zip",
-            "hash": "240f8f10abb8f7515f7843034b99bb7b10e45b66fdfb50fdd400b3d093cd558d"
+            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.6/vidi_0.2.5.6_x64_win.zip",
+            "hash": "833fb9c19f0899d3491f8bd61a8173af1206bba3e2ce37a1fee9a5163b8ef4fc"
         },
         "32bit": {
-            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.4/vidi_x86.zip",
-            "hash": "71022401d14a7c648b23c4a472fefb5a743af447fb921487c45834dd7d348fe9"
+            "url": "https://github.com/hasherezade/ViDi/releases/download/0.2.5.6/vidi_0.2.5.6_x86_win.zip",
+            "hash": "8e4dfa8b4ea0b98a71a3d79f3d0dc30a9db8006914fd5b2f5898313a7c018284"
         }
     },
     "bin": "vidi.exe",
@@ -21,7 +21,7 @@
         ]
     ],
     "suggest": {
-        "vcredist": "extras/vcredist2017"
+        "vcredist": "extras/vcredist2015"
     },
     "checkver": {
         "github": "https://github.com/hasherezade/ViDi"
@@ -29,10 +29,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_x64.zip"
+                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_$version_x64_win.zip"
             },
             "32bit": {
-                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_x86.zip"
+                "url": "https://github.com/hasherezade/ViDi/releases/download/$version/vidi_$version_x86_win.zip"
             }
         }
     }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* **ViDi** has changed their file name patterns. ~Therefore `autoupdate` needs to be modified.~ Removing `autoupdate` since their latest version is marked as **experimental**.

* ~ViDi now depends on VCRedist 2015. (was VCRedist 2017 previously) (see: https://github.com/hasherezade/ViDi/releases)~
    -> Visual C++ 2015, 2017 and 2019 all share the same redistributable files, therefore use `extras/vcredist2019` instead.