### PR TITLE
gedit: Add version 3.20.1

### DIFF
--- a/bucket/gedit.json
+++ b/bucket/gedit.json
@@ -1,0 +1,34 @@
+{
+    "version": "3.20.1",
+    "description": "A powerful general purpose text editor",
+    "homepage": "https://wiki.gnome.org/Apps/Gedit",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.gnome.org/binaries/win64/gedit/gedit-x86_64-3.20.1.msi",
+            "hash": "6f5be888c1128c302181d75fdece6085d4eb94391dc92d25df48946b2dd0a630",
+            "extract_dir": "ProgramFiles64Folder\\gedit"
+        }
+    },
+    "bin": "bin\\gedit.exe",
+    "shortcuts": [
+        [
+            "bin\\gedit.exe",
+            "gedit"
+        ]
+    ],
+    "checkver": {
+        "url": "https://download.gnome.org/binaries/win64/gedit/",
+        "regex": "gedit-x86_64-([\\d.]+)\\.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.gnome.org/binaries/win64/gedit/gedit-x86_64-3.20.1.msi"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
close https://github.com/lukesampson/scoop-extras/issues/3384

> Warning: The latest official Windows binary is the version 3.20, and the latest official Mac binary is the version 3.2, however, the latest source releases should work. If you can help with building binaries of newer releases for either platform, please get in touch with us.

Last update of 64bit binary is 3 years ago and 32bit binary is even older so I only add 64bit. There are lots of cli tools in bin directory but they are not related to gedit's usage so I didn't add them.