### PR TITLE
bulk-crap-uninstaller@4.16: Fix URL

### DIFF
--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -1,10 +1,14 @@
 {
-    "homepage": "https://www.bcuninstaller.com/",
-    "description": "Bulk program uninstaller with advanced automation.",
-    "license": "Apache-2.0",
     "version": "4.16",
+    "description": "Bulk program uninstaller with advanced automation",
+    "homepage": "https://www.bcuninstaller.com/",
+    "license": "Apache-2.0",
     "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v4.16/BCUninstaller_4.16_portable.zip",
     "hash": "d383996cc87a82bbb6c51f775d711c887db6e44687d848b6fb0792fde703d548",
+    "pre_install": "Copy-Item \"$persist_dir\\BCUninstaller.settings\" \"$dir\" -ErrorAction SilentlyContinue -Force",
+    "uninstaller": {
+        "script": "Copy-Item \"$dir\\BCUninstaller.settings\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
+    },
     "bin": [
         "BCUninstaller.exe",
         "BCU-console.exe",
@@ -18,15 +22,6 @@
             "BCUninstaller.exe",
             "Bulk Crap Uninstaller"
         ]
-    ],
-    "persist": [
-        "BCUninstaller.exe.config",
-        "BCUninstaller.settings"
-    ],
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\BCUninstaller.settings\")) {",
-        "   New-Item \"$dir\\BCUninstaller.settings\" -ItemType File | Out-Null",
-        "}"
     ],
     "checkver": {
         "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"

--- a/bucket/bulk-crap-uninstaller.json
+++ b/bucket/bulk-crap-uninstaller.json
@@ -3,7 +3,7 @@
     "description": "Bulk program uninstaller with advanced automation.",
     "license": "Apache-2.0",
     "version": "4.16",
-    "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_4.16_portable.zip",
+    "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v4.16/BCUninstaller_4.16_portable.zip",
     "hash": "d383996cc87a82bbb6c51f775d711c887db6e44687d848b6fb0792fde703d548",
     "bin": [
         "BCUninstaller.exe",
@@ -29,10 +29,9 @@
         "}"
     ],
     "checkver": {
-        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html",
-        "regex": "\"softwareVersion\">([\\d.]+)"
+        "github": "https://github.com/Klocman/Bulk-Crap-Uninstaller"
     },
     "autoupdate": {
-        "url": "https://www.fosshub.com/Bulk-Crap-Uninstaller.html/BCUninstaller_$version_portable.zip"
+        "url": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v$version/BCUninstaller_$version_portable.zip"
     }
 }


### PR DESCRIPTION
Update links to download from https://github.com/Klocman/Bulk-Crap-Uninstaller/

- Closes #4173