### PR TITLE
tegrarcmsmash: Add version 1.2.1-3

### DIFF
--- a/bucket/tegrarcmsmash.json
+++ b/bucket/tegrarcmsmash.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.2.1-3",
+    "description": "A reimplementation of fusee-launcher in C++ for Windows platforms.",
+    "homepage": "https://switchtools.sshnuke.net/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://files.sshnuke.net/TegraRcmSmash1213.zip",
+    "hash": "3a850b8f7b75bdda00f52e51edd0f43c234fbe532b9c328efbb1e17a2111828f",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "x64"
+        },
+        "32bit": {
+            "extract_dir": "Win32"
+        }
+    },
+    "bin": "TegraRcmSmash.exe",
+    "checkver": "<li>(.*?)\\s",
+    "autoupdate": {
+        "url": "https://files.sshnuke.net/TegraRcmSmash$majorVersion$minorVersion$patchVersion$preReleaseVersion.zip",
+        "hash": "$url.sha256"
+    }
+}


### PR DESCRIPTION
Adds TegraRcmSmash to the bucket. It's not a GUI application, but it's not really a ["well-known and widely used developer tool"](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket) either.

Description taken from the [official website](https://switchtools.sshnuke.net/), license via [GitHub](https://github.com/rajkosto/TegraRcmSmash/blob/master/LICENSE).