### PR TITLE
zoom: Add version 5.0.1

### DIFF
--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -1,0 +1,31 @@
+{
+    "version": "4.6.7",
+    "description": "Video and audio conferencing, chat, and webinars",
+    "homepage": "https://zoom.com.cn/",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://zoom.com.cn/terms"
+    },
+    "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",
+    "hash": "9c73bc037b0082185978711e4a26701ca9efe69db0dbbfd0292682399c140f7b",
+    "installer": {
+        "script": [
+            "Expand-7zipArchive \"$dir\\Zoom.msi\" \"$dir\"",
+            "Remove-Item \"$dir\\Zoom.msi\""
+        ]
+    },
+    "bin": "Zoom.exe",
+    "shortcuts": [
+        [
+            "Zoom.exe",
+            "Zoom"
+        ]
+    ],
+    "checkver": {
+        "url": "https://zoom.com.cn/download",
+        "re": "Version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z"
+    }
+}

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -1,7 +1,7 @@
 {
     "version": "4.6.7",
     "description": "Video and audio conferencing, chat, and webinars",
-    "homepage": "https://zoom.com.cn/",
+    "homepage": "https://zoom.us",
     "license": {
         "identifier": "Shareware",
         "url": "https://zoom.com.cn/terms"

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -4,7 +4,7 @@
     "homepage": "https://zoom.us",
     "license": {
         "identifier": "Shareware",
-        "url": "https://zoom.com.cn/terms"
+        "url": "https://zoom.us/terms"
     },
     "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",
     "hash": "9c73bc037b0082185978711e4a26701ca9efe69db0dbbfd0292682399c140f7b",

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.6.7",
+    "version": "4.6.12",
     "description": "Video and audio conferencing, chat, and webinars",
     "homepage": "https://zoom.us",
     "license": {

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -20,8 +20,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://zoom.com.cn/download",
-        "re": "Version ([\\d.]+)"
+        "url": "https://support.zoom.us/hc/en-us/articles/201361953-New-Updates-for-Windows",
+        "regex": ">([\\d.]+)\\s+\\(\\d+"
     },
     "autoupdate": {
         "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z"

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -6,7 +6,7 @@
         "identifier": "Proprietary",
         "url": "https://zoom.us/terms"
     },
-    "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",
+    "url": "https://zoom.us/client/latest/ZoomInstaller.exe#/dl.7z",
     "hash": "7041659098810c5f0b4924ab8f0469c125d4637f28784e7910f1bb7d809c978d",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\Zoom.msi\" -Removal",
@@ -24,6 +24,6 @@
         "regex": ">([\\d.]+)\\s+\\(\\d+"
     },
     "autoupdate": {
-        "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z"
+        "url": "https://zoom.us/client/latest/ZoomInstaller.exe#/dl.7z"
     }
 }

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -7,13 +7,11 @@
         "url": "https://zoom.us/terms"
     },
     "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",
-    "hash": "9c73bc037b0082185978711e4a26701ca9efe69db0dbbfd0292682399c140f7b",
-    "installer": {
-        "script": [
-            "Expand-7zipArchive \"$dir\\Zoom.msi\" \"$dir\"",
-            "Remove-Item \"$dir\\Zoom.msi\""
-        ]
-    },
+    "hash": "4d152d4ec0e2a8e60f964d712a15c2947f5a04499d0c38fe14d2940284f8c969",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\Zoom.msi\" -Removal",
+        "Remove-Item \"$dir\\Install*\""
+    ],
     "bin": "Zoom.exe",
     "shortcuts": [
         [

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -3,7 +3,7 @@
     "description": "Video and audio conferencing, chat, and webinars",
     "homepage": "https://zoom.us",
     "license": {
-        "identifier": "Shareware",
+        "identifier": "Proprietary",
         "url": "https://zoom.us/terms"
     },
     "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",

--- a/bucket/zoom.json
+++ b/bucket/zoom.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.6.12",
+    "version": "5.0.1",
     "description": "Video and audio conferencing, chat, and webinars",
     "homepage": "https://zoom.us",
     "license": {
@@ -7,7 +7,7 @@
         "url": "https://zoom.us/terms"
     },
     "url": "https://zoom.com.cn/client/latest/ZoomInstaller.exe#/dl.7z",
-    "hash": "4d152d4ec0e2a8e60f964d712a15c2947f5a04499d0c38fe14d2940284f8c969",
+    "hash": "7041659098810c5f0b4924ab8f0469c125d4637f28784e7910f1bb7d809c978d",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\Zoom.msi\" -Removal",
         "Remove-Item \"$dir\\Install*\""


### PR DESCRIPTION
- Closes #3920 

[Zoom](https://zoom.com.cn/) is a video and audio conferencing, chat, and webinars service.

Note for `checkver`:
- The Zoom client has a "Check updates", but it's a post request.
- The Zoom [download page](https://zoom.com.cn/download) has other software, only using `Version ([\\d.]+)` is not strict.
- The Zoom [release notes page](https://support.zoom.us/hc/en-us/articles/201361953-New-Updates-for-Windows) may be better.