### PR TITLE
multicommander@9.5.3.2578: Fix hash

### DIFF
--- a/bucket/multicommander.json
+++ b/bucket/multicommander.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "http://multicommander.com/files/updates/MultiCommander_x64_Portable_(9.5.3.2578).zip",
-            "hash": "sha1:9780e5d12b62b71492028cb60f653e8d8bdde0cc"
+            "hash": "sha1:bbbcb817f42a8d5ead0d01fc7c05ecf36a03a093"
         },
         "32bit": {
             "url": "http://multicommander.com/files/updates/MultiCommander_win32_Portable_(9.5.3.2578).zip",
-            "hash": "sha1:4824b5c259c3cff7f3aa39e1be66b8f0c158f881"
+            "hash": "sha1:ced86c6e485a35f399d45689787335b2e5359f28"
         }
     },
     "persist": [


### PR DESCRIPTION
The hashes advertised on multicommander.com do not match the hashes of the
downloaded files.  However, the downloaded files are 'clean' according to
virustotal.com