### PR TITLE
mpv-git@20200510: Fix URLs

### DIFF
--- a/bucket/mpv-git.json
+++ b/bucket/mpv-git.json
@@ -5,12 +5,12 @@
     "license": "LGPL-2.1-or-later,GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/64bit/mpv-x86_64-20200510-git-caf228b.7z",
-            "hash": "sha1:c8c54e4d83e93e9db17875b3189c4a7807c42603"
+            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/64bit/mpv-x86_64-20200510-git-4e94b21.7z",
+            "hash": "sha1:d06cfcc2256b8cce963a7aaedfb1b0e5859189ed"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/32bit/mpv-i686-20200510-git-caf228b.7z",
-            "hash": "sha1:4330b5cb21f440a6caf5651ee606e6347f82089f"
+            "url": "https://downloads.sourceforge.net/project/mpv-player-windows/32bit/mpv-i686-20200510-git-4e94b21.7z",
+            "hash": "sha1:ae6b5477ff365fb1e513f38f2f5e5353d3b9f344"
         }
     },
     "bin": "mpv.com",


### PR DESCRIPTION
- Closes #4047 

Currently it 404s:

```
Updating 'mpv-git' (20200426 -> 20200510)
Downloading new version
The remote server returned an error: (404) Not Found.
At C:\Users\Pedro\scoop\apps\scoop\current\lib\install.ps1:130 char:9
+         throw $e
+         ~~~~~~~~
    + CategoryInfo          : OperationStopped: (:) [], WebException
    + FullyQualifiedErrorId : The remote server returned an error: (404) Not Found.
```