### PR TITLE
dokan: Add version 1.3.1.1000

### DIFF
--- a/bucket/dokan.json
+++ b/bucket/dokan.json
@@ -1,0 +1,70 @@
+{
+    "homepage": "https://dokan-dev.github.io/",
+    "description": "Dokan is a user mode file system for Windows. It allows anyone to safely and easily develop new file systems on Windows operating systems.",
+    "license": "LGPL-3.0-only",
+    "version": "1.3.1.1000",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x64.msi",
+            "hash": "1b89e2f3cf90902726a5d03a9694596a3a247d6908b74ab493469b259d8f8462"
+        },
+        "32bit": {
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x86.msi",
+            "hash": "b296e7bef4c6ca45f10b6c1b444ff2e38dec40c79753ca24f26f19c1a6aaaf0b"
+        }
+    },
+    "bin": [
+        "dokanctl.exe",
+        "mirror.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x64.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x86.msi"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    },
+{
+    "homepage": "https://dokan-dev.github.io/",
+    "description": "Dokan is a user mode file system for Windows. It allows anyone to safely and easily develop new file systems on Windows operating systems.",
+    "license": "LGPL-3.0-only",
+    "version": "1.3.1.1000",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x64.msi",
+            "hash": "1b89e2f3cf90902726a5d03a9694596a3a247d6908b74ab493469b259d8f8462"
+        },
+        "32bit": {
+            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x86.msi",
+            "hash": "b296e7bef4c6ca45f10b6c1b444ff2e38dec40c79753ca24f26f19c1a6aaaf0b"
+        }
+    },
+    "bin": [
+        "dokanctl.exe",
+        "mirror.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x64.msi"
+            },
+            "32bit": {
+                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x86.msi"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    },
+    "depends": {
+        "vcredist": "extras/vcredist2019"
+    }
+}

--- a/bucket/dokan.json
+++ b/bucket/dokan.json
@@ -31,40 +31,7 @@
             "mode": "download"
         }
     },
-{
-    "homepage": "https://dokan-dev.github.io/",
-    "description": "Dokan is a user mode file system for Windows. It allows anyone to safely and easily develop new file systems on Windows operating systems.",
-    "license": "LGPL-3.0-only",
-    "version": "1.3.1.1000",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x64.msi",
-            "hash": "1b89e2f3cf90902726a5d03a9694596a3a247d6908b74ab493469b259d8f8462"
-        },
-        "32bit": {
-            "url": "https://github.com/dokan-dev/dokany/releases/download/v1.3.1.1000/Dokan_x86.msi",
-            "hash": "b296e7bef4c6ca45f10b6c1b444ff2e38dec40c79753ca24f26f19c1a6aaaf0b"
-        }
-    },
-    "bin": [
-        "dokanctl.exe",
-        "mirror.exe"
-    ],
-    "checkver": "github",
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x64.msi"
-            },
-            "32bit": {
-                "url": "https://github.com/dokan-dev/dokany/releases/download/v$version/Dokan_x86.msi"
-            }
-        },
-        "hash": {
-            "mode": "download"
-        }
-    },
-    "depends": {
+    "suggest": {
         "vcredist": "extras/vcredist2019"
     }
 }


### PR DESCRIPTION
dokan is a FUSE filesystem driver for windows that requires `vcredist2019` and admin privileges to install