### PR TITLE
streamwriter: Add version 5.5.0.0.788

### DIFF
--- a/bucket/streamwriter.json
+++ b/bucket/streamwriter.json
@@ -16,7 +16,7 @@
         "\"@ | Set-Content -LiteralPath \"$dir\\streamwriter_settings.ini\" -Encoding Ascii",
         "}",
         "if (Test-Path \"$persist_dir\\streamwriter_data.dat\") {",
-        "    Copy-Item \"$persist_dir\\streamwriter_data.dat\" -Destination \"$dir\"",
+        "    Copy-Item \"$persist_dir\\streamwriter_data.dat\" \"$dir\"",
         "}"
     ],
     "uninstaller": {

--- a/bucket/streamwriter.json
+++ b/bucket/streamwriter.json
@@ -1,0 +1,28 @@
+{
+    "version": "5.5.0.0.788",
+    "description": "Records music broadcasted by Internet radio stations.",
+    "homepage": "https://streamwriter.org/en/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://streamwriter.org/en/downloads/3/#/dl.zip",
+    "hash": "d9939da465b718c57ac28176ac6262397eca91addf9221b52bf6533a65b6ffc9",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\streamwriter_settings.ini\")) {",
+        "    Set-Content \"$dir\\streamwriter_settings.ini\" \"[Settings]`nAutoUpdate=0\" -Encoding Ascii | Out-Null",
+        "}"
+    ],
+    "bin": "streamwriter.exe",
+    "shortcuts": [
+        [
+            "streamwriter.exe",
+            "streamWriter"
+        ]
+    ],
+    "persist": "streamwriter_settings.ini",
+    "checkver": {
+        "regex": "(?sm)streamwriter,\\srev\\.\\s(\\d+).*?Current version:\\s([\\d.]+)",
+        "replace": "${2}.${1}"
+    },
+    "autoupdate": {
+        "url": "https://streamwriter.org/en/downloads/3/#/dl.zip"
+    }
+}

--- a/bucket/streamwriter.json
+++ b/bucket/streamwriter.json
@@ -7,9 +7,25 @@
     "hash": "d9939da465b718c57ac28176ac6262397eca91addf9221b52bf6533a65b6ffc9",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\streamwriter_settings.ini\")) {",
-        "    Set-Content \"$dir\\streamwriter_settings.ini\" \"[Settings]`nAutoUpdate=0\" -Encoding Ascii | Out-Null",
+        "    $cur = current_dir \"$dir\"",
+        "    @\"",
+        "[Settings]",
+        "AutoUpdate=0",
+        "Dir=$cur\\Music",
+        "DirAuto=$cur\\Music",
+        "\"@ | Set-Content -LiteralPath \"$dir\\streamwriter_settings.ini\" -Encoding Ascii",
+        "}",
+        "if (Test-Path \"$persist_dir\\streamwriter_data.dat\") {",
+        "    Copy-Item \"$persist_dir\\streamwriter_data.dat\" -Destination \"$dir\"",
         "}"
     ],
+    "uninstaller": {
+        "script": [
+            "if (Test-Path \"$dir\\streamwriter_data.dat\") {",
+            "    Copy-Item \"$dir\\streamwriter_data.dat\" -Destination \"$persist_dir\" -Force",
+            "}"
+        ]
+    },
     "bin": "streamwriter.exe",
     "shortcuts": [
         [

--- a/bucket/streamwriter.json
+++ b/bucket/streamwriter.json
@@ -22,7 +22,7 @@
     "uninstaller": {
         "script": [
             "if (Test-Path \"$dir\\streamwriter_data.dat\") {",
-            "    Copy-Item \"$dir\\streamwriter_data.dat\" -Destination \"$persist_dir\" -Force",
+            "    Copy-Item \"$dir\\streamwriter_data.dat\" \"$persist_dir\" -Force",
             "}"
         ]
     },

--- a/bucket/streamwriter.json
+++ b/bucket/streamwriter.json
@@ -17,7 +17,10 @@
             "streamWriter"
         ]
     ],
-    "persist": "streamwriter_settings.ini",
+    "persist": [
+        "Music",
+        "streamwriter_settings.ini"
+    ],
     "checkver": {
         "regex": "(?sm)streamwriter,\\srev\\.\\s(\\d+).*?Current version:\\s([\\d.]+)",
         "replace": "${2}.${1}"


### PR DESCRIPTION
close #3466

**streamWriter** ([homepage](https://streamwriter.org/en/)) is an application that records music broadcasted by Internet radio stations.

Notes:

* **license**: The *GPL-3.0-or-later* license can be found in the "Application information" section of the main program.

* **pre_install**: The content written to `streamwriter_settings.ini` makes "search for updates" unchecked by default in the setup dialogs. (the setup dialogs will appear when users run the program for the first time)

* *StreamWriter* saves some of its data in `streamwriter_data.dat`.
 ~I tried to put the file in *persist*, but an empty streamwriter_data.dat will cause error messages to show up.~ Use "copy over method" to persist `streamwriter_data.dat`.

> If streamWriter is used in portable mode, all settings are saved to the folder that contains streamwriter.exe - configuration usually saved to the registry will be saved to streamwriter_settings.ini, data will be saved to streamwriter_data.dat as in installed mode.

(https://streamwriter.org/en/wiki/artikel/details/)
