### PR TITLE
lighttable@0.8.1: Add Shortcuts

### DIFF
--- a/bucket/lighttable.json
+++ b/bucket/lighttable.json
@@ -5,6 +5,7 @@
     "license": "MIT",
     "url": "https://github.com/LightTable/LightTable/releases/download/0.8.1/lighttable-0.8.1-windows.zip",
     "hash": "cb0496343bb9c7ebe851e6169aa02fce8fec941d92dfeee21966f4ea311f0329",
+    "extract_dir": "lighttable-0.8.1-windows",
     "bin": "LightTable.exe",
     "shortcuts": [
         [
@@ -12,7 +13,6 @@
             "LightTable"
         ]
     ],
-    "extract_dir": "lighttable-0.8.1-windows",
     "checkver": {
         "github": "https://github.com/lighttable/lighttable"
     },

--- a/bucket/lighttable.json
+++ b/bucket/lighttable.json
@@ -6,6 +6,12 @@
     "url": "https://github.com/LightTable/LightTable/releases/download/0.8.1/lighttable-0.8.1-windows.zip",
     "hash": "cb0496343bb9c7ebe851e6169aa02fce8fec941d92dfeee21966f4ea311f0329",
     "bin": "LightTable.exe",
+    "shortcuts": [
+        [
+            "LightTable.exe",
+            "LightTable"
+        ]
+    ],
     "extract_dir": "lighttable-0.8.1-windows",
     "checkver": {
         "github": "https://github.com/lighttable/lighttable"


### PR DESCRIPTION
Being a GUI Application, I feel like LightTable should be accessible from the start menu, even if its icon is just the default Electron one.