### PR TITLE
teamviewer: fix hash for now and future

### DIFF
--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -7,7 +7,7 @@
     "description": "TeamViewer is proprietary computer software for remote control, desktop sharing, online meetings, web conferencing and file transfer between computers.",
     "version": "15.3.8497",
     "url": "https://download.teamviewer.com/download/version_15x/TeamViewerPortable.zip",
-    "hash": "20c169a0d26973dfcd35f0c3deb753d59aa759e2d9f298e6f2e5b10c1e030248",
+    "hash": "2d9aa122eea49b6913f702be89b2387e1865a758c772bba274501b4d5ae3e946",
     "bin": "teamviewer.exe",
     "shortcuts": [
         [
@@ -21,6 +21,9 @@
         "re": ">\\s*([\\d.]+)\\s*<"
     },
     "autoupdate": {
-        "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewerPortable.zip"
+        "url": "https://download.teamviewer.com/download/version_$majorVersionx/TeamViewerPortable.zip",
+        "hash": {
+            "mode": "download"
+        }
     }
 }


### PR DESCRIPTION
Since I could not find a place to extract a valid `hash` of the latest release of `Teamviewer`, I simply chose the *download and compute* way to **autoupdate** the hash.

**relevant issue**: #3676 