### PR TITLE
chk: 'lang.txt' persist tweaks

### DIFF
--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -3,7 +3,7 @@
     "description": "GUI hash tool",
     "homepage": "https://compressme.net",
     "license": "Freeware",
-    "notes": "Language packs for Czech, English, French, German, Italian, and Simplified Chinese are available at http://compressme.net",
+    "notes": "Language packs for Czech, French, German, Italian, and Simplified Chinese are available at http://compressme.net",
     "architecture": {
         "64bit": {
             "url": "http://compressme.net/chk321.zip",

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -15,7 +15,7 @@
         }
     },
     "pre_install": [
-        "Set-Content \"$dir\\chk.ps1\" -Value \"Start-Process `\"$dir\\chk.exe`\" -WorkingDirectory `\"$dir`\" \" -Encoding Ascii",
+        "Set-Content \"$dir\\chk.ps1\" -Value 'Start-Process \"$PSScriptRoot\\chk.exe\" -WorkingDirectory $PSScriptRoot' -Encoding Ascii",
         "if (!(Test-Path \"$persist_dir\\chk.cfg\")) { New-Item \"$dir\\chk.cfg\" | Out-Null }",
         "if (!(Test-Path \"$persist_dir\\lang.txt\")) { New-Item \"$dir\\lang.txt\" | Out-Null }"
     ],

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -20,7 +20,7 @@
         "if (!(Test-Path \"$persist_dir\\lang.txt\")) { New-Item \"$dir\\lang.txt\" | Out-Null }"
     ],
     "uninstaller": {
-        "script": "if ((Get-Item \"$dir\\lang.txt\").LinkType -ne 'HardLink') {Move-Item \"$dir\\lang.txt\" \"$persist_dir\\lang.txt\" -Force | Out-Null}"
+        "script": "if ((Get-Item \"$dir\\lang.txt\").LinkType -ne 'HardLink') { Move-Item \"$dir\\lang.txt\" \"$persist_dir\" -Force | Out-Null }"
     },
     "bin": "chk.ps1",
     "shortcuts": [

--- a/bucket/chk.json
+++ b/bucket/chk.json
@@ -3,6 +3,7 @@
     "description": "GUI hash tool",
     "homepage": "https://compressme.net",
     "license": "Freeware",
+    "notes": "Language packs for Czech, English, French, German, Italian, and Simplified Chinese are available at http://compressme.net",
     "architecture": {
         "64bit": {
             "url": "http://compressme.net/chk321.zip",
@@ -14,10 +15,14 @@
         }
     },
     "pre_install": [
+        "Set-Content \"$dir\\chk.ps1\" -Value \"Start-Process `\"$dir\\chk.exe`\" -WorkingDirectory `\"$dir`\" \" -Encoding Ascii",
         "if (!(Test-Path \"$persist_dir\\chk.cfg\")) { New-Item \"$dir\\chk.cfg\" | Out-Null }",
         "if (!(Test-Path \"$persist_dir\\lang.txt\")) { New-Item \"$dir\\lang.txt\" | Out-Null }"
     ],
-    "bin": "chk.exe",
+    "uninstaller": {
+        "script": "if ((Get-Item \"$dir\\lang.txt\").LinkType -ne 'HardLink') {Move-Item \"$dir\\lang.txt\" \"$persist_dir\\lang.txt\" -Force | Out-Null}"
+    },
+    "bin": "chk.ps1",
     "shortcuts": [
         [
             "chk.exe",


### PR DESCRIPTION
* **CHK** loads the language pack file `lang.txt` from *current working directory*. Therefore language packs will not work when user starts the program **by shim-exes**. (reported by @niheaven at https://github.com/lukesampson/scoop-extras/pull/3378#issuecomment-568241863)  This fixes the issue.

* If users want to use the language pack feature, they need to download the language pack, and put the lang.txt of their preferred language (e.g. Simplified Chinese) in the install directory.
(See "Download" -> "Language Packs" on https://compressme.net/). This will **overwrite `$dir\lang.txt` (hardlink to `$persist_dir\lang.txt`) created by Scoop**, and *persist* will not be working after that.  The `uninstaller` script fixes the issue.

* Add description about language packs in `notes`.