### PR TITLE
authy: Add version 1.7.2

### DIFF
--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -28,7 +28,7 @@
     ],
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",
-        "regex": "authy-electron-([\\d\\.]+)-full\\.nupkg",
+        "regex": "authy-electron-([\\d.]+)-full\\.nupkg",
         "reverse": true
     },
     "autoupdate": {

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -24,7 +24,6 @@
         "}",
         "New-Item -ItemType Junction -Path $appdata -Target $persist_dir | Out-Null"
     ],
-    "persist": "void",
     "bin": [
         [
             "Authy Desktop.exe",

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -15,7 +15,7 @@
     },
     "extract_dir": "lib\\net45",
     "pre_install": [
-        "$appdata = \"$env:APPDATA\\Authy Desktop\"",
+        "$appdata = \"$env:APPDATA\\Authy\u0020Desktop\"",
         "if (!(Test-Path $persist_dir)) {",
         "   New-Item -ItemType Directory -Path $persist_dir | Out-Null",
         "}",
@@ -37,7 +37,7 @@
         ]
     ],
     "uninstaller": {
-        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy Desktop\""
+        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy\u0020Desktop\""
     },
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -1,0 +1,50 @@
+{
+    "version": "1.7.2",
+    "description": "Free desktop app for two factor authentication.",
+    "homepage": "https://authy.com/",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.7.2/win32/x64/authy-electron-1.7.2-full.nupkg",
+            "hash": "sha1:53646438bd9c05efa4790b655ab1d056302a6a7f"
+        },
+        "32bit": {
+            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.7.2/win32/x32/authy-electron-1.7.2-full.nupkg",
+            "hash": "sha1:adb40cd6a325585b3b2fc32c4ccf29d8d1bb08da"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "bin": [
+        [
+            "Authy Desktop.exe",
+            "authy"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Authy Desktop.exe",
+            "Authy Desktop"
+        ]
+    ],
+    "checkver": {
+        "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",
+        "regex": "authy-electron-([\\d\\.]+)-full\\.nupkg",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x64/authy-electron-$version-full.nupkg",
+                "hash": {
+                    "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES"
+                }
+            },
+            "32bit": {
+                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x32/authy-electron-$version-full.nupkg",
+                "hash": {
+                    "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x32/RELEASES"
+                }
+            }
+        }
+    }
+}

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -15,7 +15,7 @@
     },
     "extract_dir": "lib\\net45",
     "pre_install": [
-        "$appdata = \"$env:APPDATA\\Authy\u0020Desktop\"",
+        "$appdata = \"$env:APPDATA\\Authy Desktop\"",
         "if (!(Test-Path $persist_dir)) {",
         "   New-Item -ItemType Directory -Path $persist_dir | Out-Null",
         "}",
@@ -38,7 +38,7 @@
         ]
     ],
     "uninstaller": {
-        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy\u0020Desktop\""
+        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy Desktop\""
     },
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -14,6 +14,17 @@
         }
     },
     "extract_dir": "lib\\net45",
+    "pre_install": [
+        "$appdata = \"$env:APPDATA\\Authy\u0020Desktop\"",
+        "if (!(Test-Path $persist_dir)) {",
+        "   New-Item -ItemType Directory -Path $persist_dir | Out-Null",
+        "}",
+        "if (Test-Path $appdata) {",
+        "   Remove-Item -Force -Recurse $appdata | Out-Null",
+        "}",
+        "New-Item -ItemType Junction -Path $appdata -Target $persist_dir | Out-Null"
+    ],
+    "persist": "void",
     "bin": [
         [
             "Authy Desktop.exe",
@@ -26,6 +37,9 @@
             "Authy Desktop"
         ]
     ],
+    "uninstaller": {
+        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy\u0020Desktop\""
+    },
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",
         "regex": "authy-electron-([\\d\\.]+)-full\\.nupkg",

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -1,6 +1,6 @@
 {
     "version": "1.7.2",
-    "description": "Free desktop app for two factor authentication.",
+    "description": "Two factor authentication client",
     "homepage": "https://authy.com/",
     "license": "Freeware",
     "architecture": {

--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -14,16 +14,6 @@
         }
     },
     "extract_dir": "lib\\net45",
-    "pre_install": [
-        "$appdata = \"$env:APPDATA\\Authy\u0020Desktop\"",
-        "if (!(Test-Path $persist_dir)) {",
-        "   New-Item -ItemType Directory -Path $persist_dir | Out-Null",
-        "}",
-        "if (Test-Path $appdata) {",
-        "   Remove-Item -Force -Recurse $appdata | Out-Null",
-        "}",
-        "New-Item -ItemType Junction -Path $appdata -Target $persist_dir | Out-Null"
-    ],
     "bin": [
         [
             "Authy Desktop.exe",
@@ -36,9 +26,6 @@
             "Authy Desktop"
         ]
     ],
-    "uninstaller": {
-        "script": "Remove-Item -Confirm:$false -Force -Recurse -Path \"$env:APPDATA\\Authy\u0020Desktop\""
-    },
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",
         "regex": "authy-electron-([\\d\\.]+)-full\\.nupkg",


### PR DESCRIPTION
From https://github.com/Ash258/Scoop-Ash258/blob/master/TODO/AAAuthy.json

**Checklist:**
 - [x] Link Authy's AppData to `persist` so that `scoop uninstall -p authy` clears all data.
- [x] Make sure we're in control of the update process (this is, Authy autoupdate will not interfere).

~~Should we import (as in preserve) Authy's existing `AppData`, or just perform a clean installation?~~