### PR TITLE
Transmission: add env variable TRANSMISSION_HOME to manifest

### DIFF
--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -1,16 +1,16 @@
 {
     "description": "Nightly builds of Firefox: the popular open source web browser.",
     "homepage": "https://www.mozilla.org/en-US/firefox/nightly/",
-    "version": "75.0a1.20200308095244",
+    "version": "75.0a1.20200307213339",
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/2020/03/2020-03-08-09-52-44-mozilla-central/firefox-75.0a1.en-US.win64.installer.exe#/dl.7z",
-            "hash": "sha512:f01864ab0db1e342dcb0e99c12318e163cf8b37b1ee25072a39e080c182eb07c913d95494387d19629bbdbb79b0f8605d8cb4553b3118d8404a8fc1198374cc1"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2020/03/2020-03-07-21-33-39-mozilla-central/firefox-75.0a1.en-US.win64.installer.exe#/dl.7z",
+            "hash": "sha512:dadd19d1b7e736c825a4a612cc69ff5204c8bda8096b27efb59b7e43c2d7aa1e3d444314790ef7d3814647671a1a463b43f9dd9fba0ce71279c8177d8e10bd85"
         },
         "32bit": {
-            "url": "https://archive.mozilla.org/pub/firefox/nightly/2020/03/2020-03-08-09-52-44-mozilla-central/firefox-75.0a1.en-US.win32.installer.exe#/dl.7z",
-            "hash": "sha512:b6250e6cc0c22ee04d046fde2b88ee799968e69c0301ec2e46a0b157b937d0505c13df2c0a4954d24be440523ca85ef5c1554271c7c389b7c2694895f3b992f1"
+            "url": "https://archive.mozilla.org/pub/firefox/nightly/2020/03/2020-03-07-21-33-39-mozilla-central/firefox-75.0a1.en-US.win32.installer.exe#/dl.7z",
+            "hash": "sha512:534f4fdd764863a978400365d56e02ddf9254a9366b9ec665b4577b179e0ff362b1edfc494f5196714314726817dacd4b8d405e17ac19c294865fe0a1187bdb7"
         }
     },
     "extract_dir": "core",

--- a/bucket/googlechrome-canary.json
+++ b/bucket/googlechrome-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "82.0.4078.2",
+    "version": "82.0.4078.0",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/canary",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/YWxcdaj0LNo7MYe--_TJWw_82.0.4078.2/82.0.4078.2_chrome_installer.exe#/dl.7z",
-            "hash": "8584fca194b75187527e1b07b84789d8f3b518609004e4b3276dd0b15dffd194"
+            "url": "https://dl.google.com/release2/chrome/QbqP0YsbtCb3kDsMTAT1bw_82.0.4078.0/82.0.4078.0_chrome_installer.exe#/dl.7z",
+            "hash": "9eb37d54f03df5df06836447e3963c3ba068de9a09cdfc5f4dd28a73b0ddf4f2"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/AMwKJ-6i4Q_S-yxBmPPaYF4_82.0.4078.2/82.0.4078.2_chrome_installer.exe#/dl.7z",
-            "hash": "e06031f268dfe04abd4b0ae6212dd7297e7362998c2967a8a869f1822a084a14"
+            "url": "https://dl.google.com/release2/chrome/GLFkpzAVzWhWUarSMPoE1g_82.0.4078.0/82.0.4078.0_chrome_installer.exe#/dl.7z",
+            "hash": "a6196c7148af51ca15a760431134e892e9e94aaf912af824d3de70f12d6df9e8"
         }
     },
     "installer": {

--- a/bucket/tinymediamanager.json
+++ b/bucket/tinymediamanager.json
@@ -5,9 +5,9 @@
         "identifier": "Apache-2.0",
         "url": "https://github.com/tinyMediaManager/tinyMediaManager/blob/master/LICENSE"
     },
-    "version": "3.1.4",
-    "url": "http://release.tinymediamanager.org/v3/dist/tmm_3.1.4_win.zip",
-    "hash": "sha1:2d061accc0ef31a18b12f20b9dff7efa66bb397c",
+    "version": "3.1.3",
+    "url": "http://release.tinymediamanager.org/v3/dist/tmm_3.1.3_win.zip",
+    "hash": "sha1:21dbe3db82be49923daedc2514be37b6fa5e4531",
     "bin": "tinyMediaManagerCMD.exe",
     "shortcuts": [
         [

--- a/bucket/transmission.json
+++ b/bucket/transmission.json
@@ -13,6 +13,9 @@
             "hash": "9083bed824d707e8791f53811aaa88def8047d40f221a8e823571c103cf3aff6"
         }
     },
+    "env_set": {
+        "TRANSMISSION_HOME": "$persist_dir"
+    },
     "extract_dir": "PFiles\\Transmission",
     "bin": [
         [


### PR DESCRIPTION
TRANSMISSION_HOME env variable allows settings to be in the persist folder and not in the APPDATA folder.