### PR TITLE
ventoy: Add version 1.0.08

### DIFF
--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.0.07",
+    "version": "1.0.08",
+    "description": "Bootable USB drive creator",
     "homepage": "https://www.ventoy.net/en/index.html",
-    "description": "a new tool to create bootable USB drive for ISO files.",
     "license": "GPL-3.0-or-later",
-    "url": "https://github.com/ventoy/Ventoy/releases/download/v1.0.07/ventoy-1.0.07-windows.zip",
-    "hash": "sha1:5894722056cd24e5debd83da461a0c940e4c0a46",
-    "extract_dir": "ventoy-1.0.07",
+    "url": "https://github.com/ventoy/Ventoy/releases/download/v1.0.08/ventoy-1.0.08-windows.zip",
+    "hash": "sha1:884a1476142aa4f71924c27aa8ac0b1272afdd82",
+    "extract_dir": "ventoy-1.0.08",
     "pre_install": "if (!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
     "bin": "Ventoy2Disk.exe",
     "shortcuts": [
         [
             "Ventoy2Disk.exe",
-            "Ventoy"
+            "Ventoy2Disk"
         ]
     ],
     "persist": "log.txt",
@@ -22,7 +22,7 @@
         "url": "https://github.com/ventoy/Ventoy/releases/download/v$version/ventoy-$version-windows.zip",
         "hash": {
             "url": "https://github.com/ventoy/Ventoy/releases/tag/v$version",
-            "regex": "-windows.zip:\\s*$sha1"
+            "regex": "$basename:\\s+$sha1"
         },
         "extract_dir": "ventoy-$version"
     }

--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.0.07",
+    "homepage": "https://www.ventoy.net/en/index.html",
+    "description": "a new tool to create bootable USB drive for ISO files.",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/ventoy/Ventoy/releases/download/v1.0.07/ventoy-1.0.07-windows.zip",
+    "hash": "095b06c21b28eadd69178eff75cb447f2a61bdc467319d6611771ee44ccc3d39",
+    "extract_dir": "ventoy-1.0.07",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
+    "bin": "Ventoy2Disk.exe",
+    "shortcuts": [
+        [
+            "Ventoy2Disk.exe",
+            "Ventoy"
+        ]
+    ],
+    "persist": "log.txt",
+    "checkver": {
+        "github": "https://github.com/ventoy/Ventoy"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ventoy/Ventoy/releases/download/v$version/ventoy-$version-windows.zip",
+        "extract_dir": "ventoy-$version"
+    }
+}

--- a/bucket/ventoy.json
+++ b/bucket/ventoy.json
@@ -4,7 +4,7 @@
     "description": "a new tool to create bootable USB drive for ISO files.",
     "license": "GPL-3.0-or-later",
     "url": "https://github.com/ventoy/Ventoy/releases/download/v1.0.07/ventoy-1.0.07-windows.zip",
-    "hash": "095b06c21b28eadd69178eff75cb447f2a61bdc467319d6611771ee44ccc3d39",
+    "hash": "sha1:5894722056cd24e5debd83da461a0c940e4c0a46",
     "extract_dir": "ventoy-1.0.07",
     "pre_install": "if (!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
     "bin": "Ventoy2Disk.exe",
@@ -20,6 +20,10 @@
     },
     "autoupdate": {
         "url": "https://github.com/ventoy/Ventoy/releases/download/v$version/ventoy-$version-windows.zip",
+        "hash": {
+            "url": "https://github.com/ventoy/Ventoy/releases/tag/v$version",
+            "regex": "-windows.zip:\\s*$sha1"
+        },
         "extract_dir": "ventoy-$version"
     }
 }


### PR DESCRIPTION
[Ventoy](https://www.ventoy.net/en/index.html): is an open source tool to create bootable USB drive for ISO files. With ventoy, you don't need to format the disk again and again, you just need to copy the iso file to the USB drive and boot it.