### PR TITLE
Update caffeine.json for 32/64bit architectures

### DIFF
--- a/bucket/caffeine.json
+++ b/bucket/caffeine.json
@@ -9,33 +9,28 @@
         "32bit": {
             "bin": [
                 [
-                    "caffeine32.exe", 
-                    "Caffeine"
+                    "caffeine32.exe", "Caffeine"
                 ]
             ],
             "shortcuts": [
                 [
-                    "caffeine32.exe", 
-                    "Caffeine"
+                    "caffeine32.exe", "Caffeine"
                 ]
             ]
         },
         "64bit": {
             "bin": [
                 [
-                    "caffeine64.exe", 
-                    "Caffeine"
+                    "caffeine64.exe", "Caffeine"
                 ]
             ],
             "shortcuts": [
                 [
-                    "caffeine64.exe", 
-                    "Caffeine"
+                    "caffeine64.exe", "Caffeine"
                 ]
             ]
         }
     },
-
     "checkver": "v([\\d.]+)\\s+-",
     "autoupdate": {
         "url": "https://www.zhornsoftware.co.uk/caffeine/caffeine.zip"

--- a/bucket/caffeine.json
+++ b/bucket/caffeine.json
@@ -5,13 +5,37 @@
     "license": "Freeware",
     "url": "https://www.zhornsoftware.co.uk/caffeine/caffeine.zip",
     "hash": "09e476d2275f2cf40c1f7f04727f0f0baf5d60ebc7cc27aaa19805e6265517f1",
-    "bin": "caffeine.exe",
-    "shortcuts": [
-        [
-            "caffeine.exe",
-            "Caffeine"
-        ]
-    ],
+    "architecture": {
+        "32bit": {
+            "bin": [
+                [
+                    "caffeine32.exe", 
+                    "Caffeine"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "caffeine32.exe", 
+                    "Caffeine"
+                ]
+            ]
+        },
+        "64bit": {
+            "bin": [
+                [
+                    "caffeine64.exe", 
+                    "Caffeine"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "caffeine64.exe", 
+                    "Caffeine"
+                ]
+            ]
+        }
+    },
+
     "checkver": "v([\\d.]+)\\s+-",
     "autoupdate": {
         "url": "https://www.zhornsoftware.co.uk/caffeine/caffeine.zip"


### PR DESCRIPTION
caffeine v1.81 does not appear to include a single caffeine.exe (anymore?) instead has separate caffeine32.exe and caffeine64.exe files