### PR TITLE
Update Powertoys autoupdate url & new release

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.17.0",
+    "version": "0.18.0",
     "homepage": "https://github.com/microsoft/PowerToys",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.17.0/PowerToysSetup-0.17.0-x64.msi",
+            "url": "https://github.com/microsoft/PowerToys/releases/download/0.18.0/PowerToysSetup-0.18.0-x64.msi",
             "hash": "63a73159c8dd12b395b2d0550aa929d562bd1c054210b20d924567ae28cbfd97"
         }
     },
@@ -20,7 +20,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.msi"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/$version/PowerToysSetup-$version-x64.msi"
             }
         }
     }


### PR DESCRIPTION
It has been changed a bit at the url, please take a look at latest version to get more info.
https://github.com/microsoft/PowerToys/releases/latest

Thanks & regards.