### PR TITLE
foto-mosaik-edda: Add version 7.7.18156.1

### DIFF
--- a/bucket/foto-mosaik-edda.json
+++ b/bucket/foto-mosaik-edda.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://fmedda.com/en/licensing"
     },
-    "url": "https://fmedda.com/ext/download.php?type=portable#/dl.zip",
+    "url": "https://fmedda.com/ext/download/Foto-Mosaik-Edda-Portable.zip",
     "hash": "9b1561c65aa38560226bd5b0f96c2a6609af382131dd7c3e3b9edfc3131ee7e9",
     "extract_dir": "Foto-Mosaik-Edda-Portable",
     "pre_install": [

--- a/bucket/foto-mosaik-edda.json
+++ b/bucket/foto-mosaik-edda.json
@@ -12,7 +12,10 @@
     "pre_install": [
         "[xml]$xml = Get-Content \"$dir\\Rapid-Mosaic.exe.config\"",
         "$xml.SelectSingleNode(\"/configuration/appSettings/add[@key='LocalizationLanguageId']\").value = 'en'",
-        "$xml.Save(\"$dir\\Rapid-Mosaic.exe.config\")"
+        "$xml.Save(\"$dir\\Rapid-Mosaic.exe.config\")",
+        "[xml]$xml = Get-Content \"$dir\\Data\\settings.config\"",
+        "$xml.SelectSingleNode('/Settings/ProgramConfig/ProgramConfig/CheckForUpdates').InnerText = 'false'",
+        "$xml.Save(\"$dir\\Data\\settings.config\")"
     ],
     "bin": [
         "Foto-Mosaik-Edda.exe",

--- a/bucket/foto-mosaik-edda.json
+++ b/bucket/foto-mosaik-edda.json
@@ -11,8 +11,7 @@
     "extract_dir": "Foto-Mosaik-Edda-Portable",
     "pre_install": [
         "[xml]$xml = Get-Content \"$dir\\Rapid-Mosaic.exe.config\"",
-        "$xpath = \"/configuration/appSettings/add[@key='LocalizationLanguageId']\"",
-        "$xml.SelectNodes($xpath)[0].value = 'en'",
+        "$xml.SelectNodes(\"/configuration/appSettings/add[@key='LocalizationLanguageId']\")[0].value = 'en'",
         "$xml.Save(\"$dir\\Rapid-Mosaic.exe.config\")"
     ],
     "bin": [
@@ -35,6 +34,6 @@
         "regex": "Version:</td>\\s+<td>([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://fmedda.com/ext/download.php?type=portable#/dl.zip"
+        "url": "https://fmedda.com/ext/download/Foto-Mosaik-Edda-Portable.zip"
     }
 }

--- a/bucket/foto-mosaik-edda.json
+++ b/bucket/foto-mosaik-edda.json
@@ -1,0 +1,40 @@
+{
+    "version": "7.7.18156.1",
+    "description": "Photo mosaic picture maker",
+    "homepage": "https://fmedda.com/en/home",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://fmedda.com/en/licensing"
+    },
+    "url": "https://fmedda.com/ext/download.php?type=portable#/dl.zip",
+    "hash": "9b1561c65aa38560226bd5b0f96c2a6609af382131dd7c3e3b9edfc3131ee7e9",
+    "extract_dir": "Foto-Mosaik-Edda-Portable",
+    "pre_install": [
+        "[xml]$xml = Get-Content \"$dir\\Rapid-Mosaic.exe.config\"",
+        "$xpath = \"/configuration/appSettings/add[@key='LocalizationLanguageId']\"",
+        "$xml.SelectNodes($xpath)[0].value = 'en'",
+        "$xml.Save(\"$dir\\Rapid-Mosaic.exe.config\")"
+    ],
+    "bin": [
+        "Foto-Mosaik-Edda.exe",
+        "Rapid-Mosaic.exe"
+    ],
+    "shortcuts": [
+        [
+            "Foto-Mosaik-Edda.exe",
+            "Foto-Mosaik-Edda"
+        ],
+        [
+            "Rapid-Mosaic.exe",
+            "Rapid-Mosaic"
+        ]
+    ],
+    "persist": "Data",
+    "checkver": {
+        "url": "https://fmedda.com/en/download",
+        "regex": "Version:</td>\\s+<td>([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://fmedda.com/ext/download.php?type=portable#/dl.zip"
+    }
+}

--- a/bucket/foto-mosaik-edda.json
+++ b/bucket/foto-mosaik-edda.json
@@ -11,7 +11,7 @@
     "extract_dir": "Foto-Mosaik-Edda-Portable",
     "pre_install": [
         "[xml]$xml = Get-Content \"$dir\\Rapid-Mosaic.exe.config\"",
-        "$xml.SelectNodes(\"/configuration/appSettings/add[@key='LocalizationLanguageId']\")[0].value = 'en'",
+        "$xml.SelectSingleNode(\"/configuration/appSettings/add[@key='LocalizationLanguageId']\").value = 'en'",
         "$xml.Save(\"$dir\\Rapid-Mosaic.exe.config\")"
     ],
     "bin": [


### PR DESCRIPTION
**Foto-Mosaik-Edda** ([homepage](https://fmedda.com/en/home)) is a software which allows you to create photo mosaic pictures (such as the picture below)

Notes:
* **license**: The pro version of Foto-Mosaik-Edda is proprietary, but standard version is **Free**.

* **Shortcut** is named as `Foto-Mosaik-Edda` (instead of `Foto Mosaik Edda`) according to the Window name.

* The **pre_install** script:
    * Modifies the default language of `Rapid-Mosaic` from German to English (when  users start the program for the first time). 
        * If users chooses their own language (e.g. Japanese) in Rapid-Mosaic's configuration, their settings will be preserved in `Data\Rapid-Mosaic.config`. Therefore the *pre_install* script will not modify the language back to English when users update the program through Scoop.

    * Disables "check for update" (update is maintained by Scoop)




![image](https://fmedda.com/pic/mosaic_classic.png)