### PR TITLE
openconnect-gui: Add version 1.5.3

### DIFF
--- a/bucket/openconnect-gui.json
+++ b/bucket/openconnect-gui.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.5.3",
+    "description": "GUI client for openconnect VPN.",
+    "homepage": "https://openconnect.github.io/openconnect-gui/",
+    "license": "GPL-2.0-only",
+    "notes": "tap-windows is required, install it separately: https://build.openvpn.net/downloads/releases/",
+    "url": "https://github.com/openconnect/openconnect-gui/releases/download/v1.5.3/openconnect-gui-1.5.3-win32.exe#/dl.7z",
+    "hash": "sha512:2055a303ed6a40a0267203bc3c3d4ad14c86f7d690ab3cc85918ff0afc2103b1ca985e28f9e1efa92fb7b3cb41cd0add02aac9439a83b9b42e29e5bd01bff621",
+    "bin": "openconnect.exe",
+    "shortcuts": [
+        [
+            "openconnect-gui.exe",
+            "OpenConnect GUI"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/openconnect/openconnect-gui"
+    },
+    "autoupdate": {
+        "url": "https://github.com/openconnect/openconnect-gui/releases/download/v$version/openconnect-gui-$version-win32.exe#/dl.7z",
+        "hash": {
+            "url": "https://github.com/openconnect/openconnect-gui/releases/download/v$version/openconnect-gui-$version-win32.exe.sha512"
+        }
+    }
+}


### PR DESCRIPTION
https://openconnect.github.io/openconnect-gui/

It's a VPN client that supports Cisco AnyConnect.

It requires a TAP driver from OpenVPN. The installer does contain it in `Drivers\tap-windows.exe`, but version is not new. And it could conflict with [openvpn](https://github.com/lukesampson/scoop-extras/blob/master/bucket/openvpn.json), so I decided to leave a user to install it manually. The best way to do it probably, is to create a separate manifest for tap driver and require or suggest it here.

Connection profiles and settings are stored in registry. There is a INI-config support, but, if I understand correctly, it's defined during build time: https://github.com/openconnect/openconnect-gui/blob/1b9bc0ae61496a871dbee955ec2443e46d411ed4/src/main.cpp#L135.

Also it contains an `openconnect` cli tool.