### PR TITLE
GIMP: twain,2.exe appears to have been renamed to twain,3.exe

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -12,7 +12,7 @@
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
             "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe'",
+            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,3.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   New-Item '32\\etc', '32\\share', 'share\\gimp\\2.0\\fonts' -ItemType 'Directory' | Out-Null",


### PR DESCRIPTION
It appears that a file was renamed from one version to the next. The install script tried to delete twain,2.exe; it now deletes twain,3.exe.

I have no idea if it is the right thing to do or how to test it, but the install works again.