### PR TITLE
video-thumbnails-maker: Add version 14.0.0.0

### DIFF
--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -6,8 +6,8 @@
     "url": "http://www.suu-design.com/Files/VTM/1414881427/VideoThumbnailsMaker_Setup.zip",
     "hash": "cee9e8b4016b0f009a8e9b4452b61823f982d275315c96dbf9cb1a4a0e1b2303",
     "pre_install": [
-        "Expand-7zipArchive -Path \"$dir\\VideoThumbnailsMaker_Setup.exe\" -DestinationPath \"$dir\"",
-        "Remove-Item \"$dir\\VideoThumbnailsMaker_Setup.exe\", \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse"
+        "Expand-7zipArchive \"$dir\\VideoThumbnailsMaker_Setup.exe\" \"$dir\" -Removal",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse"
     ],
     "bin": "VideoThumbnailsMaker.exe",
     "shortcuts": [

--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -1,0 +1,26 @@
+{
+    "version": "14.0.0.0",
+    "description": "Create video thumbnails.",
+    "homepage": "http://www.suu-design.com/projects_vtm.html",
+    "license": "Proprietary",
+    "url": "http://www.suu-design.com/Files/VTM/7/VideoThumbnailsMaker_Setup.zip",
+    "hash": "b3569ef0d4b9a53af2e6bc49fc4490aecf43c8c768035e994d9e9e0d5a688567",
+    "pre_install": [
+        "Expand-7zipArchive -Path \"$dir\\VideoThumbnailsMaker_Setup.exe\" -DestinationPath \"$dir\"",
+        "Remove-Item \"$dir\\VideoThumbnailsMaker_Setup.exe\", \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse"
+    ],
+    "bin": "VideoThumbnailsMaker.exe",
+    "shortcuts": [
+        [
+            "VideoThumbnailsMaker.exe",
+            "Video Thumbnails Maker"
+        ]
+    ],
+    "checkver": {
+        "url": "http://www.suu-design.com/downloads.html",
+        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+(?<random>\\d+)/VideoThumbnailsMaker_Setup.zip"
+    },
+    "autoupdate": {
+        "url": "http://www.suu-design.com/Files/VTM/$matchRandom/VideoThumbnailsMaker_Setup.zip"
+    }
+}

--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "http://www.suu-design.com/downloads.html",
-        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+(?<random>\\d+)/VideoThumbnailsMaker_Setup.zip"
+        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+(?<random>\\d+)/VideoThumbnailsMaker_Setup\\.zip"
     },
     "autoupdate": {
         "url": "http://www.suu-design.com/Files/VTM/$matchRandom/VideoThumbnailsMaker_Setup.zip"

--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -3,8 +3,8 @@
     "description": "Create video thumbnails.",
     "homepage": "http://www.suu-design.com/projects_vtm.html",
     "license": "Proprietary",
-    "url": "http://www.suu-design.com/Files/VTM/7/VideoThumbnailsMaker_Setup.zip",
-    "hash": "b3569ef0d4b9a53af2e6bc49fc4490aecf43c8c768035e994d9e9e0d5a688567",
+    "url": "http://www.suu-design.com/Files/VTM/1414881427/VideoThumbnailsMaker_Setup.zip",
+    "hash": "cee9e8b4016b0f009a8e9b4452b61823f982d275315c96dbf9cb1a4a0e1b2303",
     "pre_install": [
         "Expand-7zipArchive -Path \"$dir\\VideoThumbnailsMaker_Setup.exe\" -DestinationPath \"$dir\"",
         "Remove-Item \"$dir\\VideoThumbnailsMaker_Setup.exe\", \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse"
@@ -18,7 +18,7 @@
     ],
     "checkver": {
         "url": "http://www.suu-design.com/downloads.html",
-        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+(?<random>\\d+)/VideoThumbnailsMaker_Setup\\.zip"
+        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+/(?<random>\\d+)/VideoThumbnailsMaker_Setup\\.zip"
     },
     "autoupdate": {
         "url": "http://www.suu-design.com/Files/VTM/$matchRandom/VideoThumbnailsMaker_Setup.zip"

--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -6,7 +6,7 @@
     "url": "http://www.suu-design.com/Files/VTM/1414881427/VideoThumbnailsMaker_Setup.zip",
     "hash": "cee9e8b4016b0f009a8e9b4452b61823f982d275315c96dbf9cb1a4a0e1b2303",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\VideoThumbnailsMaker_Setup.exe\" \"$dir\" -Removal",
+        "Expand-7zipArchive \"$dir\\VideoThumbnailsMaker_Setup.exe\" -Removal",
         "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Force -Recurse"
     ],
     "bin": "VideoThumbnailsMaker.exe",

--- a/bucket/video-thumbnails-maker.json
+++ b/bucket/video-thumbnails-maker.json
@@ -18,9 +18,9 @@
     ],
     "checkver": {
         "url": "http://www.suu-design.com/downloads.html",
-        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+/(?<random>\\d+)/VideoThumbnailsMaker_Setup\\.zip"
+        "regex": "(?sm)Video Thumbnails Maker</strong>.+v([\\d.]+).+/(?<fileid>\\d+)/VideoThumbnailsMaker_Setup\\.zip"
     },
     "autoupdate": {
-        "url": "http://www.suu-design.com/Files/VTM/$matchRandom/VideoThumbnailsMaker_Setup.zip"
+        "url": "http://www.suu-design.com/Files/VTM/$matchFileid/VideoThumbnailsMaker_Setup.zip"
     }
 }


### PR DESCRIPTION
* **Video Thumbnails Maker** ([homepage](http://www.suu-design.com/projects_vtm.html)) is not a free software. However most of its features are available *without a premium license*.

* The number in the download URL (Files/VTM/**1414881427**/VideoThumbnailsMaker_Setup.zip) ~is constant (remains the same) in different sessions~ changes every time when the file is updated (for example, updating from version `14.0.0.0` -> `14.0.0.1`). Also, it is not related to actual version number, see [web archive](https://web.archive.org/web/20160310043804/http://www.suu-design.com/downloads.html) for example.

* **persist** is not needed because Video Thumbnails Maker stores its user settings under registry `HKCU:\Software\SUU Design\Video Thumbnails Maker`.