### PR TITLE
 fadetop: Add version 3.1.0.171

### DIFF
--- a/bucket/fadetop.json
+++ b/bucket/fadetop.json
@@ -1,0 +1,25 @@
+{
+    "version": "3.1.0.171",
+    "description": "Simple and fun break reminder",
+    "homepage": "https://www.fadetop.com",
+    "license": "Freeware",
+    "url": "https://www.fadetop.com/action.php?an=download&as=ft_p#/FadeTop.zip",
+    "hash": "6a2db71bc0fae6adae1edcf06d3ee626143e53d10e0190226c66384eae5c18ba",
+    "pre_install": "if (-not (Test-Path \"$persist_dir\\Settings.xml\")) { New-Item \"$dir\\Settings.xml\" | Out-Null }",
+    "bin": "FadeTop.exe",
+    "shortcuts": [
+        [
+            "FadeTop.exe",
+            "FadeTop"
+        ]
+    ],
+    "persist": "Settings.xml",
+    "checkver": {
+        "url": "https://www.fadetop.com/action.php?an=checkforupdates&as=ft_p&ver=3.1.0.170",
+        "regex": ">([\\d.]+)<",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "https://www.fadetop.com/action.php?an=download&as=ft_p#/FadeTop.zip"
+    }
+}


### PR DESCRIPTION
I added two apps to remind myself to take regular breaks.

Both have their quirks:
- FadeTop: is a portable app but I was unable to make the persist mechanism work because the Settings.xml is a file next to the executable, not in a directory next to the executable
- stretchly: is not really portable, it stores its settings in AppData\Roaming\stretchly