### PR TITLE
qbittorrent: Update checkver to use sf.net

### DIFF
--- a/bucket/qbittorrent-portable.json
+++ b/bucket/qbittorrent-portable.json
@@ -23,24 +23,16 @@
     ],
     "persist": "profile",
     "checkver": {
-        "url": "https://www.qbittorrent.org/download.php",
-        "regex": "Latest:\\s+v([\\d.]+)"
+        "url": "https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent/",
+        "re": "/qbittorrent/qbittorrent-([\\d.]+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.qbittorrent.org/download.php",
-                    "regex": "64-bit.*\\s+.*<code>$sha256</code>"
-                }
+                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.qbittorrent.org/download.php",
-                    "regex": "32-bit.*\\s+.*<code>$sha256</code>"
-                }
+                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z"
             }
         }
     }

--- a/bucket/qbittorrent.json
+++ b/bucket/qbittorrent.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.2.1/qbittorrent_4.2.1_x64_setup.exe#/dl.7z",
-            "hash": "f826a56d9deca1d673c64e36e7070f01b02de842e0a627b2f12bf28d864fb061"
+            "hash": "sha1:192a86af595843062acda37a1e2ad0363fb0c157"
         },
         "32bit": {
             "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-4.2.1/qbittorrent_4.2.1_setup.exe#/dl.7z",
-            "hash": "6fd8ae6bb54314f9de01bc4427d0da7e3a1c886adb802b679db9c1abc4ef9b94"
+            "hash": "sha1:d9576e61e63c0b56c25135c662dc4c59688f4a1a"
         }
     },
     "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
@@ -25,24 +25,16 @@
         ]
     ],
     "checkver": {
-        "url": "https://www.qbittorrent.org/download.php",
-        "re": "Latest:\\s+v([\\d.]+)"
+        "url": "https://sourceforge.net/projects/qbittorrent/rss?path=/qbittorrent/",
+        "re": "/qbittorrent/qbittorrent-([\\d.]+)/"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.qbittorrent.org/download.php",
-                    "find": "64-bit.*\\s+.*<code>([a-fA-F0-9]{40,128})</code>"
-                }
+                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_x64_setup.exe#/dl.7z"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z",
-                "hash": {
-                    "url": "https://www.qbittorrent.org/download.php",
-                    "find": "32-bit.*\\s+.*<code>([a-fA-F0-9]{40,128})</code>"
-                }
+                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Addresses: The operation has timed out. URL https://www.qbittorrent.org/download.php is not valid. See #2308.