### PR TITLE
potplayer@200317: Hash fix

### DIFF
--- a/bucket/potplayer.json
+++ b/bucket/potplayer.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/200317/PotPlayerSetup64.exe#/dl.7z",
-            "hash": "b3e65f5acf5f0999aa2344b8d75e2049f9812ab84c5bbe40d41bc6d3e2035e78",
+            "hash": "2f187b1ba9d15619f6943c17c43c53aa0c096ef90494b166511819604acc91b0",
             "shortcuts": [
                 [
                     "PotPlayer64.exe",
@@ -23,7 +23,7 @@
         },
         "32bit": {
             "url": "https://t1.daumcdn.net/potplayer/PotPlayer/Version/200317/PotPlayerSetup.exe#/dl.7z",
-            "hash": "f5697b3984bff392c1aa250c6aa76e1da51fc0b2f1fa2575cb5b66824094c68c",
+            "hash": "f9c6cc9de16f1362129a17bd81211291dce3034d46e6f66de5bc0a53334c6708",
             "shortcuts": [
                 [
                     "PotPlayer.exe",


### PR DESCRIPTION
The checkver only checks main version, not build version, we should change the checkver more reliable.