### PR TITLE
windows-terminal: Add wt shim

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -20,7 +20,13 @@
             "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
         ]
     },
-    "bin": "WindowsTerminal.exe",
+    "bin": [
+        "WindowsTerminal.exe",
+        [
+            "WindowsTerminal.exe",
+            "wt"
+        ]
+    ],
     "shortcuts": [
         [
             "WindowsTerminal.exe",


### PR DESCRIPTION
regular Windows Terminal install creates a `wt` shortcut, we should replicate this behavior

see e.g. [How to open Windows Terminal from command prompt or run](https://www.thomasmaurer.ch/2019/08/how-to-open-windows-terminal-from-command-prompt-or-run/)