### PR TITLE
CHK: Add version 3.21

### DIFF
--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -1,7 +1,7 @@
 {
     "version": "3.21",
     "description": "GUI hash tool",
-    "homepage": "https://compressme.net/",
+    "homepage": "https://compressme.net",
     "license": "Freeware",
     "architecture": {
         "64bit": {

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -2,7 +2,7 @@
     "version": "3.21",
     "description": "GUI hash tool",
     "homepage": "https://compressme.net/",
-    "license": "Proprietary",
+    "license": "Freeware",
     "architecture": {
         "64bit": {
             "url": "http://compressme.net/chk321.zip",

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -14,7 +14,7 @@
         }
     },
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\chk.cfg\")) {New-Item \"$dir\\chk.cfg\" -ItemType File | Out-Null}",
+        "if (!(Test-Path \"$persist_dir\\chk.cfg\")) { New-Item \"$dir\\chk.cfg\" | Out-Null }",
         "if(!(Test-Path \"$persist_dir\\lang.txt\")) {New-Item \"$dir\\lang.txt\" -ItemType File | Out-Null}"
     ],
     "bin": "chk.exe",

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -15,7 +15,7 @@
     },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\chk.cfg\")) { New-Item \"$dir\\chk.cfg\" | Out-Null }",
-        "if(!(Test-Path \"$persist_dir\\lang.txt\")) {New-Item \"$dir\\lang.txt\" -ItemType File | Out-Null}"
+        "if (!(Test-Path \"$persist_dir\\lang.txt\")) { New-Item \"$dir\\lang.txt\" | Out-Null }"
     ],
     "bin": "chk.exe",
     "shortcuts": [

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -1,0 +1,42 @@
+{
+    "version": "3.21",
+    "description": "GUI hash tool",
+    "homepage": "https://compressme.net/",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "http://compressme.net/chk321.zip",
+            "hash": "61dfa9602a3cc90e3f17b4bbdf114585eec214e87dcfcbc5d2d2d4b9236f4208"
+        },
+        "32bit": {
+            "url": "http://compressme.net/chk321_x86.zip",
+            "hash": "c8e9e79e0f85639fd0c8b7742cc96a06a0a559c71ca5484e4d996ed23275889a"
+        }
+    },
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\chk.cfg\")) {New-Item \"$dir\\chk.cfg\" -ItemType File | Out-Null}",
+        "if(!(Test-Path \"$persist_dir\\lang.txt\")) {New-Item \"$dir\\lang.txt\" -ItemType File | Out-Null}"
+    ],
+    "bin": "chk.exe",
+    "shortcuts": [
+        [
+            "chk.exe",
+            "CHK"
+        ]
+    ],
+    "persist": [
+        "chk.cfg",
+        "lang.txt"
+    ],
+    "checkver": "CHK\\s+v([\\d.]+)\\s+Win64",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://compressme.net/chk$cleanVersion.zip"
+            },
+            "32bit": {
+                "url": "http://compressme.net/chk$cleanVersion_x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
close #3198

**CHK** ([homepage](https://compressme.net/)) is an advanced hash tool with gui interface.

* `lang.txt` is the language pack file. If users want to use the language pack feature, they need to download the language pack, and put the `lang.txt` of their preferred language (e.g. Simplified Chinese) in the install directory.
(See "Download" -> "Language Packs" on https://compressme.net/)