### PR TITLE
notepadplusplus: use GitHub release URLs

### DIFF
--- a/bucket/notepadplusplus.json
+++ b/bucket/notepadplusplus.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.4/npp.7.8.4.bin.x64.7z",
+            "url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.8.4/npp.7.8.4.bin.x64.7z",
             "hash": "5e2658a49404fc1b23a0fc3915b283ac190f9f6da2e86a49708602b77e50595d"
         },
         "32bit": {
-            "url": "http://download.notepad-plus-plus.org/repository/7.x/7.8.4/npp.7.8.4.bin.7z",
+            "url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v7.8.4/npp.7.8.4.bin.7z",
             "hash": "421dca4dcfb9ca8ae81bf51bd5c64d1432229ec89708efb3664a3603617824e2"
         }
     },
@@ -40,10 +40,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.x64.7z"
+                "url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v$version/npp.$version.bin.x64.7z"
             },
             "32bit": {
-                "url": "http://download.notepad-plus-plus.org/repository/$majorVersion.x/$version/npp.$version.bin.7z"
+                "url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v$version/npp.$version.bin.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
Download from download.notepad-plus-plus.org wasn't working for me so I redirected the download to the project's GitHub releases page.