### PR TITLE
Add scripts for adding Beyond Compare into the context menu. Referenc…

### DIFF
--- a/bucket/beyondcompare.json
+++ b/bucket/beyondcompare.json
@@ -8,14 +8,39 @@
     "version": "4.3.4.24657",
     "architecture": {
         "64bit": {
-            "url": "https://www.scootersoftware.com/BCompare-4.3.4.24657_x64.msi",
-            "hash": "5dcfbe7cc810e8e93580a972919d32454383ff880f52bd919a790ac9e62f577e"
+            "url": [
+                "https://www.scootersoftware.com/BCompare-4.3.4.24657_x64.msi",
+                "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/beyondcompare/beyondcompare-install-context-menu-64bit.reg",
+                "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/beyondcompare/beyondcompare-uninstall-context-menu.reg"
+            ],
+            "hash": [
+                "5dcfbe7cc810e8e93580a972919d32454383ff880f52bd919a790ac9e62f577e",
+                "9426172676b39a4d489b0f351f2ba569e6219926c9c4b6f867107737e263c5a8",
+                "6b28893880e64ac91a6605bb8abe0d59d7e8105d3687e38d9669bf9b6fd95abc"
+            ]
         },
         "32bit": {
-            "url": "https://www.scootersoftware.com/BCompare-4.3.4.24657_x86.msi",
-            "hash": "b732113493a290663b724261801e5220e11652ed85f4feddd4399ded7be8fda3"
+            "url": [
+                "https://www.scootersoftware.com/BCompare-4.3.4.24657_x86.msi",
+                "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/beyondcompare/beyondcompare-install-context-menu-32bit.reg",
+                "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/beyondcompare/beyondcompare-uninstall-context-menu.reg"
+            ],
+            "hash": [
+                "b732113493a290663b724261801e5220e11652ed85f4feddd4399ded7be8fda3",
+                "7e2111850d769bcb603a941829918d0c71185152f5efaba7ebdeb13683425baa",
+                "6b28893880e64ac91a6605bb8abe0d59d7e8105d3687e38d9669bf9b6fd95abc"
+            ]
         }
     },
+    "post_install": [
+        "if (Test-Path \"$dir\\beyondcompare-install-context-menu-$architecture.reg\") {",
+        "   $path = \"$dir\".Replace('\\', '\\\\')",
+        "   $content = Get-Content \"$dir\\beyondcompare-install-context-menu-$architecture.reg\"",
+        "   $content = $content.Replace('$path', $path)",
+        "   $content | Set-Content -Path \"$dir\\beyondcompare-install-context-menu.reg\"",
+        "}"
+    ],
+    "notes": "Add Beyond Compare as a context menu option by running: \"$dir\\beyondcompare-install-context-menu.reg\"",
     "bin": "Bcomp.exe",
     "extract_dir": "Beyond Compare 4",
     "shortcuts": [

--- a/scripts/beyondcompare/beyondcompare-install-context-menu-32bit.reg
+++ b/scripts/beyondcompare/beyondcompare-install-context-menu-32bit.reg
@@ -1,0 +1,23 @@
+﻿Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$path\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare/beyondcompare-install-context-menu-64bit.reg
+++ b/scripts/beyondcompare/beyondcompare-install-context-menu-64bit.reg
@@ -1,0 +1,30 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$path\\BCShellEx64.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$path\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare/beyondcompare-uninstall-context-menu.reg
+++ b/scripts/beyondcompare/beyondcompare-uninstall-context-menu.reg
@@ -1,0 +1,13 @@
+Windows Registry Editor Version 5.00
+[-HKEY_CURRENT_USER\Software\Scooter Software\Beyond Compare 4\BcShellEx]
+
+[-HKEY_CURRENT_USER\Software\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+[-HKEY_CURRENT_USER\Software\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+
+[-HKEY_CURRENT_USER\Software\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"=-


### PR DESCRIPTION
 Add scripts for adding Beyond Compare into the context menu. 

After adding the .reg file, additional steps are **required** to enable the context menu:
> 1. Select **Tools** | **Options** and pick the Startup tab.
> 2. In the **Explorer Integration** group, enable the Include **Beyond Compare** in Explorer context menu option.

[Reference](https://www.scootersoftware.com/support.php?zz=kb_shellex)

