### PR TITLE
multicommander: Update to version 9.6.1.2582

### DIFF
--- a/bucket/multicommander.json
+++ b/bucket/multicommander.json
@@ -30,8 +30,8 @@
         ]
     ],
     "checkver": {
-        "url": "http://multicommander.com/downloads",
-        "regex": "\\(([\\d\\.]+)\\)\\.zip"
+        "url": "http://multicommander.com/updates/version.xml",
+        "xpath": "/updates/multicommander/stable/@version"
     },
     "autoupdate": {
         "architecture": {
@@ -41,10 +41,6 @@
             "32bit": {
                 "url": "http://multicommander.com/files/updates/MultiCommander_win32_Portable_($version).zip"
             }
-        },
-        "hash": {
-            "url": "http://multicommander.com/downloads",
-            "find": "$basename.+([A-Fa-f\\d]{40})"
         }
     }
 }

--- a/bucket/multicommander.json
+++ b/bucket/multicommander.json
@@ -16,18 +16,18 @@
             "hash": "d2b56e757e5b87d8b93431fdb54ebb922c5d829ed7913a7014af686941472028"
         }
     },
-    "persist": [
-        "Config",
-        "SessionConfig",
-        "Extensions",
-        "UserData"
-    ],
     "bin": "MultiCommander.exe",
     "shortcuts": [
         [
             "MultiCommander.exe",
             "Multi Commander"
         ]
+    ],
+    "persist": [
+        "Config",
+        "SessionConfig",
+        "Extensions",
+        "UserData"
     ],
     "checkver": {
         "url": "http://multicommander.com/updates/version.xml",

--- a/bucket/multicommander.json
+++ b/bucket/multicommander.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.6.0.2580",
+    "version": "9.6.1.2582",
     "description": "A multi-tabbed file manager and is an alternative to the standard Windows Explorer",
     "homepage": "http://multicommander.com/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "http://multicommander.com/files/updates/MultiCommander_x64_Portable_(9.6.0.2580).zip",
-            "hash": "sha1:da188830946f3a2fba5a4a79bf19e81fe8944233"
+            "url": "http://multicommander.com/files/updates/MultiCommander_x64_Portable_(9.6.1.2582).zip",
+            "hash": "d9059fad9924c6da92636d8be40274e3aa6d45a1614a9ee629fc4c6702903124"
         },
         "32bit": {
-            "url": "http://multicommander.com/files/updates/MultiCommander_win32_Portable_(9.6.0.2580).zip",
-            "hash": "sha1:2b09d56b0ff3dcec089815d2dca9c894a861255e"
+            "url": "http://multicommander.com/files/updates/MultiCommander_win32_Portable_(9.6.1.2582).zip",
+            "hash": "d2b56e757e5b87d8b93431fdb54ebb922c5d829ed7913a7014af686941472028"
         }
     },
     "persist": [


### PR DESCRIPTION
Multicommander's website displays an older version than the latest version offered by MultiUpdate (companion tool of multicommander): by using the same version info download as MultiUpdate, we can track the latest version more closely.

I took the opportunity to update multicommander to the latest version at the same time.