### PR TITLE
openshot@2.5.0: Fix bin/shortcuts

### DIFF
--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -1,8 +1,12 @@
 {
-    "homepage": "https://www.openshot.org/",
     "version": "2.5.0",
+    "description": "Easy to use video editor",
+    "homepage": "https://www.openshot.org/",
     "license": "GPL-3.0-or-later",
-    "description": "Video editor",
+    "suggest": {
+        "Blender": "extras/blender",
+        "Inkscape": "extras/inkscape"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/OpenShot/openshot-qt/releases/download/v2.5.0/OpenShot-v2.5.0-x86_64.exe",
@@ -15,12 +19,7 @@
     },
     "innosetup": true,
     "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process '$dir\\launch-win.bat' -WorkingDirectory '$dir'\" -Encoding Ascii",
-    "bin": [
-        [
-            "openshot.ps1",
-            "openshot"
-        ]
-    ],
+    "bin": "openshot.ps1",
     "shortcuts": [
         [
             "launch-win.bat",
@@ -29,10 +28,6 @@
             "openshot-qt.exe"
         ]
     ],
-    "suggest": {
-        "Blender": "extras/blender",
-        "Inkscape": "extras/inkscape"
-    },
     "checkver": {
         "github": "https://github.com/OpenShot/openshot-qt"
     },

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -2,7 +2,7 @@
     "homepage": "https://www.openshot.org/",
     "version": "2.5.0",
     "license": "GPL-3.0-or-later",
-    "description": "An easy to use, quick to learn, and surprisingly powerful video editor.",
+    "description": "Video editor",
     "architecture": {
         "64bit": {
             "url": "https://github.com/OpenShot/openshot-qt/releases/download/v2.5.0/OpenShot-v2.5.0-x86_64.exe",
@@ -16,14 +16,16 @@
     "innosetup": true,
     "bin": [
         [
-            "launch.exe",
+            "launch-win.bat",
             "openshot"
         ]
     ],
     "shortcuts": [
         [
-            "launch.exe",
-            "OpenShot Video Editor"
+            "launch-win.bat",
+            "OpenShot Video Editor",
+            "",
+            "openshot-qt.exe"
         ]
     ],
     "suggest": {

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -14,7 +14,7 @@
         }
     },
     "innosetup": true,
-    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process `\"$dir\\launch-win.bat`\" -WorkingDirectory `\"$dir`\"\" -Encoding Ascii",
+    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process '$dir\\launch-win.bat' -WorkingDirectory '$dir'\" -Encoding Ascii",
     "bin": [
         [
             "openshot.ps1",

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -14,7 +14,7 @@
         }
     },
     "innosetup": true,
-    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process `\"$dir\\launch-win.bat`\" -WorkingDirectory `\"$dir`\"\"",
+    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process `\"$dir\\launch-win.bat`\" -WorkingDirectory `\"$dir`\"\" -Encoding Ascii",
     "bin": [
         [
             "openshot.ps1",

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -14,12 +14,8 @@
         }
     },
     "innosetup": true,
-    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process cmd -ArgumentList @('/c', `\"$dir\\launch-win.bat`\") -WorkingDirectory `\"$dir`\"\"",
+    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process `\"$dir\\launch-win.bat`\" -WorkingDirectory `\"$dir`\"\"",
     "bin": [
-        [
-            "launch-win.bat",
-            "openshot"
-        ],
         [
             "openshot.ps1",
             "openshot"

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -14,9 +14,14 @@
         }
     },
     "innosetup": true,
+    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process cmd -ArgumentList @('/c', `\"$dir\\launch-win.bat`\") -WorkingDirectory `\"$dir`\"\"",
     "bin": [
         [
             "launch-win.bat",
+            "openshot"
+        ],
+        [
+            "openshot.ps1",
             "openshot"
         ]
     ],


### PR DESCRIPTION
close #3601

* **Openshot** now uses `launch-win.bat` (which sets the env variables needed by the main program `openshot-qt.exe`) instead of `launch.exe`.

* Modify *description*.

additional notes:
* The `settings` folder under installation path only stores default settings. User settings are actually stored at `$Env:USERPROFILE\.openshot_qt`.

* Running `openshot-cli.exe` will also start the regular(GUI) interface. `openshot-cli.exe` is used for debug purposes. (See https://github.com/OpenShot/openshot-qt/pull/3106)