### PR TITLE
material-maker: Add version 0.8

### DIFF
--- a/bucket/material-maker.json
+++ b/bucket/material-maker.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.8",
+    "description": "Extensible procedural material generator",
+    "homepage": "https://rodzilla.itch.io/material-maker",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/RodZill4/godot-procedural-textures/releases/download/0.8/material_maker_0_8_windows.zip",
+            "hash": "67ea14278e6f6ff9d9143b39d014503b75c4768c1bc7bbf85840e3f2f63fa83b"
+        }
+    },
+    "extract_dir": "material_maker_0.8_windows",
+    "bin": "material_maker.exe",
+    "shortcuts": [
+        [
+            "material_maker.exe",
+            "Material Maker"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/RodZill4/godot-procedural-textures"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/RodZill4/godot-procedural-textures/releases/download/$version/material_maker_$underscoreVersion_windows.zip"
+            }
+        },
+        "extract_dir": "material_maker_$version_windows"
+    }
+}


### PR DESCRIPTION
Material Maker is an open source, extensible procedural material generation tool for use with physically-based rendering engines.