### PR TITLE
ngspice: Add version 31

### DIFF
--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -10,7 +10,13 @@
             "extract_dir": "Spice64"
         }
     },
-    "bin": "bin\\ngspice_con.exe",
+    "bin": [
+        "bin\\ngspice_con.exe",
+        [
+            "bin\\ngspice_con.exe",
+            "ngspice"
+        ]
+    ],
     "shortcuts": [
         [
             "bin\\ngspice.exe",

--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -1,8 +1,9 @@
 {
+    "##": "Ngspice is licensed under an 'modified BSD license'. License terms can be found under docs/COPYING in the archive.",
     "version": "31",
     "description": "SPICE simulator for electric and electronic circuits",
     "homepage": "http://ngspice.sourceforge.net",
-    "license": "GFDL-1.3-or-later",
+    "license": "Freeware",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/31/ngspice-31_64.zip",

--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -1,0 +1,31 @@
+{
+    "version": "31",
+    "description": "SPICE simulator for electric and electronic circuits",
+    "homepage": "http://ngspice.sourceforge.net",
+    "license": "GFDL-1.3-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/31/ngspice-31_64.zip",
+            "hash": "sha1:a2be39b16179b53e0a9b9b0d10d9c8f3a415c317",
+            "extract_dir": "Spice64"
+        }
+    },
+    "bin": "bin\\ngspice_con.exe",
+    "shortcuts": [
+        [
+            "bin\\ngspice.exe",
+            "Ngspice"
+        ]
+    ],
+    "checkver": {
+        "url": "http://ngspice.sourceforge.net/download.html",
+        "regex": "ngspice-(\\d+)</strong></a>"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/$version/ngspice-$version_64.zip"
+            }
+        }
+    }
+}

--- a/bucket/ngspice.json
+++ b/bucket/ngspice.json
@@ -1,9 +1,8 @@
 {
-    "##": "Ngspice is licensed under an 'modified BSD license'. License terms can be found under docs/COPYING in the archive.",
     "version": "31",
     "description": "SPICE simulator for electric and electronic circuits",
     "homepage": "http://ngspice.sourceforge.net",
-    "license": "Freeware",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/31/ngspice-31_64.zip",


### PR DESCRIPTION
**Ngspice** ([homepage](http://ngspice.sourceforge.net/)) is a SPICE simulator for electric and electronic circuits.

* Only the **64-bit** version is included because the 32-bit version is no longer updated (it stays at version 27).