### PR TITLE
Update wsl-ssh-pageant to the latest release.

### DIFF
--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -20,10 +20,8 @@
         },
         "32bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20200408.1/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe"
             ],
             "hash": [
-                "77738a910eb0646deaaec44f3b0cf6fc269b12fb1def854a0d929ed9a79c7dea"
             ]
         }
     }

--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -2,7 +2,7 @@
     "homepage": "https://github.com/benpye/wsl-ssh-pageant/",
     "description": "A Pageant -> TCP bridge for use with WSL, allowing for Pageant to be used as an ssh-ageant within the WSL environment.",
     "license": "BSD-2-Clause",
-    "version": "20190513.14",
+    "version": "20200408.1",
     "bin": [
         "wsl-ssh-pageant.exe",
         "wsl-ssh-pageant-gui.exe"
@@ -10,22 +10,20 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20200408.1/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20200408.1/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
-                "84b926fd8737cb509bba9ff5c51a01838088dadaa9513addccb5a8ace4a7f7dc",
-                "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
+                "adca8c821b86a399360fc562e7b5ef47ac3bec5fdecdc67971ca41cedf4d9368",
+                "ce6c40c060565869e1e72e4837fcf4cae616fc73fcde2f086d5687ca89c289e9"
             ]
         },
         "32bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20200408.1/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe"
             ],
             "hash": [
-                "85d923a911b9604ab457219318264c776969990cf9d49ce60882c83835a8591d",
-                "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
+                "77738a910eb0646deaaec44f3b0cf6fc269b12fb1def854a0d929ed9a79c7dea"
             ]
         }
     }


### PR DESCRIPTION
The latest version of wsl-ssh-pageant includes a --force command to delete any stale sockets (ie. leftover from before a system restart). This allows it to be run at system startup and come back up as normal.

Note: I had to drop the 32-bit wsl-ssh-pageant gui version as Windows Defender complained of malware when I downloaded it and I didn't feel comfortable including it in the packaging. I've opened a ticket with the repo owner benpye/wsl-ssh-pageant#38 and will update the package again when he resolves the issue.