### PR TITLE
openclosedriveeject: Add version 1.33

### DIFF
--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -29,7 +29,7 @@
             "bin": "OpenCloseDriveEject.exe",
             "shortcuts": [
                 [
-                    "OpenCloseDriveEject_p.exe",
+                    "OpenCloseDriveEject.exe",
                     "OpenCloseDriveEject"
                 ]
             ]

--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -1,0 +1,63 @@
+{
+    "version": "1.33",
+    "description": "Eject, open, or close any drive: USB, DVD/CD, SSD, etc.",
+    "homepage": "http://www.softwareok.com/?seite=Microsoft/OpenCloseDriveEject",
+    "license": {
+        "identifier": "Freeware",
+        "url": "http://www.softwareok.com/?seite=Microsoft/OpenCloseDriveEject/Eula"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://www.softwareok.com/Download/OpenCloseDriveEject_x64.zip",
+            "hash": "7e48467153d2f0c441c4a55fbe3f47ec8ee4b3629bf45c3096b11b4a0838a7f7",
+            "bin": [
+                [
+                    "OpenCloseDriveEject_x64_p.exe",
+                    "OpenCloseDriveEject"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "OpenCloseDriveEject_x64_p.exe",
+                    "OpenCloseDriveEject"
+                ]
+            ]
+        },
+        "32bit": {
+            "url": "https://www.softwareok.com/Download/OpenCloseDriveEject.zip",
+            "hash": "fa09f13605c944efd606a40b1a267633bf3baa5a885c52fb52de75d3a81d15d8",
+            "bin": [
+                [
+                    "OpenCloseDriveEject_p.exe",
+                    "OpenCloseDriveEject"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "OpenCloseDriveEject_p.exe",
+                    "OpenCloseDriveEject"
+                ]
+            ]
+        }
+    },
+    "pre_install": "if (-not (Test-Path \"$persist_dir\\OpenCloseDriveEject.ini\")) { New-Item \"$dir\\OpenCloseDriveEject.ini\" | Out-Null }",
+    "persist": "OpenCloseDriveEject.ini",
+    "checkver": {
+        "url": "https://www.softwareok.com/?seite=Microsoft/OpenCloseDriveEject/History",
+        "regex": "version ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.softwareok.com/Download/OpenCloseDriveEject_x64.zip"
+            },
+            "32bit": {
+                "url": "https://www.softwareok.com/Download/OpenCloseDriveEject.zip"
+            }
+        },
+        "hash": {
+            "url": "https://www.softwareok.com/?Download=OpenCloseDriveEject",
+            "regex": "$basename.*?$sha256<"
+        }
+    }
+}

--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -26,12 +26,7 @@
         "32bit": {
             "url": "https://www.softwareok.com/Download/OpenCloseDriveEject.zip",
             "hash": "fa09f13605c944efd606a40b1a267633bf3baa5a885c52fb52de75d3a81d15d8",
-            "bin": [
-                [
-                    "OpenCloseDriveEject_p.exe",
-                    "OpenCloseDriveEject"
-                ]
-            ],
+            "bin": "OpenCloseDriveEject.exe",
             "shortcuts": [
                 [
                     "OpenCloseDriveEject_p.exe",


### PR DESCRIPTION
Used https://github.com/lukesampson/scoop-extras/blob/master/bucket/quicktextpaste.json as the base template.