### PR TITLE
duplicati: Add version 2.0.5.1

### DIFF
--- a/bucket/duplicati.json
+++ b/bucket/duplicati.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.0.5.1",
+    "description": "Duplicati. A backup software to store encrypted backups online.",
+    "homepage": "https://www.duplicati.com",
+    "license": "LGPL-2.1-only",
+    "suggest": {
+        "Visual C++ Redistributable for Visual Studio 2015": "vcredist2015"
+    },
+    "url": "https://updates.duplicati.com/beta/duplicati-2.0.5.1_beta_2020-01-18.zip",
+    "hash": "168aa8b6162586a8a16489e4ac2beece5e14e678bb01c4afcf37fbfb708482f6",
+    "bin": [
+        [
+            "Duplicati.CommandLine.exe",
+            "duplicati-cli"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Duplicati.GUI.TrayIcon.exe",
+            "Duplicati",
+            "--portable-mode"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "url": "https://updates.duplicati.com/beta/latest.json",
+        "jsonpath": "$.zip",
+        "regex": "(?<filename>.+?(?<version>[\\d.]{5,}).+)"
+    },
+    "autoupdate": {
+        "url": "https://updates.duplicati.com/beta/$matchFilename",
+        "hash": {
+            "url": "https://updates.duplicati.com/beta/latest.json",
+            "mode": "json",
+            "jsonpath": "$.zipsha256"
+        }
+    }
+}


### PR DESCRIPTION
Duplicati 2.0. https://www.duplicati.com/
There is no _stable_ channel right now (only _beta_ and _canary_). It would need to be updated to _stable_ as soon as it released. Or we should add several manifests (duplicati-beta, duplicati-canary etc).

I didn't find a way to disable updates checking. There is env variables for that, but it actually [aren't disabling it completely](https://github.com/duplicati/duplicati/issues/3983#issuecomment-564592026). There is a `updates` folder. If user decides to update it via web-interface, new version would be unpacked in that folder. Running application after that would run this updated version. This folder isn't persisted, because updating via scoop should update to version provided by scoop.

There is a `default_compressed_extensions.txt` file. It's a default list of uncompressible extensions. It's debatable for persist. I think that default list should remain default and be updated with application. If a user wants to use his own list, he should create his list and provide path to it in settings.
