### PR TITLE
skaffold: Update to version 1.10.1

### DIFF
--- a/bucket/skaffold.json
+++ b/bucket/skaffold.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.10.0",
+    "version": "1.10.1",
     "description": "A command line tool that facilitates continuous development for Kubernetes applications.",
     "homepage": "https://skaffold.dev",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/GoogleCloudPlatform/skaffold/releases/download/v1.10.0/skaffold-windows-amd64.exe#/skaffold.exe",
-            "hash": "3d66a199dfd01b268eb97ce1c6dff9f96bbf2de8213cbaa859d04e489bbdda8d"
+            "url": "https://github.com/GoogleCloudPlatform/skaffold/releases/download/v1.10.1/skaffold-windows-amd64.exe#/skaffold.exe",
+            "hash": "0b564121cdf6daeab90e18eecdf02a7b50fe4cbe9066354972e2de51a0e8a01f"
         }
     },
     "bin": "skaffold.exe",


### PR DESCRIPTION
Update to version 1.10.1 since that the binaries for 1.10.0 is broken:

https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.10.0