### PR TITLE
eac: Add version 1.3

### DIFF
--- a/bucket/eac.json
+++ b/bucket/eac.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.3",
+    "description": "A free audio CD grabber using standard drives.",
+    "homepage": "http://www.exactaudiocopy.de/",
+    "license": "Freeware",
+    "url": "http://www.exactaudiocopy.de/eac-1.3.exe#dl.7z",
+    "hash": "sha1:49f1028bd2b0cce0829250430bf8771c4a766daf",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Empty*\", \"$dir\\uninst*\" -Recurse",
+    "shortcuts": [
+        [
+            "EAC.exe",
+            "Exact Audio Copy"
+        ]
+    ],
+    "checkver": {
+        "url": "http://www.exactaudiocopy.de/en/index.php/resources/download/",
+        "regex": "V([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "http://www.exactaudiocopy.de/eac-$version.exe#dl.7z",
+        "hash": {
+            "url": "http://www.exactaudiocopy.de/en/index.php/resources/download/",
+            "regex": "$sha1"
+        }
+    }
+}

--- a/bucket/eac.json
+++ b/bucket/eac.json
@@ -1,11 +1,11 @@
 {
     "version": "1.3",
-    "description": "A free audio CD grabber using standard drives.",
-    "homepage": "http://www.exactaudiocopy.de/",
+    "description": "Exact Audio Copy using standard drives",
+    "homepage": "http://www.exactaudiocopy.de",
     "license": "Freeware",
-    "url": "http://www.exactaudiocopy.de/eac-1.3.exe#dl.7z",
+    "url": "http://www.exactaudiocopy.de/eac-1.3.exe#/dl.7z",
     "hash": "sha1:49f1028bd2b0cce0829250430bf8771c4a766daf",
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Empty*\", \"$dir\\uninst*\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Empty*\", \"$dir\\uninst*\" -Recurse",
     "shortcuts": [
         [
             "EAC.exe",
@@ -14,10 +14,10 @@
     ],
     "checkver": {
         "url": "http://www.exactaudiocopy.de/en/index.php/resources/download/",
-        "regex": "V([\\d.]+)"
+        "regex": "Exact Audio Copy\\s+V([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://www.exactaudiocopy.de/eac-$version.exe#dl.7z",
+        "url": "http://www.exactaudiocopy.de/eac-$version.exe#/dl.7z",
         "hash": {
             "url": "http://www.exactaudiocopy.de/en/index.php/resources/download/",
             "regex": "$sha1"


### PR DESCRIPTION
A commonly-used audio CD grabber for accurate rip. [Website](http://www.exactaudiocopy.de/)