### PR TITLE
awake: Add shortcuts

### DIFF
--- a/bucket/awake.json
+++ b/bucket/awake.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://github.com/gdegeneve/Awake",
-    "description": "A tool that resides in system tray and prevents the computer from entering the idle state.",
+    "description": "Prevents the computer from entering the idle state.",
     "version": "1.4.2",
     "license": "MIT",
     "url": "https://github.com/gdegeneve/Awake/releases/download/v1.4.2/Awake.exe",

--- a/bucket/awake.json
+++ b/bucket/awake.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/gdegeneve/Awake/releases/download/v1.4.2/Awake.exe",
     "hash": "ae993364229195427519b33cb8b4dcc53a03244e4046a06ca655cb781978d27e",
+    "bin": "Awake.exe",
     "shortcuts": [
         [
             "Awake.exe",

--- a/bucket/awake.json
+++ b/bucket/awake.json
@@ -5,7 +5,12 @@
     "license": "MIT",
     "url": "https://github.com/gdegeneve/Awake/releases/download/v1.4.2/Awake.exe",
     "hash": "ae993364229195427519b33cb8b4dcc53a03244e4046a06ca655cb781978d27e",
-    "bin": "Awake.exe",
+    "shortcuts": [
+        [
+            "Awake.exe",
+            "Awake"
+        ]
+    ],
     "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/gdegeneve/Awake/releases/download/v$version/Awake.exe"


### PR DESCRIPTION
Awake is not a command line program. Should remove `bin`, and add `shortcuts`.