### PR TITLE
pixelorama: Add extract_dir to fix shortcut

### DIFF
--- a/bucket/pixelorama.json
+++ b/bucket/pixelorama.json
@@ -13,6 +13,9 @@
             "hash": "a02e21765c2c5a0e81e192bd9256c3fce7dcbc1777385ec0bdcb2dee25a40405"
         }
     },
+    "extract_dir": [
+        "Pixelorama [Windows]"
+    ],
     "bin": "Pixelorama.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
This fix failed shim creation.