### PR TITLE
keepass-plugin-webautotype: Add version 6.3.0

### DIFF
--- a/bucket/keepass-plugin-webautotype.json
+++ b/bucket/keepass-plugin-webautotype.json
@@ -1,0 +1,22 @@
+{
+    "version": "6.3.0",
+    "description": "Plugin for KeePass 2.x that allows the AutoType functionality to work with browser URLs.",
+    "homepage": "https://sourceforge.net/projects/webautotype/",
+    "license": "GPL-3.0-only",
+    "url": "https://downloads.sourceforge.net/project/webautotype/v6.3.0/WebAutoType-v6.3.0.zip",
+    "hash": "sha1:713140ba8139e73fc6a61b4217e0bc7bc73689b0",
+    "depends": "extras/keepass",
+    "checkver": {
+        "url": "https://sourceforge.net/projects/webautotype/rss?path=/",
+        "re": "WebAutoType-v([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://downloads.sourceforge.net/project/webautotype/v$version/WebAutoType-v$version.zip"
+    },
+    "installer": {
+        "script": "Copy-Item \"$dir\\WebAutoType.plgx\" \"$(appdir keepass $global)\\current\\Plugins\""
+    },
+    "uninstaller": {
+        "script": "Remove-Item \"$(appdir keepass $global)\\current\\Plugins\\WebAutoType.plgx\""
+    }
+}


### PR DESCRIPTION
https://sourceforge.net/projects/webautotype/
Based on [keepass-plugin-keeagent manifest](https://github.com/lukesampson/scoop-extras/blob/master/bucket/keepass-plugin-keeagent.json).