### PR TITLE
libreoffice-fresh: Add extract_dir

### DIFF
--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -18,27 +18,27 @@
     },
     "shortcuts": [
         [
-            "program\\sbase.exe",
+            "LibreOffice\\program\\sbase.exe",
             "LibreOffice\\LibreOffice Base"
         ],
         [
-            "program\\scalc.exe",
+            "LibreOffice\\program\\scalc.exe",
             "LibreOffice\\LibreOffice Calc"
         ],
         [
-            "program\\sdraw.exe",
+            "LibreOffice\\program\\sdraw.exe",
             "LibreOffice\\LibreOffice Draw"
         ],
         [
-            "program\\simpress.exe",
+            "LibreOffice\\program\\simpress.exe",
             "LibreOffice\\LibreOffice Impress"
         ],
         [
-            "program\\smath.exe",
+            "LibreOffice\\program\\smath.exe",
             "LibreOffice\\LibreOffice Math"
         ],
         [
-            "program\\swriter.exe",
+            "LibreOffice\\program\\swriter.exe",
             "LibreOffice\\LibreOffice Writer"
         ]
     ],

--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -18,27 +18,27 @@
     },
     "shortcuts": [
         [
-            "LibreOffice\\program\\sbase.exe",
+            "program\\sbase.exe",
             "LibreOffice\\LibreOffice Base"
         ],
         [
-            "LibreOffice\\program\\scalc.exe",
+            "program\\scalc.exe",
             "LibreOffice\\LibreOffice Calc"
         ],
         [
-            "LibreOffice\\program\\sdraw.exe",
+            "program\\sdraw.exe",
             "LibreOffice\\LibreOffice Draw"
         ],
         [
-            "LibreOffice\\program\\simpress.exe",
+            "program\\simpress.exe",
             "LibreOffice\\LibreOffice Impress"
         ],
         [
-            "LibreOffice\\program\\smath.exe",
+            "program\\smath.exe",
             "LibreOffice\\LibreOffice Math"
         ],
         [
-            "LibreOffice\\program\\swriter.exe",
+            "program\\swriter.exe",
             "LibreOffice\\LibreOffice Writer"
         ]
     ],


### PR DESCRIPTION
Newest version (6.4.2.2) moved many files into the folder "LibreOffice", including executables, so scoop gives an error when linking shortcuts to them.