### PR TITLE
ibmcloud-cli@0.22.1: Fix hash

### DIFF
--- a/bucket/ibmcloud-cli.json
+++ b/bucket/ibmcloud-cli.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://clis.ng.bluemix.net/download/bluemix-cli/0.22.1/win64/archive#/dl.zip",
-            "hash": "sha1:fc8422c4e2e86e72b92476c6f75b13c77f5646ba"
+            "hash": "sha1:901e96786da6d798fe5c9d5c112d85165c92c2b7"
         },
         "32bit": {
             "url": "https://clis.ng.bluemix.net/download/bluemix-cli/0.22.1/win32/archive#/dl.zip",
-            "hash": "sha1:cf31ad3071ac390a2854c33c7c27c43afc70f15d"
+            "hash": "sha1:5a012fec5e7f9e001a163460b262aca837774ff7"
         }
     },
     "extract_dir": "IBM_Cloud_CLI",


### PR DESCRIPTION
Current manifest for 0.22.1 contains wrong hashes.