### PR TITLE
foxit-reader: Change the way the url was composed

### DIFF
--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -6,7 +6,7 @@
         "identifier": "Freeware",
         "url": "https://www.foxitsoftware.com/pdf-reader/eula.html"
     },
-    "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/10.0.0/B482F50BE0AE94322AED580B59D2C060/FoxitReader1000_enu_Setup_Prom.exe",
+    "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/10.0/B482F50BE0AE94322AED580B59D2C060/FoxitReader100_enu_Setup_Prom.exe",
     "hash": "md5:b482f50be0ae94322aed580b59d2c060",
     "bin": "FoxitReader.exe",
     "shortcuts": [
@@ -18,10 +18,10 @@
     "innosetup": true,
     "checkver": {
         "url": "https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English",
-        "regex": "([\\d.]+).*(?<md5hash>([a-fA-F0-9]{32}))"
+        "regex": "([\\d.]+).*\\\\/(?<dlver>[\\d\\.]+)\\\\/(?<md5hash>([a-fA-F0-9]{32}))\\\\/(?<dlname>.+\\.exe)"
     },
     "autoupdate": {
-        "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/$majorVersion.$minorVersion.$patchVersion/$matchMd5hash/FoxitReader$majorVersion$minorVersion$patchVersion_enu_Setup_Prom.exe",
+        "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/$matchDlver/$matchMd5hash/$matchDlname",
         "hash": {
             "url": "https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English",
             "regex": "$md5"

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -1,13 +1,20 @@
 {
     "version": "10.0.0.35798",
-    "homepage": "https://www.foxitsoftware.com/",
     "description": "Super-fast, feature rich PDF reader that offers a delightful reading experience in a small footprint.",
+    "homepage": "https://www.foxitsoftware.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.foxitsoftware.com/pdf-reader/eula.html"
     },
-    "url": "https://cdn01.foxitsoftware.com//pub/foxit/reader/desktop/win/10.x/10.0/en_us/FoxitReader100_Setup_Prom_IS.exe",
+    "url": "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/10.x/10.0/en_us/FoxitReader100_Setup_Prom_IS.exe#/dl.7z",
     "hash": "eac0bf3cdb0b629381c61fe9c1767d310f8654e34e30f19145d3e88f816cac00",
+    "extract_dir": "$PLUGINSDIR",
+    "installer": {
+        "script": [
+            "Get-ChildItem \"$dir\" -Exclude 'Foxit*Prom.exe' | Remove-Item",
+            "Get-Item \"$dir\\Foxit*prom.exe\" | Expand-InnoArchive -Destination \"$dir\" -Removal"
+        ]
+    },
     "bin": "FoxitReader.exe",
     "shortcuts": [
         [
@@ -15,13 +22,11 @@
             "Foxit Reader"
         ]
     ],
-    "innosetup": true,
     "checkver": {
         "url": "https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English",
-        "jsonpath": "$.package_info",
-        "regex": "(?s)([\\d.]+)\".*\"down\":\\s*\"(?<dl>[^\"]+)\""
+        "jsonpath": "$.package_info.version.[0]"
     },
     "autoupdate": {
-        "url": "https://cdn01.foxitsoftware.com/$matchDl"
+        "url": "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/$majorVersion.x/$majorVersion.$minorVersion/en_us/FoxitReader$majorVersion$minorVersion_Setup_Prom_IS.exe#/dl.7z"
     }
 }

--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "https://www.foxitsoftware.com/pdf-reader/eula.html"
     },
-    "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/10.0/B482F50BE0AE94322AED580B59D2C060/FoxitReader100_enu_Setup_Prom.exe",
-    "hash": "md5:b482f50be0ae94322aed580b59d2c060",
+    "url": "https://cdn01.foxitsoftware.com//pub/foxit/reader/desktop/win/10.x/10.0/en_us/FoxitReader100_Setup_Prom_IS.exe",
+    "hash": "eac0bf3cdb0b629381c61fe9c1767d310f8654e34e30f19145d3e88f816cac00",
     "bin": "FoxitReader.exe",
     "shortcuts": [
         [
@@ -18,13 +18,10 @@
     "innosetup": true,
     "checkver": {
         "url": "https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English",
-        "regex": "([\\d.]+).*\\\\/(?<dlver>[\\d\\.]+)\\\\/(?<md5hash>([a-fA-F0-9]{32}))\\\\/(?<dlname>.+\\.exe)"
+        "jsonpath": "$.package_info",
+        "regex": "(?s)([\\d.]+)\".*\"down\":\\s*\"(?<dl>[^\"]+)\""
     },
     "autoupdate": {
-        "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/$matchDlver/$matchMd5hash/$matchDlname",
-        "hash": {
-            "url": "https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English",
-            "regex": "$md5"
-        }
+        "url": "https://cdn01.foxitsoftware.com/$matchDl"
     }
 }


### PR DESCRIPTION
- Closes #4000
- Closes #4005 
- Closes #4019
- Closes #4068

As the `foxit-reader` has been updated to the `10.x`, the `scoop update foxit-reader` suddenly could not work. And after some investigations, I found that the download `url` of this new `10.0.0` version does not conform the present **major.minor.patch** composing rule: 

It uses `10.0` instead of `10.0.0` as the *version number part* of the `url` and `FoxitReader100_enu_Setup_Prom.exe` instead of `FoxitReader1000_enu_Setup_Prom.exe` as the *filename part* of the `url`. 

But this **major.minor.patch** might still apply to future releases (*with non-zero minor version and non-zero patch version*) I assume.

So, rather than patching the *version number part* and the *filename part* of the `url` together using the matched version string, this PR choose to extract the 2 parts directly from the `json` provided by `https://www.foxitsoftware.com/downloads/downloadForm.php?retJson=1&product=Foxit-Reader&platform=Windows&language=English`.