### PR TITLE
nswagstudio: Add version 13.2.2

### DIFF
--- a/bucket/nswagstudio.json
+++ b/bucket/nswagstudio.json
@@ -1,0 +1,34 @@
+{
+    "version": "13.2.2",
+    "description": "The OpenAPI/Swagger API toolchain for .NET and TypeScript",
+    "homepage": "https://github.com/RicoSuter/NSwag",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://ci.appveyor.com/api/buildjobs/pl7r86mp8k60ccx2/artifacts/src/NSwagStudio.Installer/bin/Release/NSwagStudio.msi",
+            "hash": "f77401db0c3c41a32af760cef9eb1cc8d86e2537f59b4e3a862a5aee6d96b573"
+        }
+    },
+    "extract_dir": "Rico Suter\\NSwagStudio",
+    "bin": [
+        "NSwagStudio.exe",
+        "Win\\NSwag.exe"
+    ],
+    "shortcuts": [
+        [
+            "NSwagStudio.exe",
+            "NSwagStudio"
+        ]
+    ],
+    "checkver": {
+        "url": "https://rsuter.com/Projects/NSwagStudio/updates.php",
+        "regex": "(?sm)<version>([\\d.]+).*?https://ci.appveyor.com/(?<url>.*)</download"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ci.appveyor.com/$matchUrl"
+            }
+        }
+    }
+}


### PR DESCRIPTION
~~`NSwagStudio.*.nupkg` is built with this [NSwagStudio.nuspec](https://github.com/RicoSuter/NSwag/blob/master/src/NSwagStudio.Chocolatey/NSwagStudio.nuspec). It contains `NSwagStudio.msi` inside `tools\` and some chocolately ps1 files, and bunch of other files outside of the directory. That's why I've used `"extract_to"`.~~