### PR TITLE
nettraffic: Add version 1.64.0

### DIFF
--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -18,6 +18,7 @@
             "NetTraffic"
         ]
     ],
+    "persist": "Data",
     "checkver": {
         "url": "https://www.venea.net/web/downloads_start/nettraffic_portable",
         "regex": "Version: ([\\d.]+)"

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -9,7 +9,7 @@
     "url": "https://files02.tchspt.com/storage2/temp/NetTraffic1.64.0.zip",
     "hash": "0afe87c024a49eca4d141f5903952e0577f79c40a575a6d3f1320e94b67a2025",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\NetTraffic*.exe\" -Removal",
+        "Expand-7zipArchive \"$dir\\NetTraffic $version.exe\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Recurse"
     ],
     "shortcuts": [

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -7,7 +7,7 @@
     "hash": "0afe87c024a49eca4d141f5903952e0577f79c40a575a6d3f1320e94b67a2025",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\NetTraffic*.exe\" -Removal",
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$LOCALAPPDATA\", \"$dir\\uninstall.exe\" -Force -Recurse"
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Recurse"
     ],
     "shortcuts": [
         [

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://www.venea.net/web/nettraffic_portable",
+    "description": "Essential network bandwidth usage monitor",
+    "license": "Freeware",
+    "version": "1.64",
+    "url": "https://www.venea.net/web/downloads_start/nettraffic_portable",
+    "hash": "md5:03ed42220ab1aed678f054728daeeae2",
+    "extract_dir": "NetTraffic",
+    "shortcuts": [
+        [
+            "NetTraffic.exe",
+            "NetTraffic"
+        ]
+    ],
+    "persist": "Data",
+    "checkver": {
+        "url": "https://www.venea.net/web/nettraffic_version",
+        "xpath": "/nettraffic/@version"
+    },
+    "autoupdate": {
+        "url": "https://www.venea.net/web/downloads_start/nettraffic_portable"
+    }
+}

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -1,7 +1,10 @@
 {
     "homepage": "https://www.venea.net/web/nettraffic",
     "description": "Essential network bandwidth usage monitor",
-    "license": "Freeware",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.venea.net/web/nettraffic#license"
+    },
     "version": "1.64.0",
     "url": "https://files02.tchspt.com/storage2/temp/NetTraffic1.64.0.zip",
     "hash": "0afe87c024a49eca4d141f5903952e0577f79c40a575a6d3f1320e94b67a2025",

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -6,7 +6,7 @@
     "url": "https://files02.tchspt.com/storage2/temp/NetTraffic1.64.0.zip",
     "hash": "0afe87c024a49eca4d141f5903952e0577f79c40a575a6d3f1320e94b67a2025",
     "pre_install": [
-        "Expand-7zipArchive \"$dir\\NetTraffic 1.64.0.exe\" -Removal",
+        "Expand-7zipArchive \"$dir\\NetTraffic*.exe\" -Removal",
         "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$LOCALAPPDATA\", \"$dir\\uninstall.exe\" -Force -Recurse"
     ],
     "shortcuts": [

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -1,5 +1,5 @@
 {
-    "homepage": "https://www.venea.net/web/nettraffic_portable",
+    "homepage": "https://www.venea.net/web/nettraffic",
     "description": "Essential network bandwidth usage monitor",
     "license": "Freeware",
     "version": "1.64.0",

--- a/bucket/nettraffic.json
+++ b/bucket/nettraffic.json
@@ -2,22 +2,24 @@
     "homepage": "https://www.venea.net/web/nettraffic_portable",
     "description": "Essential network bandwidth usage monitor",
     "license": "Freeware",
-    "version": "1.64",
-    "url": "https://www.venea.net/web/downloads_start/nettraffic_portable",
-    "hash": "md5:03ed42220ab1aed678f054728daeeae2",
-    "extract_dir": "NetTraffic",
+    "version": "1.64.0",
+    "url": "https://files02.tchspt.com/storage2/temp/NetTraffic1.64.0.zip",
+    "hash": "0afe87c024a49eca4d141f5903952e0577f79c40a575a6d3f1320e94b67a2025",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\NetTraffic 1.64.0.exe\" -Removal",
+        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\`$LOCALAPPDATA\", \"$dir\\uninstall.exe\" -Force -Recurse"
+    ],
     "shortcuts": [
         [
             "NetTraffic.exe",
             "NetTraffic"
         ]
     ],
-    "persist": "Data",
     "checkver": {
-        "url": "https://www.venea.net/web/nettraffic_version",
-        "xpath": "/nettraffic/@version"
+        "url": "https://www.venea.net/web/downloads_start/nettraffic_portable",
+        "regex": "Version: ([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://www.venea.net/web/downloads_start/nettraffic_portable"
+        "url": "https://files02.tchspt.com/storage2/temp/NetTraffic$version.zip"
     }
 }


### PR DESCRIPTION
- Closes #3460 

[NetTraffic](https://www.venea.net/web/nettraffic): An essential network bandwidth usage monitor.


**Note:** 
- The official site does not provide a valid download url. So I open an issue #3460, thanks to @issaclin32, I use [TechSpot](https://www.techspot.com/downloads/6058-nettraffic.html) as the download service. 
- The official site offers a portable version, but we can not get it, so just use the installer.