### PR TITLE
typora: Fix bin

### DIFF
--- a/bucket/typora.json
+++ b/bucket/typora.json
@@ -18,7 +18,7 @@
         }
     },
     "innosetup": true,
-    "bin": "typora.exe",
+    "bin": "Typora.exe",
     "shortcuts": [
         [
             "Typora.exe",

--- a/bucket/typora.json
+++ b/bucket/typora.json
@@ -18,7 +18,7 @@
         }
     },
     "innosetup": true,
-    "bin": "bin\\typora.exe",
+    "bin": "typora.exe",
     "shortcuts": [
         [
             "Typora.exe",


### PR DESCRIPTION
Fixes #3409

Apparently typora has removed the `bin/` folder as of 0.9.82 (though [the changelog](https://typora.io/windows/dev_release.html) doesn't mention it).

this PR changes the `bin` path to `Typora.exe`, the only executable that is left in the installation.