### PR TITLE
tableplus: Add version 3.1.0.112

### DIFF
--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -1,17 +1,27 @@
 {
-    "version": "110",
+    "##": "TODO: There will be an option portable mode in the near future. See https://github.com/TablePlus/TablePlus/projects/1 for details.",
+    "version": "3.1.0",
     "description": "Relational database explorer",
     "homepage": "https://tableplus.com",
-    "license": "Proprietary",
-    "url": "https://s3.amazonaws.com/tableplus-win-builds/110/TablePlusSetup.exe",
-    "hash": "be696fb0c6f1f39c51cae409e02a364ebcda0172c21cb42c941430f8a9eedce5",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://tableplus.com/blog/2018/01/license-agreement.html"
+    },
+    "url": "https://s3.amazonaws.com/tableplus-win-builds/112/TablePlusSetup.exe",
+    "hash": "3f54873222e897bca34d51f6aa4444133ef31614aa5c00b5ae331bcaeeaab38d",
     "innosetup": true,
-    "architecture" :{
+    "architecture": {
         "32bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -Replace ',1' }"
+            "pre_install": [
+                "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -Replace ',1' }",
+                "Remove-Item \"$dir\\*,2*\""
+            ]
         },
         "64bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -Replace ',2' }"
+            "pre_install": [
+                "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -Replace ',2' }",
+                "Remove-Item \"$dir\\*,1*\""
+            ]
         }
     },
     "bin": "TablePlus.exe",
@@ -22,10 +32,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://tableplus.com/blog/2018/09/changelogs-windows.html",
-        "regex": "Build (\\d+)</h3>"
+        "url": "https://tableplus.com/win/version.xml?sign=&version=x64",
+        "regex": "sparkle:version=\"(?<build>\\d+)\"\\s+sparkle:shortVersionString=\"([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://s3.amazonaws.com/tableplus-win-builds/$version/TablePlusSetup.exe"
+        "url": "https://s3.amazonaws.com/tableplus-win-builds/$matchBuild/TablePlusSetup.exe"
     }
 }

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -13,13 +13,13 @@
     "architecture": {
         "32bit": {
             "pre_install": [
-                "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -replace ',1' }",
+                "Get-ChildItem \"$dir\" '*,1.*' | Rename-Item -NewName { $_.FullName -replace ',1\\.', '.' }",
                 "Remove-Item \"$dir\\*,2*\""
             ]
         },
         "64bit": {
             "pre_install": [
-                "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -replace ',2' }",
+                "Get-ChildItem \"$dir\" '*,2.*' | Rename-Item -NewName { $_.FullName -replace ',2\\.', '.' }",
                 "Remove-Item \"$dir\\*,1*\""
             ]
         }

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -1,5 +1,5 @@
 {
-    "##": "TODO: There will be an option portable mode in the near future. See https://github.com/TablePlus/TablePlus/projects/1 for details.",
+    "##": "TODO: There will be an option for portable mode in the near future. See #3424 for details.",
     "version": "3.1.0",
     "description": "Relational database explorer",
     "homepage": "https://tableplus.com",

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -1,6 +1,6 @@
 {
     "##": "TODO: There will be an option for portable mode in the near future. See #3424 for details.",
-    "version": "3.1.0",
+    "version": "3.1.0.112",
     "description": "Relational database explorer",
     "homepage": "https://tableplus.com",
     "license": {
@@ -14,7 +14,7 @@
         "32bit": {
             "pre_install": [
                 "Get-ChildItem \"$dir\" '*,1.*' | Rename-Item -NewName { $_.FullName -replace ',1\\.', '.' }",
-                "Remove-Item \"$dir\\*,2*\""
+                "Remove-Item \"$dir\\*,2.*\""
             ]
         },
         "64bit": {
@@ -33,9 +33,10 @@
     ],
     "checkver": {
         "url": "https://tableplus.com/win/version.xml?sign=&version=x64",
-        "regex": "sparkle:version=\"(?<build>\\d+)\"\\s+sparkle:shortVersionString=\"([\\d.]+)\""
+        "regex": "sparkle:version=\"(\\d+)\"\\s+sparkle:shortVersionString=\"([\\d.]+)\"",
+        "replace": "${2}.${1}"
     },
     "autoupdate": {
-        "url": "https://s3.amazonaws.com/tableplus-win-builds/$matchBuild/TablePlusSetup.exe"
+        "url": "https://s3.amazonaws.com/tableplus-win-builds/$buildVersion/TablePlusSetup.exe"
     }
 }

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -13,13 +13,13 @@
     "architecture": {
         "32bit": {
             "pre_install": [
-                "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -Replace ',1' }",
+                "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -replace ',1' }",
                 "Remove-Item \"$dir\\*,2*\""
             ]
         },
         "64bit": {
             "pre_install": [
-                "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -Replace ',2' }",
+                "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -replace ',2' }",
                 "Remove-Item \"$dir\\*,1*\""
             ]
         }

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -1,0 +1,31 @@
+{
+    "version": "110",
+    "description": "Relational database explorer",
+    "homepage": "https://tableplus.com",
+    "license": "Proprietary",
+    "url": "https://s3.amazonaws.com/tableplus-win-builds/110/TablePlusSetup.exe",
+    "hash": "be696fb0c6f1f39c51cae409e02a364ebcda0172c21cb42c941430f8a9eedce5",
+    "innosetup": true,
+    "architecture" :{
+        "32bit": {
+            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | ForEach-Object { Rename-Item $_.Fullname ($_.Name -Replace ',2') }"
+        },
+        "64bit": {
+            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | ForEach-Object { Rename-Item $_.Fullname ($_.Name -Replace ',2') }"
+        }
+    },
+    "bin": "TablePlus.exe",
+    "shortcuts": [
+        [
+            "TablePlus.exe",
+            "TablePlus"
+        ]
+    ],
+    "checkver": {
+        "url": "https://tableplus.com/blog/2018/09/changelogs-windows.html",
+        "regex": "Build (\\d+)</h3>"
+    },
+    "autoupdate": {
+        "url": "https://s3.amazonaws.com/tableplus-win-builds/$version/TablePlusSetup.exe"
+    }
+}

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -33,8 +33,8 @@
     ],
     "checkver": {
         "url": "https://tableplus.com/win/version.xml?sign=&version=x64",
-        "regex": "sparkle:version=\"(\\d+)\"\\s+sparkle:shortVersionString=\"([\\d.]+)\"",
-        "replace": "${2}.${1}"
+        "regex": "sparkle:version=\"(?<build>\\d+)\"\\s+sparkle:shortVersionString=\"([\\d.]+)\"",
+        "replace": "${1}.${build}"
     },
     "autoupdate": {
         "url": "https://s3.amazonaws.com/tableplus-win-builds/$buildVersion/TablePlusSetup.exe"

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -8,10 +8,10 @@
     "innosetup": true,
     "architecture" :{
         "32bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | ForEach-Object { Rename-Item $_.Fullname ($_.Name -Replace ',2') }"
+            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.Name -Replace ',1' }"
         },
         "64bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | ForEach-Object { Rename-Item $_.Fullname ($_.Name -Replace ',2') }"
+            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.Name -Replace ',2' }"
         }
     },
     "bin": "TablePlus.exe",

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -8,10 +8,10 @@
     "innosetup": true,
     "architecture" :{
         "32bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.Name -Replace ',1' }"
+            "pre_install": "Get-ChildItem \"$dir\" '*,1*' | Rename-Item -NewName { $_.FullName -Replace ',1' }"
         },
         "64bit": {
-            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.Name -Replace ',2' }"
+            "pre_install": "Get-ChildItem \"$dir\" '*,2*' | Rename-Item -NewName { $_.FullName -Replace ',2' }"
         }
     },
     "bin": "TablePlus.exe",

--- a/bucket/tableplus.json
+++ b/bucket/tableplus.json
@@ -20,7 +20,7 @@
         "64bit": {
             "pre_install": [
                 "Get-ChildItem \"$dir\" '*,2.*' | Rename-Item -NewName { $_.FullName -replace ',2\\.', '.' }",
-                "Remove-Item \"$dir\\*,1*\""
+                "Remove-Item \"$dir\\*,1.*\""
             ]
         }
     },


### PR DESCRIPTION
close https://github.com/lukesampson/scoop/issues/3095

**TablePlus** ([homepage](https://tableplus.com/)) is a relational database explorer.

Notes:

* *TablePlus* is not a free software. However its main features are available without a premium license.

> The free trial is limited to 2 opened tabs, 2 opened windows, 2 advanced filters at a time. We can change the limitations without any notifications in the future releases.
(https://tableplus.com/pricing)

* **pre_install**: The installer contains files for both *32-bit* and *64-bit*, and named them as `(something),1.(ext)`[32-bit] and `(something),2.(ext)`[64-bit], which is a common case ~for innosetup installers~. See [install script](https://github.com/lukesampson/scoop-extras/files/4008418/install_script.txt) for details.

* **persist** is not needed because *TablePlus* stores its user config under `$Env:LocalAppdata\com.tinyapp.TablePlus`.

* There will be an option for **portable mode** in near future (https://github.com/TablePlus/TablePlus/projects/1@ `Add config for the data path folder`)
