### PR TITLE
windows-terminal: Fix profile icons filename encoding

### DIFF
--- a/bucket/windows-terminal.json
+++ b/bucket/windows-terminal.json
@@ -20,7 +20,8 @@
         "script": [
             "$winVer = [Environment]::OSVersion.Version",
             "if (($winver.Major -lt '10') -or ($winVer.Build -lt 18362)) { error 'At least Windows 10 18362 is required.'; break }",
-            "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
+            "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",
+            "Get-ChildItem \"$dir\\ProfileIcons\" '*.png' | Rename-Item -NewName { $_.Name.Replace('%7B', '{').Replace('%7D', '}') }"
         ]
     },
     "bin": [


### PR DESCRIPTION
- Closes ScoopInstaller/Main#882

The profile icons were not displayed because in the archive the filename are URL encoded while it's not expected to be the case on the filesystem.
This fix takes care of the encoded { and } chars that are used for GUID-based icon file names.