### PR TITLE
flutter: Update to version 1.12.13-hotfix.7

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -35,7 +35,7 @@
         "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchVer+$matchBuild-stable.zip",
         "hash": {
             "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer[+]$matchBuild-stable.zip/)].sha256"
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer[-+]$matchBuild-stable.zip/)].sha256"
         }
     },
     "suggest": {

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -1,14 +1,14 @@
 {
     "homepage": "https://flutter.dev/",
-    "version": "1.5.4-hotfix.2",
+    "version": "1.12.13+hotfix.7",
     "license": "BSD-3-Clause",
     "url": [
-        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.5.4-hotfix.2-stable.zip",
+        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.12.13+hotfix.7-stable.zip",
         "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/flutter-dev-setup.ps1"
     ],
     "extract_dir": "flutter",
     "hash": [
-        "1d5e1779430be6bbb4fa49f4bccc7c5d24a76f3d2a100129e09b4b8eef33b1b4",
+        "7b71b23af9149eb29e300c0e4ceed3e3de20d0104f48c9386a03f454e4d944a2",
         "bbd8dd269dd70d97e0224025281e55b7e2e32364d5c47e082ca7f45e33d1a613"
     ],
     "depends": [

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -1,52 +1,47 @@
 {
-    "homepage": "https://flutter.dev/",
     "version": "1.12.13-hotfix.7",
+    "description": "Google’s mobile app SDK for crafting high-quality native interfaces on iOS and Android",
+    "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
-    "url": [
-        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.12.13+hotfix.7-stable.zip",
-        "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/flutter-dev-setup.ps1"
-    ],
-    "extract_dir": "flutter",
-    "hash": [
-        "7b71b23af9149eb29e300c0e4ceed3e3de20d0104f48c9386a03f454e4d944a2",
-        "bbd8dd269dd70d97e0224025281e55b7e2e32364d5c47e082ca7f45e33d1a613"
-    ],
     "depends": [
         "android-sdk",
         "java/adopt8-hotspot"
     ],
-    "description": "Flutter is Google’s mobile app SDK for crafting high-quality native interfaces on iOS and Android in record time. This is the beta version, since Flutter wasn't officially 'released' yet.",
-    "env_add_path": "bin\\cache\\dart-sdk",
-    "bin": [
-        "bin\\flutter.bat",
-        "flutter-dev-setup.ps1"
-    ],
-    "post_install": [
-        "flutter-dev-setup.ps1",
-        "Write-Host Some licenses need to be accepted before developing. We recommend you do so by running 'flutter doctor --android-licenses'. -ForegroundColor Yellow",
-        "flutter doctor"
-    ],
-    "checkver": {
-        "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-        "regex": "windows_v(?<ver>[\\d.]+)(?<delim>[-+])(?<build>[\\w.]+)-stable",
-        "replace": "${ver}-${build}"
-    },
-    "autoupdate": {
-        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchVer$matchDelim$matchBuild-stable.zip",
-        "hash": {
-            "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer$matchDelim$matchBuild-stable.zip/)].sha256"
-        }
-    },
     "suggest": {
         "Visual Studio Code with Flutter Extension": [
             "vscode",
             "vscode-portable"
         ]
     },
-    "notes": [
-        "Flutter has been successfully installed and put in your PATH.",
-        "If using Visual Studio Code, don't forget to install the Flutter Extension!",
-        "Then connect an Android Phone and start coding :-)"
-    ]
+    "url": [
+        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.12.13+hotfix.7-stable.zip",
+        "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/flutter-dev-setup.ps1"
+    ],
+    "hash": [
+        "7b71b23af9149eb29e300c0e4ceed3e3de20d0104f48c9386a03f454e4d944a2",
+        "bbd8dd269dd70d97e0224025281e55b7e2e32364d5c47e082ca7f45e33d1a613"
+    ],
+    "extract_dir": "flutter",
+    "post_install": [
+        "flutter-dev-setup.ps1",
+        "Write-Host 'Some licenses need to be accepted before developing. It is recommended to do by running ''flutter doctor --android-licenses''.' -ForegroundColor Yellow",
+        "flutter doctor"
+    ],
+    "bin": [
+        "bin\\flutter.bat",
+        "flutter-dev-setup.ps1"
+    ],
+    "env_add_path": "bin\\cache\\dart-sdk",
+    "checkver": {
+        "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
+        "regex": "windows_v([\\d.]+)(?<delim>[-+])(?<build>[\\w.]+)-stable",
+        "replace": "$1-${build}"
+    },
+    "autoupdate": {
+        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchHead$matchDelim$matchBuild-stable.zip",
+        "hash": {
+            "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchHead$matchDelim$matchBuild-stable.zip/)].sha256"
+        }
+    }
 }

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -28,7 +28,7 @@
     ],
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-        "regex": "windows_v([\\w-.]+)-stable"
+        "regex": "windows_v([\\w-+.]+)-stable"
     },
     "autoupdate": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$version-stable.zip",

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -28,14 +28,14 @@
     ],
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-        "regex": "windows_v(?<ver>[\\d.]+)[-+](?<build>[\\w.]+)-stable",
+        "regex": "windows_v(?<ver>[\\d.]+)(?<delim>[-+])(?<build>[\\w.]+)-stable",
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchVer+$matchBuild-stable.zip",
+        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchVer$matchDelim$matchBuild-stable.zip",
         "hash": {
             "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer[-+]$matchBuild-stable.zip/)].sha256"
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer$matchDelim$matchBuild-stable.zip/)].sha256"
         }
     },
     "suggest": {

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -34,7 +34,7 @@
         "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$version-stable.zip",
         "hash": {
             "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*$basename/)].sha256"
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$version-stable.zip/)].sha256"
         }
     },
     "suggest": {

--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://flutter.dev/",
-    "version": "1.12.13+hotfix.7",
+    "version": "1.12.13-hotfix.7",
     "license": "BSD-3-Clause",
     "url": [
         "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.12.13+hotfix.7-stable.zip",
@@ -28,13 +28,14 @@
     ],
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-        "regex": "windows_v([\\w-+.]+)-stable"
+        "regex": "windows_v(?<ver>[\\d.]+)[-+](?<build>[\\w.]+)-stable",
+        "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$version-stable.zip",
+        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchVer+$matchBuild-stable.zip",
         "hash": {
             "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$version-stable.zip/)].sha256"
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchVer[+]$matchBuild-stable.zip/)].sha256"
         }
     },
     "suggest": {


### PR DESCRIPTION
- Closes #2439
- Closes #2526
- Closes #2770 
- Closes #2924
- Closes #3113
- Closes #3360
- Closes #3446 
- Closes #3490

As the flutter officially used `+` instead of `-` to concatenate `hotfix` in their version string since *2019/7/9* or before, the scoop version has stuck at `1.5.4-hotfix.2` yet the real-world version has already been advanced to `1.12.13+hotfix.5`.

So here is this PR.