### PR TITLE
Add pasteboard (pbcopy/pbpaste)

### DIFF
--- a/bucket/pasteboard.json
+++ b/bucket/pasteboard.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.2.0",
+    "homepage": "https://github.com/uzxmx/pasteboard",
+    "description": "Clipboard utilities for Windows (like OSX pbcopy/pbpaste)",
+    "license": "MIT",
+    "url": "https://github.com/uzxmx/pasteboard/releases/download/v1.2.0/pasteboard-v1.2.0-windows.zip",
+    "hash": "2290667c7740a666c2d0341291538500285d737e98aa6c7c66b1217a99ebca9e",
+    "bin": [
+        "pbcopy.exe",
+        "pbpaste.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/uzxmx/pasteboard/releases/download/v$version/pasteboard-v$version-windows.zip",
+        "hash": {
+            "url": "https://github.com/uzxmx/pasteboard/releases/download/v$version/pasteboard-v$version-windows.zip.sha256"
+        }
+    }
+}


### PR DESCRIPTION
This package provides two executables: `pbcopy.exe` and `pbpaste.exe` whose purpuses are the same as OSX's pbcopy/pbpaste.

Though `clip.exe` shipped with Windows works well, it seems Windows missed an utility to get contents from clipboard using CLI. One workaround is to use `powershell.exe -command Get-Clipboard`, but that's too slow on WSL. Another drawback is it cannot supporting converting Windows line break `\r\n` to UNIX line break `\n`.

The `pbpaste.exe` provided by this package runs faster than `powershell.exe -command Get-Clipboard`, and supports line break conversion.

So this package can provide some values to others.