### PR TITLE
meshlab: Fix installation

### DIFF
--- a/bucket/meshlab.json
+++ b/bucket/meshlab.json
@@ -12,7 +12,6 @@
             "hash": "9d7f1c63fb3c99eea001d25bb24125eaad9ffb19eceb9bc336e95ee2cf019c37"
         }
     },
-    "extract_dir": "meshlab_windows_portable",
     "bin": [
         "meshlab.exe",
         "meshlabserver.exe"


### PR DESCRIPTION
Meshlab changed its archive format. Remove the "extract_dir" parameter.