### PR TITLE
vscode-insiders-portable: Adjust notes

### DIFF
--- a/bucket/vscode-insiders-portable.json
+++ b/bucket/vscode-insiders-portable.json
@@ -8,8 +8,8 @@
     },
     "notes": [
         "Visual Studio Code now supports Portable Mode! Please move the following directories:",
-        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders-portable\\data\\extensions\"",
-        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders-portable\\data\\user-data\"",
+        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:SCOOP\\persist\\vscode-insiders-portable\\data\\extensions\"",
+        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:SCOOP\\persist\\vscode-insiders-portable\\data\\user-data\"",
         "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\""
     ],
     "bin": [

--- a/bucket/vscode-insiders-portable.json
+++ b/bucket/vscode-insiders-portable.json
@@ -8,8 +8,8 @@
     },
     "notes": [
         "Visual Studio Code now supports Portable Mode! Please move the following directories:",
-        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders\\data\\extensions\"",
-        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders\\data\\user-data\"",
+        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders-portable\\data\\extensions\"",
+        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:USERPROFILE\\scoop\\persist\\vscode-insiders-portable\\data\\user-data\"",
         "Add Visual Studio Code as a context menu option by running: \"$dir\\vscode-install-context.reg\""
     ],
     "bin": [


### PR DESCRIPTION
If I execute: 

```cmd
dir /a %userprofile%\scoop\apps\vscode-insiders-portable\current
```

I will get:

```cmd
04/23/2020  11:28 AM    <JUNCTION>     data [C:\Users\somebody\scoop\persist\vscode-insiders-portable\data]
```

But the `notes` tell us to move to `"$env:USERPROFILE\\scoop\\persist\\vscode-insiders\\data\\extensions\"`, which in inconstant with the resulting directory of `persist`.