### PR TITLE
Handbrake: Update to version 1.3.3

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -9,7 +9,6 @@
             "hash": "412e6c861d8363ea86f4beda8da484adb99c158c203a5cf23db9354549ec33b5"
         }
     },
-    "extract_dir": "HandBrake",
     "shortcuts": [
         [
             "HandBrake.exe",


### PR DESCRIPTION
Handbrake no longer has the Handbrake subdirectory in the Portable EXE download in release 1.3.3