### PR TITLE
sql-workbench-dev@125.5: Fix shim

### DIFF
--- a/bucket/sql-workbench-dev.json
+++ b/bucket/sql-workbench-dev.json
@@ -10,12 +10,6 @@
     "hash": "sha1:9558841b129bc83a50e6d8b7262fbffd8a8f6c7e",
     "architecture": {
         "64bit": {
-            "bin": [
-                [
-                    "sqlwbconsole.cmd",
-                    "sqlwbconsole"
-                ]
-            ],
             "shortcuts": [
                 [
                     "SQLWorkbench64.exe",
@@ -24,12 +18,6 @@
             ]
         },
         "32bit": {
-            "bin": [
-                [
-                    "sqlwbconsole.cmd",
-                    "sqlwbconsole"
-                ]
-            ],
             "shortcuts": [
                 [
                     "SQLWorkbench.exe",
@@ -38,6 +26,7 @@
             ]
         }
     },
+    "bin": "sqlwbconsole.cmd",
     "persist": [
         "ext",
         "sqlwbconsole64.ini",

--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -5,7 +5,7 @@
         "url": "https://www.teamviewer.com/en/eula/"
     },
     "description": "TeamViewer is proprietary computer software for remote control, desktop sharing, online meetings, web conferencing and file transfer between computers.",
-    "version": "15.1.3937",
+    "version": "15.2.2756",
     "url": "https://download.teamviewer.com/download/version_15x/TeamViewerPortable.zip",
     "hash": "9dd663b3448db6438b845f6743b25e622fb72c16961707152a18be3630e8b7a8",
     "bin": "teamviewer.exe",


### PR DESCRIPTION
Files sqlwbconsole.exe and sqlwbconsole64.exe don't exist in version 125.5. Shims linked to sqlwbconsole.cmd.