### PR TITLE
openmpt: Update to version 1.28.09.00 (manually)

### DIFF
--- a/bucket/openmpt.json
+++ b/bucket/openmpt.json
@@ -1,16 +1,16 @@
 {
     "homepage": "https://openmpt.org/",
-    "description": "Powerful audio application that makes writing music fun, easy and efficient.",
+    "description": "Music tracker",
     "license": "BSD-3-Clause",
-    "version": "1.28.08.00",
+    "version": "1.28.09.00",
     "architecture": {
         "32bit": {
-            "url": "https://download.openmpt.org/OpenMPT-1.28.08.00-Setup.exe",
-            "hash": "sha1:1325c8ece48ea04da782612e7666924c048fbd6c"
+            "url": "https://download.openmpt.org/archive/openmpt/1.28/OpenMPT-1.28.09.00-Setup.exe",
+            "hash": "sha1:00313d3799e223c7f4f2027c38bdf8c7ebf08f0d"
         },
         "64bit": {
-            "url": "https://download.openmpt.org/OpenMPT-1.28.08.00-Setup-x64.exe",
-            "hash": "sha1:070b89e44c57b3a9dbd8dc455556cbfb991f0bff"
+            "url": "https://download.openmpt.org/archive/openmpt/1.28/OpenMPT-1.28.09.00-Setup-x64.exe",
+            "hash": "sha1:4e70a1006285114645574049066c74ec4c4fb4b1"
         }
     },
     "innosetup": true,
@@ -31,10 +31,10 @@
     "autoupdate": {
         "architecture": {
             "32bit": {
-                "url": "https://download.openmpt.org/OpenMPT-$version-Setup.exe"
+                "url": "https://download.openmpt.org/archive/openmpt/$majorVersion.$minorVersion/OpenMPT-$version-Setup.exe"
             },
             "64bit": {
-                "url": "https://download.openmpt.org/OpenMPT-$version-Setup-x64.exe"
+                "url": "https://download.openmpt.org/archive/openmpt/$majorVersion.$minorVersion/OpenMPT-$version-Setup-x64.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* Update download URL
* Modify `description` to make it briefer.