### PR TITLE
vitrite: Add version 1.1.1

### DIFF
--- a/bucket/vitrite.json
+++ b/bucket/vitrite.json
@@ -1,8 +1,8 @@
 {
-    "homepage": "http://www.vanmiddlesworth.org/vitrite/",
-    "description": "A small Windows utility that allows you to manually adjust the level of transparency for almost any visible window",
-    "license": "GPL",
     "version": "1.1.1",
+    "description": "Configures the level of transparency for almost any visible window.",
+    "homepage": "http://www.vanmiddlesworth.org/vitrite/",
+    "license": "GPL-2.0-only",
     "url": "http://vitrite.vanmiddlesworth.org/vitrite/1.1.1/Vitrite-1.1.zip",
     "hash": "870bdfdddb463587b98cce6269dd5cda3335cb6004358dcfc226bbc7ca625cc6",
     "bin": "Vitrite.exe",

--- a/bucket/vitrite.json
+++ b/bucket/vitrite.json
@@ -1,0 +1,15 @@
+{
+    "homepage": "http://www.vanmiddlesworth.org/vitrite/",
+    "description": "A small Windows utility that allows you to manually adjust the level of transparency for almost any visible window",
+    "license": "GPL",
+    "version": "1.1.1",
+    "url": "http://vitrite.vanmiddlesworth.org/vitrite/1.1.1/Vitrite-1.1.zip",
+    "hash": "870bdfdddb463587b98cce6269dd5cda3335cb6004358dcfc226bbc7ca625cc6",
+    "bin": "Vitrite.exe",
+    "shortcuts": [
+        [
+            "Vitrite.exe",
+            "Vitrite"
+        ]
+    ]
+}


### PR DESCRIPTION
http://www.vanmiddlesworth.org/vitrite/
Vitrite is a small Windows utility that allows you to manually adjust the level of transparency for almost any visible window.

I didn't add checkver since I couldn't find a reliable version pattern on the homepage and the tool hasn't been updated since 2002.