### PR TITLE
libreoffice-fresh@6.4.3.2: Fix installation

### DIFF
--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -16,7 +16,6 @@
             "hash": "a6846a7947d0c727a4faa2eee26ed477d57616058bd115a5e6a4c00037d32208"
         }
     },
-    "extract_dir": "LibreOffice",
     "shortcuts": [
         [
             "program\\sbase.exe",

--- a/bucket/libreoffice-fresh.json
+++ b/bucket/libreoffice-fresh.json
@@ -1,6 +1,6 @@
 {
     "version": "6.4.3.2",
-    "description": "Powerful office suite.",
+    "description": "Powerful office suite",
     "homepage": "https://libreoffice.org/",
     "license": "MPL-2.0",
     "suggest": {


### PR DESCRIPTION
- Closes #3869
- Closes #3790

The latest msi installer of libreoffice-fresh doesn't create the "LibreOffice" top directory anymore.