### PR TITLE
hwp-converter: Add version 2.0

### DIFF
--- a/bucket/hwp-converter.json
+++ b/bucket/hwp-converter.json
@@ -30,6 +30,15 @@
             }
         }
     },
+    "installer": {
+        "script": [
+            "Expand-MSIArchive \"$dir\\hwpconverter.msi\"",
+            "New-Item \"$dir\\bin\" -ItemType Directory | Out-Null",
+            "Move-Item \"$dir\\System*\\*\" \"$dir\\bin\"",
+            "Move-Item \"$dir\\FILES\\Program Files\\Microsoft Office\\O*\\*\" \"$dir\\bin\"",
+            "'files.cat', 'System*', 'FILES', 'swidtags' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }"
+        ]
+    },
     "bin": "bin\\BATCHHWPCONV.EXE",
     "shortcuts": [
         [

--- a/bucket/hwp-converter.json
+++ b/bucket/hwp-converter.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0",
+    "description": "Open and convert HWP files in Word as DOCX file.",
+    "homepage": "https://www.microsoft.com/en-us/download/details.aspx?id=49152",
+    "license": "Proprietary",
+    "notes": "MS Word 2016 integration can be manually installed with '$dir\\hwpconverter.msi'",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.microsoft.com/download/1/8/D/18D83826-2F32-4535-8C6A-686149B39DF8/hwpconverter_x64_en-us.exe#dl.7z",
+            "hash": "1a6a69c00a60f0ba44527c345017e4aba309b3e0003ee463721913ab9c6d9302",
+            "installer": {
+                "script": [
+                    "Remove-Item \"$dir\\files.cat\"",
+                    "New-Item -Path \"$dir\" -Name \"bin\" -ItemType directory | Out-Null",
+                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'FILES\\Program Files\\Microsoft Office\\OFF16.x64'",
+                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'System64'"
+                ]
+            }
+        },
+        "32bit": {
+            "url": "https://download.microsoft.com/download/1/8/D/18D83826-2F32-4535-8C6A-686149B39DF8/hwpconverter_x86_en-us.exe#dl.7z",
+            "hash": "48d599393a0a15b9c81a453bfa2e8db5d546e4cb63045cc382629f4fa35db82e",
+            "installer": {
+                "script": [
+                    "Remove-Item \"$dir\\files.cat\"",
+                    "New-Item -Path \"$dir\" -Name \"bin\" -ItemType directory | Out-Null",
+                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'FILES\\Program Files\\Microsoft Office\\Office16'",
+                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'System'"
+                ]
+            }
+        }
+    },
+    "bin": "bin\\BATCHHWPCONV.EXE",
+    "shortcuts": [
+        [
+            "bin\\BATCHHWPCONV.EXE",
+            "HWP Converter"
+        ]
+    ]
+}

--- a/bucket/hwp-converter.json
+++ b/bucket/hwp-converter.json
@@ -7,27 +7,11 @@
     "architecture": {
         "64bit": {
             "url": "https://download.microsoft.com/download/1/8/D/18D83826-2F32-4535-8C6A-686149B39DF8/hwpconverter_x64_en-us.exe#dl.7z",
-            "hash": "1a6a69c00a60f0ba44527c345017e4aba309b3e0003ee463721913ab9c6d9302",
-            "installer": {
-                "script": [
-                    "Remove-Item \"$dir\\files.cat\"",
-                    "New-Item -Path \"$dir\" -Name \"bin\" -ItemType directory | Out-Null",
-                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'FILES\\Program Files\\Microsoft Office\\OFF16.x64'",
-                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'System64'"
-                ]
-            }
+            "hash": "1a6a69c00a60f0ba44527c345017e4aba309b3e0003ee463721913ab9c6d9302"
         },
         "32bit": {
             "url": "https://download.microsoft.com/download/1/8/D/18D83826-2F32-4535-8C6A-686149B39DF8/hwpconverter_x86_en-us.exe#dl.7z",
-            "hash": "48d599393a0a15b9c81a453bfa2e8db5d546e4cb63045cc382629f4fa35db82e",
-            "installer": {
-                "script": [
-                    "Remove-Item \"$dir\\files.cat\"",
-                    "New-Item -Path \"$dir\" -Name \"bin\" -ItemType directory | Out-Null",
-                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'FILES\\Program Files\\Microsoft Office\\Office16'",
-                    "Expand-MSIArchive \"$dir\\hwpconverter.msi\" -DestinationPath \"$dir\\bin\" -ExtractDir 'System'"
-                ]
-            }
+            "hash": "48d599393a0a15b9c81a453bfa2e8db5d546e4cb63045cc382629f4fa35db82e"
         }
     },
     "installer": {
@@ -39,7 +23,6 @@
             "'files.cat', 'System*', 'FILES', 'swidtags' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }"
         ]
     },
-    "bin": "bin\\BATCHHWPCONV.EXE",
     "shortcuts": [
         [
             "bin\\BATCHHWPCONV.EXE",


### PR DESCRIPTION
Hanword HWP document converter for Microsoft Word is a tool which allows you to convert as DOCX files. Bulk converting by folder-bases is also allowed. It's a Microsoft's **official** tool!

![image](https://user-images.githubusercontent.com/4435445/72391514-ac038c80-3770-11ea-8998-5b8a224112d6.png)
