### PR TITLE
pageedit: Add version 1.0.0

### DIFF
--- a/bucket/pageedit.json
+++ b/bucket/pageedit.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/1.1.0/PageEdit-1.0.0-Windows-x64-Setup.exe",
+            "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/1.1.0/PageEdit-1.1.0-Windows-x64-Setup.exe",
             "hash": "96432743dfaa6e7d76a7927c340b0070fb4d24c744e11ae5555262b13a0a7405"
         }
     },

--- a/bucket/pageedit.json
+++ b/bucket/pageedit.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "homepage": "https://github.com/Sigil-Ebook/PageEdit",
-    "description": "ePub XHTML Visual Editor.",
+    "description": "ePub XHTML Visual Editor",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
@@ -17,9 +17,7 @@
             "PageEdit"
         ]
     ],
-    "checkver": {
-        "github": "https://github.com/Sigil-Ebook/PageEdit"
-    },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/pageedit.json
+++ b/bucket/pageedit.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "homepage": "https://github.com/Sigil-Ebook/PageEdit",
     "description": "ePub XHTML Visual Editor",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/1.0.0/PageEdit-1.0.0-Windows-x64-Setup.exe",
-            "hash": "bdde5e73aae242ce2b8b367d4f373d1e44f316a61bd72487f3b6cbeb5f2cfc37"
+            "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/1.1.0/PageEdit-1.0.0-Windows-x64-Setup.exe",
+            "hash": "96432743dfaa6e7d76a7927c340b0070fb4d24c744e11ae5555262b13a0a7405"
         }
     },
     "innosetup": true,

--- a/bucket/pageedit.json
+++ b/bucket/pageedit.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.0.0",
+    "homepage": "https://github.com/Sigil-Ebook/PageEdit",
+    "description": "ePub XHTML Visual Editor.",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/1.0.0/PageEdit-1.0.0-Windows-x64-Setup.exe",
+            "hash": "bdde5e73aae242ce2b8b367d4f373d1e44f316a61bd72487f3b6cbeb5f2cfc37"
+        }
+    },
+    "innosetup": true,
+    "bin": "PageEdit.exe",
+    "shortcuts": [
+        [
+            "PageEdit.exe",
+            "PageEdit"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Sigil-Ebook/PageEdit"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Sigil-Ebook/PageEdit/releases/download/$version/PageEdit-$version-Windows-x64-Setup.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/PageEdit-$version-CHECKSUMS.sha256.txt"
+        }
+    }
+}


### PR DESCRIPTION
pageedit is a companion app of sigil (en epub editor) and created when sigil decided to remove the xhtml visual editor.