### PR TITLE
launchy: Update to version 2.10.79

### DIFF
--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -14,6 +14,12 @@
         }
     },
     "innosetup": true,
+    "installer": {
+        "script": "if (Test-Path \"$persist_dir\") { Copy-Item \"$persist_dir\\launchy.ini\" \"$dir\" -Force }"
+    },
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\launchy.ini\" \"$persist_dir\" -Force"
+    },
     "bin": "Launchy.exe",
     "shortcuts": [
         [
@@ -23,8 +29,7 @@
     ],
     "persist": [
         "history.db",
-        "launchy.db",
-        "launchy.ini"
+        "launchy.db"
     ],
     "checkver": {
         "github": "https://github.com/OpenNingia/Launchy",

--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "http://www.launchy.net/",
+    "homepage": "https://openningia.github.io/Launchy",
     "description": "A smart search launcher for installed programs or files.",
     "version": "2.10.79",
     "license": "Unknown",

--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -28,7 +28,7 @@
     ],
     "checkver": {
         "github": "https://github.com/OpenNingia/Launchy",
-        "re": "/releases/tag/launchy-(?:v|V)?([\\d.]+)"
+        "regex": "tag/launchy-v([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -1,16 +1,16 @@
 {
-    "homepage": "https://openningia.github.io/Launchy",
+    "homepage": "http://www.launchy.net/",
     "description": "A smart search launcher for installed programs or files.",
-    "version": "2.9.66",
+    "version": "2.10.79",
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://dl.bintray.com/openningia/Launchy/Launchy_Setup_x64-2.9.66.exe",
-            "hash": "3cb6da4b37c7c3fc922bb49959c2ed19023b377b09280875dd79b4e6170a32f8"
+            "url": "https://github.com/OpenNingia/Launchy/releases/download/launchy-v2.10.79/Launchy_Setup_x64-2.10.79.exe",
+            "hash": "d14b2cc5ce7aba75e0189d7047e805b07d469cb92efc0f21c2f2f67177e0b17a"
         },
         "32bit": {
-            "url": "https://dl.bintray.com/openningia/Launchy/Launchy_Setup-2.9.66.exe",
-            "hash": "223a21915011399e74566b12cb00fd61893b8e724c86f9fb34c016d3326dee66"
+            "url": "https://github.com/OpenNingia/Launchy/releases/download/launchy-v2.10.79/Launchy_Setup-2.10.79.exe",
+            "hash": "866c8fe490f710886fe17852bc8a1cdf4cbf51844d8306a9520db7e7bf6d3d04"
         }
     },
     "innosetup": true,
@@ -27,20 +27,17 @@
         "launchy.ini"
     ],
     "checkver": {
-        "url": "https://api.bintray.com/packages/openningia/Launchy/LaunchyInstaller",
-        "jp": "$.latest_version"
+        "github": "https://github.com/OpenNingia/Launchy",
+        "re": "/releases/tag/launchy-(?:v|V)?([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.bintray.com/openningia/Launchy/Launchy_Setup_x64-$version.exe"
+                "url": "https://github.com/OpenNingia/Launchy/releases/download/launchy-v$version/Launchy_Setup_x64-$version.exe"
             },
             "32bit": {
-                "url": "https://dl.bintray.com/openningia/Launchy/Launchy_Setup-$version.exe"
+                "url": "https://github.com/OpenNingia/Launchy/releases/download/launchy-v$version/Launchy_Setup-$version.exe"
             }
-        },
-        "hash": {
-            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/launchy.json
+++ b/bucket/launchy.json
@@ -15,7 +15,7 @@
     },
     "innosetup": true,
     "installer": {
-        "script": "if (Test-Path \"$persist_dir\") { Copy-Item \"$persist_dir\\launchy.ini\" \"$dir\" -Force }"
+        "script": "if (Test-Path \"$persist_dir\\launchy.ini\") { Copy-Item \"$persist_dir\\launchy.ini\" \"$dir\" -Force }"
     },
     "uninstaller": {
         "script": "Copy-Item \"$dir\\launchy.ini\" \"$persist_dir\" -Force"


### PR DESCRIPTION
Looks like the releases on github are more up to date, so let's switch over to them.

One issue I found while using it: (this is independent of the version update)
Looks like the persistence of `launchy.ini` is not working properly. I suspect the app deletes and recreates the file on every settings change leading to a decoupled file in the `persistent` folder and a regular, non-linked file in the app folder. Any suggestions about that? Should I file it in a separate issue?