### PR TITLE
authy: Add nightly

### DIFF
--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://authy.com",
-    "description": "The .",
+    "description": "The 2FA client for all devices.",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.twilio.com/legal/tos"

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://authy.com",
+    "description": "The .",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.twilio.com/legal/tos"
+    },
+    "version": "nightly",
+    "architecture": {
+        "32bit": {
+            "url": "https://electron.authy.com/download?channel=stable&arch=x32&platform=win32&version=latest&product=authy#dl.7z"
+        },
+        "64bit": {
+            "url": "https://electron.authy.com/download?channel=stable&arch=x64&platform=win32&version=latest&product=authy#dl.7z"
+        }
+    },
+    "pre_install": [
+        "# Manual extraction",
+        "7z x -y -r \"$cachedir\\$app#nightly-*\\ \"$dir\\\" *.nupkg > $null",
+        "7z x -y -r \"$dir\\authy-electron-*-full.nupkg\" > $null",
+        "Remove-Item \"$dir\\download\""
+    ],
+    "bin": ".\\lib\\net45\\Authy Desktop.exe",
+    "shortcuts": [
+        [
+            "\".\\lib\\net45\\Authy Desktop.exe\"",
+            "Authy Desktop"
+        ]
+    ]
+}


### PR DESCRIPTION
Authy is a multi-device 2FA (aka Two Factor Authentication) client, being the most popular 2FA app in mobile devices.

# Considerations about this PR

Like some custom installer-based apps (like Spotify), installing Authy via Scoop is presenting us some challenges (apart from very poor developer-sided documentation):

## Nightly-versioned manifest
I am aware that Authy versions are numbered (at the moment of writing this, we're at version `1.7.2`). However, from a technical standpoint, it doesn't seem feasible to do so:

- Authy comes with an auto-updater, so it's possible that the application breaks free from the scoop directory. (Still need to investigate this)
- Older versions are not made (publicly) available for us to download. I'm unable to look for an older version and older endpoints seem to be no longer existing.

## Double extraction
To get what we want out of the installer, we need to perform two extractions:

- The first one, to get the NuGet package out (e.g. `authy-electron-1.7.2-full.nupkg`
- And then extract that package.

At the moment it's impossible to perform this double extraction without extremely hacky methods (for example, the manifest downloading an installer script and then running that script in `post_install` - and even that doesn't allow us to set up shortcuts without their own very hacky methods, etc.) - so clearly scoop itself might need to be adjusted to this case.

### Possible solutions
At the moment the solution that involves the least work would be either:
- Copying the download file into the directory before running `pre_install`, allowing us to run 7z directly over it without copying it manually from cache;
- - Alternatively, if there are manifests that rely on an empty directory for `pre_install`, add a second step between making the download available to use and before installation (shimming, etc.)

**OR**

- Allowing us to specify more than one extraction step

## Persisting

The application's persisting data is stored on `AppData/Roaming/Authy Desktop` (apparently an hardcoded path).

# Checklist

- [x] Download the files
- [x] Extract the contents (manually) and avoiding running the installer.
- [ ] Extract the contents (automatically)
- [ ] Monitor and make sure autoupdate doesn't ruin the party.
- [ ] *Anything else that might be missing?*