### PR TITLE
batcodecheck: Add version 0.32.1

### DIFF
--- a/bucket/batcodecheck.json
+++ b/bucket/batcodecheck.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.32.1",
+    "description": "Batch file (.bat) linter",
+    "homepage": "https://www.robvanderwoude.com",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.robvanderwoude.com"
+    },
+    "url": "https://www.robvanderwoude.com/files/batcodecheck.zip",
+    "hash": "md5:7ac4094906c77b5765dba6ac3c96f1ef",
+    "bin": "BatCodeCheck.exe"
+}


### PR DESCRIPTION
**BatCodeCheck** ([manual](https://www.robvanderwoude.com/helptext.php?src=batcodecheck_cs_help)) is a linter for Windows batch file **(.bat)**.

Notes:
* BatCodeCheck is a command-line tool. However it is **not suitable for the main bucket** since the author states that it is still in beta. (https://github.com/ScoopInstaller/Main/pull/687)

* The MD5 hash value comes from [the download page](https://www.robvanderwoude.com/csharpexamples.php).

* *BatCodeCheck* has not been updated since 2014. Therefore **checkver/autoupdate** is not needed. 

* **License** info can be found in the *Disclaimer* section of the homepage(https://www.robvanderwoude.com/).
> Unless stated otherwise, these pages, the scripts presented and their sources are copyrighted freeware.
You may modify them, as long as a reference to the original code is included in the modified code.

>However, it is not allowed to publish (copies of) my scripts on your own site, or distribute them on paper, CD or by whatever medium, without my prior written consent (hence copyrighted freeware).