### PR TITLE
obs-studio: Use CDN download URL

### DIFF
--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/obsproject/obs-studio/releases/download/25.0.1/OBS-Studio-25.0.1-Full-x64.zip",
+            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-25.0.1-Full-x64.zip",
             "hash": "b72489e97a34289990a190bd6d373c047d8a0ab5f7eabb36ce1c53fb6db3faab",
             "shortcuts": [
                 [
@@ -15,7 +15,7 @@
             ]
         },
         "32bit": {
-            "url": "https://github.com/obsproject/obs-studio/releases/download/25.0.1/OBS-Studio-25.0.1-Full-x86.zip",
+            "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-25.0.1-Full-x86.zip",
             "hash": "03c7c9305645299536fe0c150d0ec1f1f3f310267a1ae30b08d9083a03fc249b",
             "shortcuts": [
                 [
@@ -30,14 +30,17 @@
         "config",
         "portable_mode.txt"
     ],
-    "checkver": "aria-label=\"Windows\"></div><span>([\\d.]+)</span>",
+    "checkver": {
+        "url": "https://obsproject.com/download",
+        "regex": "OBS-Studio-([\\d.]+)-Full-x64.zip"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Full-x64.zip"
+                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Full-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/obsproject/obs-studio/releases/download/$version/OBS-Studio-$version-Full-x86.zip"
+                "url": "https://cdn-fastly.obsproject.com/downloads/OBS-Studio-$version-Full-x86.zip"
             }
         }
     }

--- a/bucket/obs-studio.json
+++ b/bucket/obs-studio.json
@@ -32,7 +32,7 @@
     ],
     "checkver": {
         "url": "https://obsproject.com/download",
-        "regex": "OBS-Studio-([\\d.]+)-Full-x64.zip"
+        "regex": "OBS-Studio-([\\d.]+)-Full-x64\\.zip"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
#2308 
- Closes #3735 

- Uses CDN for download instead of Github.
- Uses download page for version regex, since CDN only have one version variable in download URL.