### PR TITLE
age: Add version 1.0.0-beta2

### DIFF
--- a/bucket/age.json
+++ b/bucket/age.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "https://age-encryption.org/",
+    "version": "1.0.0-beta2",
+    "description": "A simple, modern and secure encryption tool with small explicit keys, no config options, and UNIX-style composability.",
+    "license": {
+        "identifier": "BSD 3-Clause",
+        "url": "https://github.com/FiloSottile/age/blob/master/LICENSE"
+    },
+    "url": "https://github.com/FiloSottile/age/releases/download/v1.0.0-beta2/age-v1.0.0-beta2-windows-amd64.zip",
+    "extract_dir": "age",
+    "bin": [
+        "age.exe",
+        "age-keygen.exe"
+    ]
+}

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -2,16 +2,13 @@
     "homepage": "https://age-encryption.org/",
     "version": "1.0.0-beta2",
     "description": "A simple, modern and secure encryption tool with small explicit keys, no config options, and UNIX-style composability.",
-    "license": {
-        "identifier": "BSD 3-Clause",
-        "url": "https://github.com/FiloSottile/age/blob/master/LICENSE"
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/FiloSottile/age/releases/download/v1.0.0-beta2/age-v1.0.0-beta2-windows-amd64.zip",
+            "hash": "76c616ee56c2a2e182b50504d7a3b8ca390ee8bc2083a1dfd3cb7da50dcf70cc"
+        }
     },
-     "architecture": {
-         "64bit": {
-             "url": "https://github.com/FiloSottile/age/releases/download/v1.0.0-beta2/age-v1.0.0-beta2-windows-amd64.zip",
-             "hash": "76c616ee56c2a2e182b50504d7a3b8ca390ee8bc2083a1dfd3cb7da50dcf70cc"
-         }
-     },
     "extract_dir": "age",
     "bin": [
         "age.exe",

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -19,6 +19,10 @@
         "regex": "tag/v([\\\\w.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/FiloSottile/age/releases/download/v$version/age-v$version-windows-amd64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/FiloSottile/age/releases/download/v$version/age-v$version-windows-amd64.zip"
+            }
+        }
     }
 }

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -16,7 +16,7 @@
     ],
     "checkver": {
         "github": "https://github.com/FiloSottile/age",
-        "regex": "tag/v([\\\\w.]+)"
+        "regex": "tag/v([\\w.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -16,7 +16,7 @@
     ],
     "checkver": {
         "github": "https://github.com/FiloSottile/age",
-        "regex": "tag/v([\\w.]+)"
+        "regex": "tag/v([\\w-.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -6,7 +6,12 @@
         "identifier": "BSD 3-Clause",
         "url": "https://github.com/FiloSottile/age/blob/master/LICENSE"
     },
-    "url": "https://github.com/FiloSottile/age/releases/download/v1.0.0-beta2/age-v1.0.0-beta2-windows-amd64.zip",
+     "architecture": {
+         "64bit": {
+             "url": "https://github.com/FiloSottile/age/releases/download/v1.0.0-beta2/age-v1.0.0-beta2-windows-amd64.zip",
+             "hash": "76c616ee56c2a2e182b50504d7a3b8ca390ee8bc2083a1dfd3cb7da50dcf70cc"
+         }
+     },
     "extract_dir": "age",
     "bin": [
         "age.exe",

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -15,7 +15,8 @@
         "age-keygen.exe"
     ],
     "checkver": {
-        "github": "https://github.com/FiloSottile/age"
+        "github": "https://github.com/FiloSottile/age",
+        "regex": "tag/v([\\\\w.]+)"
     },
     "autoupdate": {
         "url": "https://github.com/FiloSottile/age/releases/download/v$version/age-v$version-windows-amd64.zip"

--- a/bucket/age.json
+++ b/bucket/age.json
@@ -11,5 +11,11 @@
     "bin": [
         "age.exe",
         "age-keygen.exe"
-    ]
+    ],
+    "checkver": {
+        "github": "https://github.com/FiloSottile/age"
+    },
+    "autoupdate": {
+        "url": "https://github.com/FiloSottile/age/releases/download/v$version/age-v$version-windows-amd64.zip"
+    }
 }


### PR DESCRIPTION
age ([homepage](https://age-encryption.org)) is a simple, modern and secure encryption tool with small explicit keys, no config options, and UNIX-style composability.

- Only a 64-bit version exists