### PR TITLE
archi@4.6.0: download url fix

### DIFF
--- a/bucket/archi.json
+++ b/bucket/archi.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://www.archimatetool.com/downloads/4.6.0/Archi-Win64-4.6.0.zip",
+            "url": "https://www.archimatetool.com/downloads/19ef8fac18d/Archi-Win64-4.6.0.zip",
             "hash": "md5:78f2f45b32386154bbf28bef512c9e78"
         }
     },
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.archimatetool.com/downloads/$version/Archi-Win64-$version.zip"
+                "url": "https://www.archimatetool.com/downloads/19ef8fac18d/Archi-Win64-$version.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
issue ref: https://github.com/lukesampson/scoop-extras/issues/4056

