### PR TITLE
dust: Add version 0.5.0

### DIFF
--- a/bucket/dust.json
+++ b/bucket/dust.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://github.com/bootandy/dust/",
+    "description": "A more intuitive version of du in Rust",
+    "version": "0.5.0",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/bootandy/dust/releases/download/v0.5.0/dust-v0.5.0-x86_64-pc-windows-msvc.zip",
+            "hash": "5f88092d8b13c900c3eb7482ea66eb2f4136477e7e510daa11b6a23235eebeaa",
+            "extract_dir": "dust-v0.5.0-x86_64-pc-windows-msvc"
+        },
+        "32bit": {
+            "url": "https://github.com/bootandy/dust/releases/download/v0.5.0/dust-v0.5.0-i686-pc-windows-msvc.zip",
+            "hash": "a441f9d6b249c96d00baac68f5e0123f7ac776145466d05df6af678774d7fe80",
+            "extract_dir": "dust-v0.5.0-i686-pc-windows-msvc"
+        }
+    },
+    "bin": "dust.exe",
+    "checkver": {
+        "github": "https://github.com/bootandy/dust"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/bootandy/dust/releases/download/v$version/dust-v$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "dust-v$version-x86_64-pc-windows-msvc"
+            },
+            "32bit": {
+                "url": "https://github.com/bootandy/dust/releases/download/v$version/dust-v$version-i686-pc-windows-msvc.zip",
+                "extract_dir": "dust-v$version-i686-pc-windows-msvc"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dust is an alternative to unix du command with some nice properties. It's written in Rust and is a single executable.