### PR TITLE
onefetch: Update to version 2.2.0

### DIFF
--- a/bucket/onefetch.json
+++ b/bucket/onefetch.json
@@ -1,17 +1,17 @@
 {
+    "version": "2.2.0",
     "description": "A command-line system information tool that displays information about your project directly on your terminal.",
     "homepage": "https://github.com/o2sh/onefetch",
-    "version": "2.2.0",
     "license": "MIT",
     "notes": "You may have to enable ANSI Color Codes in your terminal. See https://stackoverflow.com/questions/51680709/",
-    "bin": "onefetch.exe",
-    "checkver": "github",
     "architecture": {
         "64bit": {
             "url": "https://github.com/o2sh/onefetch/releases/download/v2.2.0/onefetch_windows-x86-64.zip",
             "hash": "c6b8dd36f050264586a0781c5b4353511e68563762e6715bb3f3d2004c18b04f"
         }
     },
+    "bin": "onefetch.exe",
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/onefetch.json
+++ b/bucket/onefetch.json
@@ -1,24 +1,21 @@
 {
     "description": "A command-line system information tool that displays information about your project directly on your terminal.",
     "homepage": "https://github.com/o2sh/onefetch",
-    "version": "2.0.0",
+    "version": "2.2.0",
     "license": "MIT",
     "notes": "You may have to enable ANSI Color Codes in your terminal. See https://stackoverflow.com/questions/51680709/",
     "bin": "onefetch.exe",
-    "checkver": {
-        "url": "https://github.com/o2sh/onefetch/releases",
-        "regex": "download/v([\\d.]+)/onefetch_windows-x86_64.zip"
-    },
+    "checkver": "github",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/o2sh/onefetch/releases/download/v2.0.0/onefetch_windows-x86_64.zip",
-            "hash": "4b488f2a5b7e8db487d787547d93c43369ba46698ca6ab136a2ce596d1bd1195"
+            "url": "https://github.com/o2sh/onefetch/releases/download/v2.2.0/onefetch_windows-x86-64.zip",
+            "hash": "c6b8dd36f050264586a0781c5b4353511e68563762e6715bb3f3d2004c18b04f"
         }
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/o2sh/onefetch/releases/download/v$version/onefetch_windows-x86_64.zip"
+                "url": "https://github.com/o2sh/onefetch/releases/download/v$version/onefetch_windows-x86-64.zip"
             }
         }
     }


### PR DESCRIPTION
and fix `checkver` & `autoupdate`