### PR TITLE
foobar2000-portable: Persist user-components

### DIFF
--- a/bucket/foobar2000-portable.json
+++ b/bucket/foobar2000-portable.json
@@ -18,7 +18,8 @@
     "persist": [
         "configuration",
         "index-data",
-        "library"
+        "library",
+        "user-components"
     ],
     "installer": {
         "script": [


### PR DESCRIPTION
Add `user-components` to the persist array within `foobar2000-portable` per issue #4044.

Tested this out locally and things seemed to work fine.

- Closes #4044