### PR TITLE
deepl: Add version 1.11.0

### DIFF
--- a/bucket/deepl.json
+++ b/bucket/deepl.json
@@ -1,0 +1,56 @@
+{
+    "homepage": "https://www.deepl.com/",
+    "description": "An online translator",
+    "version": "1.11.0",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.deepl.com/pro-license.html#free"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://www.deepl.com/windows/download/x64/1_11_0/DeepL-1.11.0-full.nupkg",
+            "hash": "sha1:dc6c72b76078eb74b6a3a69c7c994ec88158b1e6"
+        },
+        "32bit": {
+            "url": "https://www.deepl.com/windows/download/x86/1_11_0/DeepL-1.11.0-full.nupkg",
+            "hash": "sha1:0bb32a7a91c23048e50d3fc665895e8f5ceca890"
+        }
+    },
+    "pre_install": [
+        "$null = New-Item \"$dir\\DeepL\" -Type Directory -Force",
+        "$null = New-Item \"$dir\\DeepL\\packages\" -Type Directory -Force",
+        "Move-Item \"$dir\\net45\" \"$dir\\DeepL\\app-$version\"",
+        "Move-Item \"$dir\\DeepL\\app-$version\\DeepL_ExecutionStub.exe\" \"$dir\\DeepL\\DeepL.exe\"",
+        "\"0000000000000000000000000000000000000000 DeepL-$version-full.nupkg 1\" | Set-Content \"$dir\\DeepL\\packages\\RELEASES\""
+    ],
+    "extract_dir": "lib",
+    "bin": "DeepL\\DeepL.exe",
+    "shortcuts": [
+        [
+            "DeepL\\DeepL.exe",
+            "DeepL"
+        ]
+    ],
+    "checkver": {
+        "url": "https://appdownload.deepl.com/windows/x64/RELEASES",
+        "regex": "DeepL-([\\d.]+)-full.nupkg"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.deepl.com/windows/download/x64/$underscoreVersion/DeepL-$version-full.nupkg",
+                "hash": {
+                    "url": "https://appdownload.deepl.com/windows/x64/RELEASES",
+                    "regex": "^$sha1 https"
+                }
+            },
+            "32bit": {
+                "url": "https://www.deepl.com/windows/download/x86/$underscoreVersion/DeepL-$version-full.nupkg",
+                "hash": {
+                    "url": "https://appdownload.deepl.com/windows/x86/RELEASES",
+                    "regex": "^$sha1 https"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will probably update itself because there is no way to disable Squirrel ...
It will also download itself every time if it doesn't find a specific directory structure.

```
D:.
│
├───1.11.0
└───current
    │
    └───DeepL (has to be the top directory)
        │   DeepL.exe (renamed `DeepL_ExecutionStub.exe`)
        │
        ├───app-1.11.0 (has to contain the actual app)
        │       DeepL.exe (actual exe)
        │
        └───packages (has to contain valid `RELEASES` file)
                .betaId
                RELEASES
```