### PR TITLE
openmpt: Fix shortcut

### DIFF
--- a/bucket/openmpt.json
+++ b/bucket/openmpt.json
@@ -20,7 +20,7 @@
     ],
     "shortcuts": [
         [
-            "mptrack.exe",
+            "OpenMPT.exe",
             "OpenMPT"
         ]
     ],


### PR DESCRIPTION
This should hopefully fix the following error message:
```
Creating shortcut for OpenMPT (mptrack.exe) failed: Couldn't find D:\scoop\apps\openmpt\current\mptrack.exe
```

This is one of my first times doing a pull request. Hopefully I didn't do something really cringy or something.
I also couldn't test if this actually fixes the error, because even if I add my own fork as the extras bucket, it keeps giving me the same error message despite the app manifest being changed. I don't know why this is. Maybe I did something really cringy.