### PR TITLE
alass: Add version 2.0.0

### DIFF
--- a/bucket/alass.json
+++ b/bucket/alass.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "description": "A command line tool to synchronize subtitles to movies.",
+    "homepage": "https://github.com/kaegi/alass",
+    "license": "GPL-3.0-or-later",
+    "depends": "ffmpeg",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/kaegi/alass/releases/download/v2.0.0/alass-windows64.zip",
+            "hash": "e81a72f97f592910e909a2352d6b8c0de0801c51ac1383bad4ebf3f2ecdd2fd8",
+            "extract_dir": "alass-windows64\\bin"
+        }
+    },
+    "bin": [ [ "alass-cli.exe", "alass" ] ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/kaegi/alass/releases/download/v$version/alass-windows64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Alass is a command line tool to synchronize subtitles to movies.