### PR TITLE
migrate: Add version 4.8.0

### DIFF
--- a/bucket/migrate.json
+++ b/bucket/migrate.json
@@ -1,0 +1,26 @@
+{
+    "homepage": "https://github.com/golang-migrate/migrate",
+    "description": "Migrate reads migrations from sources and applies them in correct order to a database.",
+    "license": "MIT",
+    "version": "4.8.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/golang-migrate/migrate/releases/download/v4.8.0/migrate.windows-amd64.exe.tar.gz",
+            "hash": "719fbaf4ba4b3a52e5181db3d82e9aa04d43b28f02be70ab8dc971df9b0c416e"
+        }
+    },
+    "bin": [
+        [
+            "migrate.windows-amd64.exe",
+            "migrate"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/golang-migrate/migrate/releases/download/$version/migrate.windows-amd64.exe.tar.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a very useful CLI when working with databases.
It is used to migrate/rollback database changes over time.

The current version (4.8.0) is only released as a 64-bit windows exe, so this bucket only supports 64-bit installs.
I asked if upstream could provide 32-bit windows binaries in the future in https://github.com/golang-migrate/migrate/issues/339