### PR TITLE
CUDA8: Add version 8.0.61

### DIFF
--- a/bucket/cuda8.json
+++ b/bucket/cuda8.json
@@ -1,0 +1,20 @@
+{
+    "version": "8.0.61",
+    "description": "Runtime library and development toolkit for GPU-accelerated applications",
+    "homepage": "https://developer.nvidia.com/cuda-toolkit",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://docs.nvidia.com/cuda/eula/index.html"
+    },
+    "url": "https://developer.nvidia.com/compute/cuda/8.0/Prod2/local_installers/cuda_8.0.61_win10-exe#/setup.exe",
+    "hash": "md5:f857c29b8121099090524b90290cfbf6",
+    "post_install": [
+        "if (-not (is_admin)) { error 'This package requires admin privileges to install'; break }",
+        "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList @('-s', 'compiler_8.0', 'command_line_tools_8.0', 'visual_profiler_8.0', 'visual_studio_integration_8.0', 'demo_suite_8.0' ,'documentation_8.0', 'cublas_8.0', 'cublas_dev_8.0', 'cudart_8.0', 'cufft_8.0', 'cufft_dev_8.0', 'curand_8.0', 'curand_dev_8.0', 'cusolver_8.0', 'cusolver_dev_8.0', 'cusparse_8.0', 'cusparse_dev_8.0', 'nvgraph_8.0', 'nvgraph_dev_8.0', 'npp_8.0', 'npp_dev_8.0', 'nvrtc_8.0', 'nvrtc_dev_8.0', 'nvml_dev_8.0', 'occupancy_calculator_8.0') -RunAs | Out-Null"
+    ],
+    "notes": [
+        "You can now remove this installer with 'scoop uninstall cuda8'",
+        "CUDA requires a compatible NVIDIA graphics card, and NVIDIA display driver to work properly.",
+        "See https://en.wikipedia.org/wiki/CUDA#GPUs_supported for list of compatible graphic cards."
+    ]
+}


### PR DESCRIPTION
**CUDA** ([homepage](https://developer.nvidia.com/cuda-toolkit)) is NVIDIA's runtime library and development toolkit for GPU-accelerated applications.

* This package follows the pattern of [VCRedist packages](https://github.com/lukesampson/scoop-extras/blob/8a1d5cd2d16c5796a30e9f3e07eb755171c0463a/bucket/vcredist2013.json).

* This package only contains CUDA 8.0. I will send another PR for other CUDA versions (`9.0`, `9.1`, `9.2`, `10.0`, `10.1`) if this PR is accepted.

* **Naming** of other CUDA packages: Is it acceptable to use `cuda10.1.json` as the package name? (or should I name it as `cuda10-1` instead?)

* This package will install CUDA Toolkit **without installing the display driver**. It can be installed on a PC without a compatible NVIDIA graphics card. Also, different versions of CUDA can be installed on the same PC.

* Installer **arguments** can be found in the **Installation Guide Windows -> Install the CUDA Software** section in CUDA Toolkit Documentation ([CUDA 8.0](https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-microsoft-windows/index.html)) ([CUDA 9.0](https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-microsoft-windows/index.html)) ([CUDA 10.0](https://docs.nvidia.com/cuda/archive/10.0/cuda-installation-guide-microsoft-windows/index.html))

* **hash**: The MD5 hash value comes from https://developer.nvidia.com/compute/cuda/8.0/Prod2/docs/sidebar/md5sum-txt.

* **license**: I marked the `license` as **Proprietary** according to the [Wikipedia article](https://en.wikipedia.org/wiki/CUDA). Also there are some restrictions described in the EULA.
> Subject to the terms of this Agreement, NVIDIA hereby grants you a non-exclusive, non-transferable license, without the right to sublicense (except as expressly provided in this Agreement) to:
>1. Install and use the SDK,
>2. Modify and create derivative works of sample source code delivered in the SDK, and
>3. Distribute those portions of the SDK that are identified in this Agreement as distributable, as incorporated in object code format into a software application that meets the distribution requirements indicated in this Agreement.
(https://docs.nvidia.com/cuda/eula/index.html)