### PR TITLE
palemoon: Update to version 28.8.0 (manually)

### DIFF
--- a/bucket/palemoon-portable.json
+++ b/bucket/palemoon-portable.json
@@ -33,7 +33,7 @@
     "post_install": "(Get-Content \"$dir\\Palemoon-Portable.ini\") -replace 'ShowSplash=true','ShowSplash=false' | Set-Content \"$dir\\Palemoon-Portable.ini\"",
     "checkver": {
         "url": "https://www.palemoon.org/download.shtml",
-        "regex": "Hashes for release ([\\d\\.]+)"
+        "regex": "Hashes for release ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/palemoon-portable.json
+++ b/bucket/palemoon-portable.json
@@ -33,7 +33,7 @@
     "post_install": "(Get-Content \"$dir\\Palemoon-Portable.ini\") -replace 'ShowSplash=true','ShowSplash=false' | Set-Content \"$dir\\Palemoon-Portable.ini\"",
     "checkver": {
         "url": "https://www.palemoon.org/download.shtml",
-        "re": "Hashes for release ([\\d\\.]+)"
+        "regex": "Hashes for release ([\\d\\.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/palemoon-portable.json
+++ b/bucket/palemoon-portable.json
@@ -5,11 +5,11 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://rm-eu.palemoon.org/release/Palemoon-Portable-28.8.0.win64.exe#/palemoon.7z",
+            "url": "https://rm-eu.palemoon.org/release/Palemoon-Portable-28.8.0.win64.exe#/palemoon.7z",
             "hash": "0edec99672f53d65e2be55201eea872bf4868ff69b193604a3379e4b2808c1f8"
         },
         "32bit": {
-            "url": "http://rm-eu.palemoon.org/release/Palemoon-Portable-28.8.0.win32.exe#/palemoon.7z",
+            "url": "https://rm-eu.palemoon.org/release/Palemoon-Portable-28.8.0.win32.exe#/palemoon.7z",
             "hash": "ab5f44fa43706c91de5e5592ba2cf0cd5f6cc7cf193fefe8794e40c550b5397c"
         }
     },
@@ -38,10 +38,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://rm-eu.palemoon.org/release/Palemoon-Portable-$version.win64.exe#/palemoon.7z"
+                "url": "https://rm-eu.palemoon.org/release/Palemoon-Portable-$version.win64.exe#/palemoon.7z"
             },
             "32bit": {
-                "url": "http://rm-eu.palemoon.org/release/Palemoon-Portable-$version.win32.exe#/palemoon.7z"
+                "url": "https://rm-eu.palemoon.org/release/Palemoon-Portable-$version.win32.exe#/palemoon.7z"
             }
         },
         "hash": {

--- a/bucket/palemoon-portable.json
+++ b/bucket/palemoon-portable.json
@@ -1,6 +1,6 @@
 {
-    "description": "Pale Moon is an Open Source, Mozilla-derived web browser available for Microsoft Windows and Linux, focusing on efficiency and ease of use",
-    "homepage": "https://www.palemoon.org/",
+    "description": "Mozilla-derived web browser focusing on efficiency and customization",
+    "homepage": "https://www.palemoon.org",
     "version": "28.8.0",
     "license": "MPL-2.0",
     "architecture": {
@@ -46,7 +46,7 @@
         },
         "hash": {
             "url": "https://www.palemoon.org/download.shtml",
-            "find": "$basename\\s+([a-fA-F\\d]{64})"
+            "regex": "$basename\\s+$sha256"
         }
     }
 }

--- a/bucket/palemoon.json
+++ b/bucket/palemoon.json
@@ -5,7 +5,7 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://rm-eu.palemoon.org/release/palemoon-28.8.0.win64.7z",
+            "url": "https://rm-eu.palemoon.org/release/palemoon-28.8.0.win64.7z",
             "hash": "c0b2983a03731c4cfd5509411e49d9344b952e9efaf6188d26bd49d94ec25319"
         },
         "32bit": {

--- a/bucket/palemoon.json
+++ b/bucket/palemoon.json
@@ -9,7 +9,7 @@
             "hash": "c0b2983a03731c4cfd5509411e49d9344b952e9efaf6188d26bd49d94ec25319"
         },
         "32bit": {
-            "url": "http://rm-eu.palemoon.org/release/palemoon-28.8.0.win32.7z",
+            "url": "https://rm-eu.palemoon.org/release/palemoon-28.8.0.win32.7z",
             "hash": "9903921f68293325b4c11838b8b01e865ab44c34904d4b918bf87347de693be5"
         }
     },
@@ -28,10 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win64.7z"
+                "url": "https://rm-eu.palemoon.org/release/palemoon-$version.win64.7z"
             },
             "32bit": {
-                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win32.7z"
+                "url": "https://rm-eu.palemoon.org/release/palemoon-$version.win32.7z"
             }
         },
         "hash": {

--- a/bucket/palemoon.json
+++ b/bucket/palemoon.json
@@ -36,7 +36,7 @@
         },
         "hash": {
             "url": "https://www.palemoon.org/download.shtml",
-            "find": "$basename\\s+$sha256"
+            "regex": "$basename\\s+$sha256"
         }
     }
 }

--- a/bucket/palemoon.json
+++ b/bucket/palemoon.json
@@ -1,16 +1,16 @@
 {
-    "description": "Pale Moon is an Open Source, Mozilla-derived web browser available for Microsoft Windows and Linux, focusing on efficiency and ease of use",
-    "homepage": "https://www.palemoon.org/",
-    "version": "28.7.2",
+    "description": "Mozilla-derived web browser focusing on efficiency and customization",
+    "homepage": "https://www.palemoon.org",
+    "version": "28.8.0",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://rm-eu.palemoon.org/release/palemoon-28.7.2.win64.zip",
-            "hash": "86474f9f762f552e4012761f880446a3af31a6adf652f96a46cfb68ae0a465a5"
+            "url": "http://rm-eu.palemoon.org/release/palemoon-28.8.0.win64.7z",
+            "hash": "c0b2983a03731c4cfd5509411e49d9344b952e9efaf6188d26bd49d94ec25319"
         },
         "32bit": {
-            "url": "http://rm-eu.palemoon.org/release/palemoon-28.7.2.win32.zip",
-            "hash": "fc7b108c750606cd1d303efa07455d112bc1bcf0bcca91fc582ac3d50c93af1e"
+            "url": "http://rm-eu.palemoon.org/release/palemoon-28.8.0.win32.7z",
+            "hash": "9903921f68293325b4c11838b8b01e865ab44c34904d4b918bf87347de693be5"
         }
     },
     "bin": "palemoon.exe",
@@ -23,20 +23,20 @@
     "extract_dir": "palemoon",
     "checkver": {
         "url": "https://www.palemoon.org/download.shtml",
-        "re": "Hashes for release ([\\d\\.]+)"
+        "regex": "Hashes for release ([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win64.zip"
+                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win64.7z"
             },
             "32bit": {
-                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win32.zip"
+                "url": "http://rm-eu.palemoon.org/release/palemoon-$version.win32.7z"
             }
         },
         "hash": {
             "url": "https://www.palemoon.org/download.shtml",
-            "find": "$basename\\s+([a-fA-F\\d]{64})"
+            "find": "$basename\\s+$sha256"
         }
     }
 }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* **Pale Moon** now uses **7z** instead of zip. This fixes the problem.

* Re-formatting `palemoon` and `palemoon-portable` packages.