### PR TITLE
flutter: Add bin\cache\dart-sdk\bin to path

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -31,7 +31,7 @@
         "bin\\flutter.bat",
         "flutter-dev-setup.ps1"
     ],
-    "env_add_path": "bin\\cache\\dart-sdk",
+    "env_add_path": "bin\\cache\\dart-sdk\\bin",
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
         "regex": "windows_v([\\d.]+)(?<delim>[-+])(?<build>[\\w.]+)-stable",


### PR DESCRIPTION
- Closes #2238

The `dart` executable and all its util scripts reside in the bin folder rather than its home folder **now** ( *but don't know since when* ).