### PR TITLE
wizmouse: Add version 1.7.0.3

### DIFF
--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -8,7 +8,7 @@
     "pre_install": "if (-not (Test-Path \"$persist_dir\\wizmouse.ini\")) { New-Item \"$dir\\wizmouse.ini\" -ItemType File | Out-Null }",
     "bin": [
         "WizMouse.exe",
-        "WizMouseConfig.exe",
+        "WizMouseConfig.exe"
     ],
     "shortcuts": [
         [

--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -18,7 +18,7 @@
         [
             "WizMouseConfig.exe",
             "WizMouseConfig"
-        ],
+        ]
     ],
     "persist": "wizmouse.ini",
     "checkver": "v([\\d.]+)",

--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -1,6 +1,6 @@
 {
     "version": "1.7.0.3",
-    "description": "Allows mouse wheel scrolling for the window under the pointer instead of the currently focused window.",
+    "description": "Mouse enhancement utility that makes mouse wheel work on the window currently under the mouse pointer.",
     "homepage": "https://antibody-software.com/web/software/software/wizmouse-makes-your-mouse-wheel-work-on-the-window-under-the-mouse/",
     "license": "Unknown",
     "url": "https://antibody-software.com/files/wizmouse_1_7_0_3_portable.zip",

--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -1,0 +1,28 @@
+{
+    "version": "1.7.0.3",
+    "description": "Allows mouse wheel scrolling for the window under the pointer instead of the currently focused window.",
+    "homepage": "https://antibody-software.com/web/software/software/wizmouse-makes-your-mouse-wheel-work-on-the-window-under-the-mouse/",
+    "license": "Unknown",
+    "url": "https://antibody-software.com/files/wizmouse_1_7_0_3_portable.zip",
+    "hash": "452e75ef27db171e1bca55fc1762a1736da98b087eb12803a21de4c925edfbbd",
+    "pre_install": "if (-not (Test-Path \"$persist_dir\\wizmouse.ini\")) { New-Item \"$dir\\wizmouse.ini\" -ItemType File | Out-Null }",
+    "bin": [
+        "WizMouse.exe",
+        "WizMouseConfig.exe",
+    ],
+    "shortcuts": [
+        [
+            "WizMouse.exe",
+            "WizMouse"
+        ],
+        [
+            "WizMouseConfig.exe",
+            "WizMouseConfig"
+        ],
+    ],
+    "persist": "wizmouse.ini",
+    "checkver": "v([\\d.]+)",
+    "autoupdate": {
+        "url": "https://antibody-software.com/files/wizmouse_$underscoreVersion_portable.zip"
+    }
+}

--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -21,7 +21,7 @@
         ]
     ],
     "persist": "wizmouse.ini",
-    "checkver": "ver ([\\d.]+)",
+    "checkver": "([\\d.]+)\\?",
     "autoupdate": {
         "url": "https://antibody-software.com/files/wizmouse_$underscoreVersion_portable.zip"
     }

--- a/bucket/wizmouse.json
+++ b/bucket/wizmouse.json
@@ -21,7 +21,7 @@
         ]
     ],
     "persist": "wizmouse.ini",
-    "checkver": "v([\\d.]+)",
+    "checkver": "ver ([\\d.]+)",
     "autoupdate": {
         "url": "https://antibody-software.com/files/wizmouse_$underscoreVersion_portable.zip"
     }


### PR DESCRIPTION
There's already a couple of antibody-software.com programs in this bucket, but it's missing this quite useful utility.

> WizMouse is a mouse enhancement utility that makes your mouse wheel work on the window currently under the mouse pointer, instead of the currently focused window. This means you no longer have to click on a window before being able to scroll it with the mouse wheel. This is a far more comfortable and practical way to make use of the mouse wheel.
>
> WizMouse can also optionally enable the mouse wheel in applications that don't support it. It does this by translating mouse wheel commands into scroll bar commands that all applications can understand and process.