### PR TITLE
Fixed URL and MD5 for Foxit Reader 10

### DIFF
--- a/bucket/foxit-reader.json
+++ b/bucket/foxit-reader.json
@@ -6,8 +6,8 @@
         "identifier": "Freeware",
         "url": "https://www.foxitsoftware.com/pdf-reader/eula.html"
     },
-    "url": "https://cdn01.foxitsoftware.com/product/reader/desktop/win/10.0.0/B482F50BE0AE94322AED580B59D2C060/FoxitReader1000_enu_Setup_Prom.exe",
-    "hash": "md5:b482f50be0ae94322aed580b59d2c060",
+    "url": "https://cdn01.foxitsoftware.com/pub/foxit/reader/desktop/win/10.x/10.0/en_us/FoxitReader100_Setup_Prom_IS.exe",
+    "hash": "md5:256432c7d12142b8fe8a55825ffb43d5",
     "bin": "FoxitReader.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
Currently 404'ing. Needs manual adjustment at least until the autoupdate and checkver sections are updated.