### PR TITLE
syncbackfree: Add version 9.2.30.0

### DIFF
--- a/bucket/syncbackfree.json
+++ b/bucket/syncbackfree.json
@@ -1,0 +1,27 @@
+{
+    "version": "9.2.12.0",
+    "description": "Data backup and synchronize software",
+    "homepage": "https://www.2brightsparks.com/download-syncbackfree.html",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.2brightsparks.com/download-syncbackfree.html#tab2"
+    },
+    "url": "https://www.2brightsparks.com/assets/software/SyncBack_Setup.exe",
+    "hash": "498ae3d9e06d28cd5de06d11214597e051c44027ad3f8a76bef31a37016bfe5b",
+    "post_install": "Set-Content \"$dir\\SettingsFolder.ini\" @('[Settings]', 'Folder=%THISPATH%settings', 'Restricted=1') -Encoding ASCII",
+    "bin": "SyncBackFree.exe",
+    "shortcuts": [
+        [
+            "SyncBackFree.exe",
+            "SyncBackFree"
+        ]
+    ],
+    "checkver": "SyncBackFree\\s+V([\\d.]+)",
+    "autoupdate": {
+        "url": "https://www.2brightsparks.com/assets/software/SyncBack_Setup.exe",
+        "hash": {
+            "url": "https://www.2brightsparks.com/download-syncbackfree.html",
+            "regex": "SHA-256 = $sha256"
+        }
+    }
+}

--- a/bucket/syncbackfree.json
+++ b/bucket/syncbackfree.json
@@ -7,7 +7,8 @@
         "url": "https://www.2brightsparks.com/download-syncbackfree.html#tab2"
     },
     "url": "https://www.2brightsparks.com/assets/software/SyncBack_Setup.exe",
-    "hash": "498ae3d9e06d28cd5de06d11214597e051c44027ad3f8a76bef31a37016bfe5b",
+    "hash": "4995b24b6a9c2b3e71365a967b469220bfbe4f4bd42ddd4133714f1938a0a6f8",
+    "innosetup": true,
     "bin": "SyncBackFree.exe",
     "shortcuts": [
         [

--- a/bucket/syncbackfree.json
+++ b/bucket/syncbackfree.json
@@ -8,7 +8,6 @@
     },
     "url": "https://www.2brightsparks.com/assets/software/SyncBack_Setup.exe",
     "hash": "498ae3d9e06d28cd5de06d11214597e051c44027ad3f8a76bef31a37016bfe5b",
-    "post_install": "Set-Content \"$dir\\SettingsFolder.ini\" @('[Settings]', 'Folder=%THISPATH%settings', 'Restricted=1') -Encoding ASCII",
     "bin": "SyncBackFree.exe",
     "shortcuts": [
         [

--- a/bucket/syncbackfree.json
+++ b/bucket/syncbackfree.json
@@ -1,6 +1,6 @@
 {
     "version": "9.2.12.0",
-    "description": "Data backup and synchronize software",
+    "description": "Data backup and synchronization software",
     "homepage": "https://www.2brightsparks.com/download-syncbackfree.html",
     "license": {
         "identifier": "Freeware",

--- a/bucket/syncbackfree.json
+++ b/bucket/syncbackfree.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.2.12.0",
+    "version": "9.2.30.0",
     "description": "Data backup and synchronization software",
     "homepage": "https://www.2brightsparks.com/download-syncbackfree.html",
     "license": {


### PR DESCRIPTION
**SyncBackFree** ([homepage](https://www.2brightsparks.com/download-syncbackfree.html)) is a data backup and synchronize software.

Notes:

* *SyncBackPro* ([syncbackpro.json](https://github.com/lukesampson/scoop-extras/blob/master/bucket/syncbackpro.json)) has 32-bit and 64-bit versions, but **SyncBackFree** has only one application for both 32-bit and 64-bit.
> Windows 10, Windows 8, Windows 7 and Windows Vista. Both 32-bit and 64-bit versions of Windows are supported.

* **persist**: *SyncBackFree* does not provide the option for **custom backup profile location** like *SyncBackPro* does. Therefore the method used in [SyncBackPro package](https://github.com/lukesampson/scoop-extras/blob/master/bucket/syncbackpro.json) cannot be used here. I tried to put the content below in `settingsFolder.ini`, but it did not work for *SyncBackFree*.
(*SyncBackFree* stores its backup profiles in `$Env:LocalAppData\2BrightSparks\SyncBackFree` by default)
```
[Settings]
Folder=%THISPATH%settings
Restricted=1
```