### PR TITLE
gb-studio: Update to version 1.2.0 (manually)

### DIFF
--- a/bucket/gb-studio.json
+++ b/bucket/gb-studio.json
@@ -1,16 +1,16 @@
 {
-    "homepage": "https://www.gbstudio.dev/",
+    "homepage": "https://www.gbstudio.dev",
     "description": "Free and easy to use retro adventure game creator for Game Boy.",
     "license": "MIT",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.1.0/GB.Studio-win32-x64-1.1.0.zip",
-            "hash": "f471afa9254ecb628cfc9851d7946fc70263a92cc6880ce41d252688089defc4"
+            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.2.0/GB-Studio-Windows-64bit-1.2.0.zip",
+            "hash": "3121dc299a4dea882e6b463e304c612ff1848106e3e7da37edee3ee8bba57de9"
         },
         "32bit": {
-            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.1.0/GB.Studio-win32-ia32-1.1.0.zip",
-            "hash": "d4b32c095bb13b0f5aea23af54a626c6ba02ec0fe59fc3b273b491b3ce97e8db"
+            "url": "https://github.com/chrismaltby/gb-studio/releases/download/v1.2.0/GB-Studio-Windows-32bit-1.2.0.zip",
+            "hash": "cac187d0b0990bb7939c88c934fa0faaa45226e80d30287c3434ea679624f4fc"
         }
     },
     "bin": "gb-studio.exe",
@@ -21,15 +21,15 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/chrismaltby/gb-studio/"
+        "github": "https://github.com/chrismaltby/gb-studio"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/GB.Studio-win32-x64-$version.zip"
+                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/GB-Studio-Windows-64bit-$version.zip"
             },
             "32bit": {
-                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/GB.Studio-win32-ia32-$version.zip"
+                "url": "https://github.com/chrismaltby/gb-studio/releases/download/v$version/GB-Studio-Windows-32bit-$version.zip"
             }
         }
     }


### PR DESCRIPTION
#2308 (Outstanding Excavator issues)

* **gb-studio** has changed their file name pattern.

* Since *gb-studio* stores its user config in `$Env:AppData\GB Studio`, *persist* is not needed for this package.
