### PR TITLE
chromium: fix

### DIFF
--- a/bucket/chromium-dev-nosync.json
+++ b/bucket/chromium-dev-nosync.json
@@ -1,32 +1,41 @@
 {
-    "version": "81.0.3998.0-r724962",
-    "description": "An open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
-    "license": "BSD-3-Clause",
+    "version": "81.0.3998.0",
+    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web (macchrome's build)",
     "homepage": "https://www.chromium.org",
-    "checkver": {
-        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=dev-codecs-nosync&out=json",
-        "jsonpath": "$.chromium.windows.download",
-        "regex": "v([\\d.]+-r\\d+)-Win64"
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/macchrome/chromium/releases/download/v81.0.3998.0-r724962-Win64/Chrome-bin.7z",
+            "hash": "sha1:b24e0e97324f4a1c1d8ae010144d90fbfd5725b3"
+        }
     },
-    "bin": "chrome.exe",
+    "extract_dir": "Chrome-bin",
+    "bin": [
+        "chrome.exe",
+        [
+            "chrome.exe",
+            "chromium"
+        ]
+    ],
     "shortcuts": [
         [
             "chrome.exe",
             "Chromium (dev)"
         ]
     ],
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/macchrome/chromium/releases/download/v81.0.3998.0-r724962-Win64/Chrome-bin.7z",
-            "hash": "ac3a6a4519919e0a1a1895a49d61858a20bc539569b59e9a0759353b95abaf9e",
-            "extract_dir": "Chrome-bin"
-        }
+    "checkver": {
+        "url": "https://github.com/macchrome/chromium/releases",
+        "regex": "releases/tag/v([\\d.]+)-r(?<rev>\\d+)-Win64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/chromium/releases/download/v$version-Win64/Chrome-bin.7z"
+                "url": "https://github.com/macchrome/chromium/releases/download/v$version-r$matchRev-Win64/Chrome-bin.7z"
             }
+        },
+        "hash": {
+            "url": "https://github.com/macchrome/chromium/releases/tag/v$version-r$matchRev-Win64",
+            "regex": "(?s)$basename.*?$sha1"
         }
     }
 }

--- a/bucket/chromium-dev.json
+++ b/bucket/chromium-dev.json
@@ -1,31 +1,41 @@
 {
-    "version": "74.0.3689.0-r627581",
-    "description": "An open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
-    "license": "BSD-3-Clause",
+    "version": "81.0.3998.0",
+    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web (macchrome's build)",
     "homepage": "https://www.chromium.org",
-    "checkver": {
-        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=dev-codecs-sync&out=string",
-        "re": "v([\\d.]+-r(?:\\d+))-win64"
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/macchrome/chromium/releases/download/v81.0.3998.0-r724962-Win64/Chrome-bin-sync.7z",
+            "hash": "sha1:19e61fbecc2587756cb13cc0ceb891211376555c"
+        }
     },
-    "bin": "chrome.exe",
-    "extract_dir": "chrome-win32",
+    "extract_dir": "Chrome-bin-sync",
+    "bin": [
+        "chrome.exe",
+        [
+            "chrome.exe",
+            "chromium"
+        ]
+    ],
     "shortcuts": [
         [
             "chrome.exe",
             "Chromium (dev)"
         ]
     ],
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v74.0.3689.0-r627581-win64/chromium-sync.zip",
-            "hash": "3553222dae406a0ab7203b5dac179dce811132861be0e51d3faca004b998b780"
-        }
+    "checkver": {
+        "url": "https://github.com/macchrome/chromium/releases",
+        "regex": "releases/tag/v([\\d.]+)-r(?<rev>\\d+)-Win64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win64/chromium-sync.zip"
+                "url": "https://github.com/macchrome/chromium/releases/download/v$version-r$matchRev-Win64/Chrome-bin-sync.7z"
             }
+        },
+        "hash": {
+            "url": "https://github.com/macchrome/chromium/releases/tag/v$version-r$matchRev-Win64",
+            "regex": "(?s)$basename.*?$sha1"
         }
     }
 }

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -1,37 +1,51 @@
 {
-    "version": "67.0.3396.99-r550428",
-    "description": "An open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.",
-    "license": "BSD-3-Clause",
+    "version": "79.0.3945.117",
+    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web (Hibbiki's build)",
     "homepage": "https://www.chromium.org",
-    "checkver": {
-        "url": "https://chromium.woolyss.com/api/v3/?os=windows&bit=64&type=stable-codecs-nosync&out=string",
-        "re": "v([\\d.]+-r(?:\\d+))-win64"
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v79.0.3945.117-r706915/mini_installer.nosync.exe#/dl.7z",
+            "hash": "sha1:3e0c10ac6fc36ecb61743b5381e57df77e7ceafe"
+        },
+        "32bit": {
+            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v79.0.3945.117-r706915/mini_installer.nosync.exe#/dl.7z",
+            "hash": "sha1:aa2572202362c272ad5f8eb47cd4aa0de14b1856"
+        }
     },
-    "bin": "chrome.exe",
-    "extract_dir": "chrome-win32",
+    "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" \"$dir\" -ExtractDir 'Chrome-bin' -Removal",
+    "bin": [
+        "chrome.exe",
+        [
+            "chrome.exe",
+            "chromium"
+        ]
+    ],
     "shortcuts": [
         [
             "chrome.exe",
             "Chromium"
         ]
     ],
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v67.0.3396.99-r550428-win64/chromium-nosync.zip",
-            "hash": "ad3df8579b2cdf44d0b2263fd9d3e4547d91401a6bd18e29d601636948a80414"
-        },
-        "32bit": {
-            "url": "https://github.com/henrypp/chromium/releases/download/v67.0.3396.99-r550428-win32/chromium-nosync.zip",
-            "hash": "e7fe350de36614917d82582c205090dd3451041812d1f0fdfa54c33b8c08f825"
-        }
+    "checkver": {
+        "github": "https://github.com/Hibbiki/chromium-win64",
+        "regex": "v([\\d.]+)-r(?<rev>\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win64/chromium-nosync.zip"
+                "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version-r$matchRev/mini_installer.nosync.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Hibbiki/chromium-win64/releases/v$version-r$matchRev",
+                    "regex": "$sha1 /mnt/d/out/x64/$basename"
+                }
             },
             "32bit": {
-                "url": "https://github.com/henrypp/chromium/releases/download/v$version-win32/chromium-nosync.zip"
+                "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v$version-r$matchRev/mini_installer.nosync.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Hibbiki/chromium-win32/releases/v$version-r$matchRev",
+                    "regex": "$sha1 /mnt/d/out/x86/$basename"
+                }
             }
         }
     }

--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,21 +1,19 @@
 {
-    "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
     "version": "79.0.3945.117",
-    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
-    "license": "BSD-3-Clause",
+    "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web (Hibbiki's build)",
     "homepage": "https://www.chromium.org",
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v79.0.3945.117-r706915-Win64/ungoogled-chromium-79.0.3945.117-1_windows.7z",
-            "hash": "sha1:745c9dd30ec46cef517343bd953bb154ed44cbbb",
-            "extract_dir": "ungoogled-chromium-79.0.3945.117-1_windows"
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v79.0.3945.117-r706915/mini_installer.sync.exe#/dl.7z",
+            "hash": "sha1:4401d2d1e40a199ae6952e3f49bf1c3155fbbac8"
         },
         "32bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v79.0.3945.117-r706915-Win64/Ungoogled-Chromium-79.0.3945.117-Win32.7z",
-            "hash": "sha1:907094d8a3dd925b6db490bd8d65d50a3419f866",
-            "extract_dir": "Ungoogled-Chromium-79.0.3945.117-Win32"
+            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v79.0.3945.117-r706915/mini_installer.sync.exe#/dl.7z",
+            "hash": "sha1:9517b8d63728c71d78cd5d71ffd2528dd26064c4"
         }
     },
+    "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" \"$dir\" -ExtractDir 'Chrome-bin' -Removal",
     "bin": [
         "chrome.exe",
         [
@@ -30,23 +28,25 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/macchrome/winchrome",
-        "regex": "v([\\d.]+)-r(?<build>\\d+)-Win64"
+        "github": "https://github.com/Hibbiki/chromium-win64",
+        "regex": "v([\\d.]+)-r(?<rev>\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-1_windows.7z",
-                "extract_dir": "ungoogled-chromium-$version-1_windows"
+                "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version-r$matchRev/mini_installer.sync.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Hibbiki/chromium-win64/releases/v$version-r$matchRev",
+                    "regex": "$sha1 /mnt/d/out/x64/$basename"
+                }
             },
             "32bit": {
-                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-Win32.7z",
-                "extract_dir": "Ungoogled-Chromium-$version-Win32"
+                "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v$version-r$matchRev/mini_installer.sync.exe#/dl.7z",
+                "hash": {
+                    "url": "https://github.com/Hibbiki/chromium-win32/releases/v$version-r$matchRev",
+                    "regex": "$sha1 /mnt/d/out/x86/$basename"
+                }
             }
-        },
-        "hash": {
-            "url": "https://github.com/macchrome/winchrome/releases/v$version-r$matchBuild-Win64",
-            "regex": "(?s)$basename.*?$sha1"
         }
     }
 }

--- a/bucket/ungoogled-chromium.json
+++ b/bucket/ungoogled-chromium.json
@@ -1,19 +1,27 @@
 {
-    "version": "79.0.3945.117-1",
-    "description": "Modifications to Google Chromium for removing Google integration and enhancing privacy, control, and transparency.",
+    "version": "79.0.3945.117",
+    "description": "Modifications to Google Chromium for removing Google integration and enhancing privacy, control, and transparency (macchrome's build)",
     "homepage": "https://github.com/Eloston/ungoogled-chromium",
-    "license": {
-        "identifier": "BSD-3-Clause",
-        "url": "https://github.com/Eloston/ungoogled-chromium/blob/master/LICENSE"
-    },
+    "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/79.0.3945.117-1/ungoogled-chromium_79.0.3945.117-1.1_windows-x64.zip",
-            "hash": "64a20ae7bc8da0f987cb34dbd8430491cd5ec3082308498e479c8fd9db17e1bd",
-            "extract_dir": "ungoogled-chromium_79.0.3945.117-1.1_windows"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v79.0.3945.117-r706915-Win64/ungoogled-chromium-79.0.3945.117-1_windows.7z",
+            "hash": "sha1:745c9dd30ec46cef517343bd953bb154ed44cbbb",
+            "extract_dir": "ungoogled-chromium-79.0.3945.117-1_windows"
+        },
+        "32bit": {
+            "url": "https://github.com/macchrome/winchrome/releases/download/v79.0.3945.117-r706915-Win64/Ungoogled-Chromium-79.0.3945.117-Win32.7z",
+            "hash": "sha1:907094d8a3dd925b6db490bd8d65d50a3419f866",
+            "extract_dir": "Ungoogled-Chromium-79.0.3945.117-Win32"
         }
     },
-    "bin": "chrome.exe",
+    "bin": [
+        "chrome.exe",
+        [
+            "chrome.exe",
+            "chromium"
+        ]
+    ],
     "shortcuts": [
         [
             "chrome.exe",
@@ -21,15 +29,23 @@
         ]
     ],
     "checkver": {
-        "url": "https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/windows/64bit/",
-        "re": "\\d\">\\s*([\\d.-]+)<"
+        "github": "https://github.com/macchrome/winchrome",
+        "regex": "releases/tag/v([\\d.]+)-r(?<rev>\\d+)-Win64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/$version/ungoogled-chromium_$version.1_windows-x64.zip",
-                "extract_dir": "ungoogled-chromium_$version.1_windows"
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchRev-Win64/ungoogled-chromium-$version-1_windows.7z",
+                "extract_dir": "ungoogled-chromium-$version-1_windows"
+            },
+            "32bit": {
+                "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchRev-Win64/Ungoogled-Chromium-$version-Win32.7z",
+                "extract_dir": "Ungoogled-Chromium-$version-Win32"
             }
+        },
+        "hash": {
+            "url": "https://github.com/macchrome/winchrome/releases/tag/v$version-r$matchRev-Win64",
+            "regex": "(?s)$basename.*?$sha1"
         }
     }
 }


### PR DESCRIPTION
close https://github.com/lukesampson/scoop-extras/issues/3473
close https://github.com/lukesampson/scoop-extras/pull/3415
https://github.com/lukesampson/scoop-extras/issues/2308
- chromium: change to Hibbiki's build for sync
- chromium-nosync: change to Hibbiki's build, update to version 79.0.3945.117
- chromium-dev: change to macchrome's build, update to version 81.0.3998.0
- chromium-dev-nosync: add hash extraction, checkver from github
- ungoogled-chromium: change to macchrome's build for 32bit and hash extraction