### PR TITLE
pcmeter: Add version 0.4

### DIFF
--- a/bucket/pcmeter.json
+++ b/bucket/pcmeter.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.4",
+    "description": "CPU and graphic card monitor",
+    "homepage": "http://addgadgets.com/pc_meter/",
+    "license": "MPL-2.0",
+    "url": "http://addgadgets.com/download/PCMeter.zip",
+    "hash": "eb258a52a6f9e9a6e771ec849d56e84ddf46af88e79e1434fc2b4a675b64524f",
+    "extract_dir": "PCMeterV4",
+    "bin": [
+        [
+            "PCMeterV0.4.exe",
+            "PCMeter"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "PCMeterV0.4.exe",
+            "PCMeter"
+        ]
+    ]
+}


### PR DESCRIPTION
**PCMeter** ([homepage](http://addgadgets.com/pc_meter/)) is a CPU and graphic card monitor.

Notes:
* **checkver/autoupdate** is not needed because *PCMeter* has not been updated since 2013.