### PR TITLE
hydrogen: Add version 1.0.0-beta2

### DIFF
--- a/bucket/hydrogen.json
+++ b/bucket/hydrogen.json
@@ -22,8 +22,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/hydrogen-music/hydrogen/tags",
-        "jsonpath": "$[0].name"
+        "url": "http://hydrogen-music.org/downloads/",
+        "regex": "([\\w.-]+)\\s+64-Bit"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/hydrogen.json
+++ b/bucket/hydrogen.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0-beta2",
     "description": "Advanced drum machine",
-    "homepage": "http://hydrogen-music.org/",
+    "homepage": "http://hydrogen-music.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {

--- a/bucket/hydrogen.json
+++ b/bucket/hydrogen.json
@@ -13,7 +13,7 @@
             "hash": "f41ff3515fb979ad4b74e094b65ab7bc8e847eec970a24b028dcab08f4711c44"
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Recurse",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Recurse",
     "bin": "hydrogen.exe",
     "shortcuts": [
         [

--- a/bucket/hydrogen.json
+++ b/bucket/hydrogen.json
@@ -1,0 +1,38 @@
+{
+    "version": "1.0.0-beta2",
+    "description": "Advanced drum machine",
+    "homepage": "http://hydrogen-music.org/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hydrogen-music/hydrogen/releases/download/1.0.0-beta2/Hydrogen-1.0.0-beta2-win64.exe#/dl.7z",
+            "hash": "f7187843265a080b00ee4db178c46c503fcf7d722b73ef35c1abfb2bcac604cf"
+        },
+        "32bit": {
+            "url": "https://github.com/hydrogen-music/hydrogen/releases/download/1.0.0-beta2/Hydrogen-1.0.0-beta2-win32.exe#/dl.7z",
+            "hash": "f41ff3515fb979ad4b74e094b65ab7bc8e847eec970a24b028dcab08f4711c44"
+        }
+    },
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall.exe\" -Recurse",
+    "bin": "hydrogen.exe",
+    "shortcuts": [
+        [
+            "hydrogen.exe",
+            "Hydrogen"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/hydrogen-music/hydrogen/tags",
+        "jsonpath": "$[0].name"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hydrogen-music/hydrogen/releases/download/$version/Hydrogen-$version-win64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/hydrogen-music/hydrogen/releases/download/$version/Hydrogen-$version-win32.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm not using `checkver.github` because it seems to return the wrong version. Considering the latest non-beta version is almost four years old, I think 1.0.0-beta2 should be preferred.