### PR TITLE
sysinternals: Change the version pattern

### DIFF
--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -1,16 +1,16 @@
 {
-    "homepage": "https://docs.microsoft.com/en-us/sysinternals/",
+    "version": "2020.April.28",
     "description": "A set of utilities to manage, diagnose, troubleshoot, and monitor a Windows environment.",
+    "homepage": "https://docs.microsoft.com/en-us/sysinternals/",
     "license": {
         "identifier": "Freeware",
         "url": "https://docs.microsoft.com/en-us/sysinternals/license-terms"
     },
-    "version": "2020.April.28",
     "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
     "hash": "e7bb1d53993f54a2cd2ba59a0c4758d6cfa87ae2fb6a0abf423fd548caabd01e",
     "checkver": {
         "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/sysinternals-suite",
-        "re": "\\bUpdated:\\s*(\\w+)\\s+(\\d+),\\s+(\\d+)\\b",
+        "regex": "\\bUpdated:\\s*(\\w+)\\s+(\\d+),\\s+(\\d+)\\b",
         "replace": "${3}.${1}.${2}"
     },
     "autoupdate": {

--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -5,13 +5,13 @@
         "identifier": "Freeware",
         "url": "https://docs.microsoft.com/en-us/sysinternals/license-terms"
     },
-    "version": "April.28.2020",
+    "version": "2020.April.28",
     "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip",
     "hash": "e7bb1d53993f54a2cd2ba59a0c4758d6cfa87ae2fb6a0abf423fd548caabd01e",
     "checkver": {
         "url": "https://docs.microsoft.com/en-us/sysinternals/downloads/sysinternals-suite",
         "re": "\\bUpdated:\\s*(\\w+)\\s+(\\d+),\\s+(\\d+)\\b",
-        "replace": "${1}.${2}.${3}"
+        "replace": "${3}.${1}.${2}"
     },
     "autoupdate": {
         "url": "https://download.sysinternals.com/files/SysinternalsSuite.zip"


### PR DESCRIPTION
- Closes #1751

The current version pattern of sysinternals `Month.day.year` doesn't allow most of the time to automatically upgrade.
I propose to change to `year.Month.day`. Since Month is still alphabetical name instead of a number it will still miss some update. However it will better than today, eg we can get the April 2020 update if we have the September 2019 version installed. Today it won't update since September > April in alphabetical order.

Note: there is an numeric version of the date in the [page](https://docs.microsoft.com/en-us/sysinternals/downloads/sysinternals-suite) where it's extracted, but looking on webarchive it doesn't evolve consistently with the "Update: .... " (however currently it's aligned)
