### PR TITLE
imageglass: Update to version 7.5.1.1

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -1,33 +1,62 @@
 {
-    "version": "7.0.7.26",
-    "homepage": "https://imageglass.org/",
-    "description": "A lightweight, versatile image viewer.",
+    "version": "7.5.1.1",
+    "homepage": "https://imageglass.org",
+    "description": "A lightweight, versatile image viewer",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/d2phap/ImageGlass/releases/download/7.0.7.26/ImageGlass_7.0.7.26.zip",
-    "hash": "sha1:3e0af0af491e768feeae998e15dd140dc8c76bff",
-    "extract_dir": "ImageGlass_7.0.7.26",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/7.5.1.1/ImageGlass_7.5.1.1_x64.zip",
+            "hash": "sha1:67dc322f3a14799044ee84dece60a468e4d35534",
+            "extract_dir": "ImageGlass_7.5.1.1_x64"
+        },
+        "32bit": {
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/7.5.1.1/ImageGlass_7.5.1.1_x86.zip",
+            "hash": "sha1:647ccea384ba75bef6c3d549d589338ef32a35fc",
+            "extract_dir": "ImageGlass_7.5.1.1_x86"
+        }
+    },
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\igconfig.xml\")) {",
-        "    New-Item -Force -Path \"$dir\" -Name 'igconfig.xml' -Value '<ImageGlass><Configuration><Content></Content></Configuration></ImageGlass>' | Out-Null",
+        "    Add-Content \"$dir\\igconfig.xml\" '<ImageGlass><Configuration><Info/><Content><Item key=\"AutoUpdate\" value=\"0\" /></Content></Configuration></ImageGlass>' -Encoding Ascii",
         "}"
     ],
-    "persist": "igconfig.xml",
-    "bin": "ImageGlass.exe",
+    "bin": [
+        "ImageGlass.exe",
+        "igcmd.exe",
+        "igcmdWin10.exe",
+        "igtasks.exe"
+    ],
     "shortcuts": [
         [
             "ImageGlass.exe",
             "ImageGlass"
         ]
     ],
+    "persist": [
+        "Themes",
+        "igconfig.xml"
+    ],
     "checkver": {
         "github": "https://github.com/d2phap/ImageGlass/"
     },
     "autoupdate": {
-        "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version.zip",
-        "hash": {
-            "url": "https://imageglass.org/download",
-            "regex": "(?sm)Download portable version.*?$sha1"
-        },
-        "extract_dir": "ImageGlass_$version"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x64.zip",
+                "hash": {
+                    "url": "https://imageglass.org/download",
+                    "regex": "(?sm)Download portable x64 version.*?$sha1"
+                },
+                "extract_dir": "ImageGlass_$version_x64"
+            },
+            "32bit": {
+                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x86.zip",
+                "hash": {
+                    "url": "https://imageglass.org/download",
+                    "regex": "(?sm)Download portable x86 version.*?$sha1"
+                },
+                "extract_dir": "ImageGlass_$version_x86"
+            }
+        }
     }
 }

--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -58,5 +58,6 @@
                 "extract_dir": "ImageGlass_$version_x86"
             }
         }
-    }
+    },
+    "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.xml'."
 }


### PR DESCRIPTION
https://github.com/lukesampson/scoop-extras/issues/2308
When updating from old version it does not work unless `igconfig.xml` is removed. This should be an upstream issue.