### PR TITLE
attempt to fix axiom.json

### DIFF
--- a/bucket/axiom.json
+++ b/bucket/axiom.json
@@ -18,7 +18,10 @@
             "Axiom"
         ]
     ],
-    "checkver": "/releases/download/v([\\w.-]+)/Axiom\\.zip",
+    "checkver": {
+        "github": "https://github.com/MattMcManis/Axiom",
+        "re": "/download/(?:v?)([\\d.]+(?:[-\\w.\\d]*?))/"
+    },
     "autoupdate": {
         "url": "https://github.com/MattMcManis/Axiom/releases/download/v$version/Axiom.zip"
     }


### PR DESCRIPTION
I haven't tested this and it could possibly not work.

The current manifest seems broken since it needed manual updates several times so hopefully this can fix it.
I borrowed from https://github.com/lukesampson/scoop-extras/blob/master/bucket/tremulous.json for the checkver variable. It might have additional items that aren't needed in the regex.

If tags are used:
https://github.com/GrangerHub/tremulous/tags
https://github.com/MattMcManis/Axiom/tags