### PR TITLE
flutter: Update to version 1.17.2

### DIFF
--- a/bucket/flutter.json
+++ b/bucket/flutter.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.12.13-hotfix.9",
+    "version": "1.17.2",
     "description": "Google’s mobile app SDK for crafting high-quality native interfaces on iOS and Android",
     "homepage": "https://flutter.dev",
     "license": "BSD-3-Clause",
@@ -14,11 +14,11 @@
         ]
     },
     "url": [
-        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v1.12.13+hotfix.9-stable.zip",
+        "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_1.17.2-stable.zip",
         "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/flutter-dev-setup.ps1"
     ],
     "hash": [
-        "6d1a7dd628514e3b089c15ead3db715781b1f8129403b7082d214d8c30adf3c2",
+        "48674906cbdf78e47b3a90e4e01d3ff7ccaff16be681e22d55a7e8db919c34d5",
         "bbd8dd269dd70d97e0224025281e55b7e2e32364d5c47e082ca7f45e33d1a613"
     ],
     "extract_dir": "flutter",
@@ -34,14 +34,14 @@
     "env_add_path": "bin\\cache\\dart-sdk\\bin",
     "checkver": {
         "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-        "regex": "windows_v([\\d.]+)(?<delim>[-+])(?<build>[\\w.]+)-stable",
-        "replace": "$1-${build}"
+        "regex": "windows_(v?[\\d.]+)(?<delim>[-+]?)(?<build>[\\w.]*)-stable",
+        "replace": "$1${delim}${build}"
     },
     "autoupdate": {
-        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_v$matchHead$matchDelim$matchBuild-stable.zip",
+        "url": "https://storage.googleapis.com/flutter_infra/releases/stable/windows/flutter_windows_$matchHead$matchDelim$matchBuild-stable.zip",
         "hash": {
             "url": "https://storage.googleapis.com/flutter_infra/releases/releases_windows.json",
-            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_v$matchHead$matchDelim$matchBuild-stable.zip/)].sha256"
+            "jsonpath": "$.releases[?(@.archive =~ /.*flutter_windows_$matchHead$matchDelim$matchBuild-stable.zip/)].sha256"
         }
     }
 }


### PR DESCRIPTION
- Closes #4023

Also, change the `autoupdate` strategy to adapt the new versioning manner while keeping the compatibility with former versioning manners.

This is implemented by just make the matching of `delim` and `build` optional and incorporate the character `v` in the `version`.