### PR TITLE
Added AusweisApp2

### DIFF
--- a/bucket/ausweisapp2.json
+++ b/bucket/ausweisapp2.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.20.0",
+    "description": "Authenticate to websites with your german ID",
+    "homepage": "https://www.ausweisapp.bund.de/ausweisapp2/",
+    "license": "EUPL-1.2",
+    "shortcuts": [
+        [
+            "AusweisApp2\\AusweisApp2.exe",
+            "AusweisApp2"
+        ]
+    ],
+    "url": "https://github.com/Governikus/AusweisApp2/releases/download/1.20.0/AusweisApp2-1.20.0.msi",
+    "hash": "17dcb099f1fe487589b8bb8619afa69f4683a2a95120f019c983b39e4e54b82c",
+    "checkver": {
+        "github": "https://github.com/Governikus/AusweisApp2"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Governikus/AusweisApp2/releases/download/$version/AusweisApp2-$version.msi",
+        "extract_dir": "ausweisapp2-$version",
+        "hash": {
+            "url": "https://github.com/Governikus/AusweisApp2/releases/download/$version/AusweisApp2-$version.msi.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Added AusweisApp2, which is software used to identify with a german ID card.

Source code is available at https://github.com/Governikus/AusweisApp2

Autoupdater & semver embedded, installation tested and it runs fine