### PR TITLE
texstudio: Rename the shortcut

### DIFF
--- a/bucket/texstudio.json
+++ b/bucket/texstudio.json
@@ -17,7 +17,7 @@
     "shortcuts": [
         [
             "texstudio.exe",
-            "TexStudio"
+            "TeXstudio"
         ]
     ],
     "persist": "config",


### PR DESCRIPTION
Close https://github.com/lukesampson/scoop-extras/issues/4002.
Make the shortcut created by scoop be the same as that created by an installer.