### PR TITLE
haskellx@7.8.3: Fix installation

### DIFF
--- a/bucket/haskellx.json
+++ b/bucket/haskellx.json
@@ -17,5 +17,5 @@
         ""
     ],
     "env_add_path": "bin",
-    "post_install": "mv \"$dir\\cabal.exe\" \"$dir\\bin\\cabal.exe\""
+    "post_install": "Move-Item \"$dir\\cabal.exe\" \"$dir\\bin\""
 }

--- a/bucket/haskellx.json
+++ b/bucket/haskellx.json
@@ -17,5 +17,5 @@
         ""
     ],
     "env_add_path": "bin",
-    "post_install": "mv \"$dir\\cabal\" \"$dir\\bin\\cabal.exe\""
+    "post_install": "mv \"$dir\\cabal.exe\" \"$dir\\bin\\cabal.exe\""
 }


### PR DESCRIPTION
Installation currently fails with the following error:
```
Running post-install script...
mv : Cannot find path 'C:\Users\eirik\scoop\apps\haskellx\current\cabal' because it does not exist.
At line:1 char:1
+ mv "$dir\cabal" "$dir\bin\cabal.exe"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\Users\eitsar...x\current\cabal:String) [Move-Item], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.MoveItemCommand

'haskellx' (7.8.3) was installed successfully!
```