### PR TITLE
vuplayer: add version 4.9

### DIFF
--- a/bucket/vuplayer.json
+++ b/bucket/vuplayer.json
@@ -1,0 +1,36 @@
+{
+    "version": "4.9",
+    "description": "Audio player",
+    "homepage": "http://www.vuplayer.com",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jfchapman/VUPlayer/releases/download/v4.9/VUPlayer4_64bit.zip",
+            "hash": "90e3066ccf60f340d51c34ad9d172f5a54c5b8eb04d04907e274a7a5052c884d"
+        },
+        "32bit": {
+            "url": "https://github.com/jfchapman/VUPlayer/releases/download/v4.9/VUPlayer4_32bit.zip",
+            "hash": "264d5e30aa3f07e1b9ee034456d18c81b09bb62b773588cd4429f98dc2209293"
+        }
+    },
+    "bin": "VUPlayer.exe",
+    "shortcuts": [
+        [
+            "VUPlayer.exe",
+            "VUPlayer"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/jfchapman/VUPlayer"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jfchapman/VUPlayer/releases/download/v$version/VUPlayer$majorVersion_64bit.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/jfchapman/VUPlayer/releases/download/v$version/VUPlayer$majorVersion_32bit.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Portable mode can only read settings, but won't save settings to file. So I didn't make it portable.