### PR TITLE
lantern-client: Revert to version 5.5.6

### DIFF
--- a/bucket/lantern-client.json
+++ b/bucket/lantern-client.json
@@ -1,7 +1,7 @@
 {
     "##": "Removing checkver/autoupdate since the installer cannot be properly extracted after version 5.5.6.",
     "homepage": "https://getlantern.org",
-    "description": "An HTTP/HTTPS proxy",
+    "description": "HTTP/HTTPS proxy",
     "version": "5.5.6",
     "license": "Apache-2.0",
     "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-5.5.6.exe#/dl.7z",

--- a/bucket/lantern-client.json
+++ b/bucket/lantern-client.json
@@ -1,10 +1,11 @@
 {
+    "##": "Removing checkver/autoupdate since the installer cannot be properly extracted after version 5.5.6.",
     "homepage": "https://getlantern.org",
     "description": "An HTTP/HTTPS proxy",
-    "version": "5.8.1",
+    "version": "5.5.6",
     "license": "Apache-2.0",
-    "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer.exe#/dl.7z",
-    "hash": "f11c08f0d408acb838a0a8fd7d99f7e870ca894cff4bcf2cb3d21727e2d80eb1",
+    "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-5.5.6.exe#/dl.7z",
+    "hash": "edd9ccba5ad0cf0262baade11bf3b0c300a96f1638553d46baaae4de7d208cfb",
     "pre_install": [
         "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninstall.exe.nsis\" -Recurse",
         "if (!(Test-Path \"$persist_dir\\settings.yaml\")) { New-Item \"$dir\\settings.yaml\" | Out-Null }"
@@ -18,15 +19,5 @@
             "lantern.ico"
         ]
     ],
-    "persist": "settings.yaml",
-    "checkver": {
-        "url": "https://github.com/getlantern/lantern-binaries/commits/master/lantern-installer.exe",
-        "regex": "Lantern ([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer.exe#/dl.7z",
-        "hash": {
-            "url": "$url.sha256"
-        }
-    }
+    "persist": "settings.yaml"
 }


### PR DESCRIPTION
Fix #3581

The installer for version `5.8.1` cannot be properly extracted. Therefore we need to revert the package to version `5.5.6` and remove checkver/autoupdate.