### PR TITLE
Adding gradle latest release candidate

### DIFF
--- a/bucket/gradle-release-candidate.json
+++ b/bucket/gradle-release-candidate.json
@@ -1,0 +1,27 @@
+{
+    "homepage": "https://gradle.org",
+    "description": "Latest release candidate for gradle - an open-source build automation tool focused on flexibility and performance. (Source code and documentation bundled)",
+    "version": "6.3-rc-4",
+    "license": "Apache-2.0",
+    "hash": "87df93a4519a78003439db4436ba4a5ffec97eaf3ee33f0ea976f2b296a80cde",
+    "url": "https://services.gradle.org/distributions/gradle-6.3-rc-4-all.zip",
+    "extract_dir": "gradle-6.3-rc-4",
+    "bin": "bin\\gradle.bat",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    },
+    "checkver": {
+        "url": "https://services.gradle.org/distributions/",
+        "regex": "gradle\\-([\\d\\.\\-rc]+)\\-all\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://services.gradle.org/distributions/gradle-$version-all.zip",
+        "extract_dir": "gradle-$version",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Adding gradle latest release candidate as the current GA ie. 6.2.2 fails with latest JDK GA ie. JDK14. More details here: https://github.com/gradle/gradle/issues/10248