### PR TITLE
xournalpp: Add version 1.0.15

### DIFF
--- a/bucket/xournalpp.json
+++ b/bucket/xournalpp.json
@@ -22,7 +22,6 @@
             "Xournal++"
         ]
     ],
-    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit" : {

--- a/bucket/xournalpp.json
+++ b/bucket/xournalpp.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.0.15",
+    "description": "A handwriting notetaking software with PDF annotation support",
+    "homepage": "https://github.com/xournalpp/xournalpp",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit" : {
+            "url": "https://github.com/xournalpp/xournalpp/releases/download/1.0.15/xournalpp-1.0.15-windows.zip",
+            "hash": "42b0dc65992ea51938aa9fde2d874e341f4005995fde6ab1d33ae117beb2ea5d"
+        }
+    },
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\xournalpp-$version-windows.exe\" -Removal",
+            "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Recurse"
+        ]
+    },
+    "bin": "bin\\xournalpp.exe",
+    "shortcuts": [
+        [
+            "bin\\xournalpp.exe",
+            "Xournal++"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit" : {
+                "url": "https://github.com/xournalpp/xournalpp/releases/download/$version/xournalpp-$version-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Xournal++ is a handwriting notetaking software with PDF annotation support. Supports pen input from devices such as Wacom Tablets.

![Xournal++ sample screenshot](https://github.com/xournalpp/xournalpp/raw/master/readme/main-win.png)

NOTE: There's [an issue](https://github.com/xournalpp/xournalpp/issues/1600) with Xournal++ 1.0.16 so I'm hereby make a PR with version 1.0.15