### PR TITLE
eagleget-portable@2.1.5.10: Fix installation

### DIFF
--- a/bucket/eagleget-portable.json
+++ b/bucket/eagleget-portable.json
@@ -8,15 +8,12 @@
     "version": "2.1.5.10",
     "url": "http://dl.eagleget.com/latest/EagleGetProtable_2.1.5.10.zip",
     "hash": "sha1:d81b94fffae7ad5594844706ae59b5021256c680",
-    "extract_dir": "/",
     "shortcuts": [
         [
             "EagleGet.exe",
             "EagleGet"
         ]
     ],
-    "pre_install": "New-Item -ItemType Directory -Force -Path $dir\\EGDownloads | Out-Null",
-    "##": "EGDownloads directory will create after the first run.",
     "persist": [
         "EagleGet\\configs",
         "EGDownloads"


### PR DESCRIPTION
Remove `"extract_dir": "/"`, no need it.

```
Installing 'eagleget-portable' (2.1.5.10) [64bit]
Loading EagleGetProtable_2.1.5.10.zip from cache
Checking hash of EagleGetProtable_2.1.5.10.zip ... ok.
Extracting EagleGetProtable_2.1.5.10.zip ... done.
Running pre-install script...
Linking ~\scoop\apps\eagleget-portable\current => ~\scoop\apps\eagleget-portable\2.1.5.10
Creating shortcut for EagleGet (EagleGet.exe) failed: Couldn't find C:\Users\wenmin92\scoop\apps\eagleget-portable\current\EagleGet.exe
Persisting EagleGet\configs
The system cannot find the path specified.
Path not found - C:\Users\wenmin92\scoop\apps\eagleget-portable\current\EagleGet
Persisting EGDownloads
'eagleget-portable' (2.1.5.10) was installed successfully!
```