### PR TITLE
gstreamer: Add version 1.17.1

### DIFF
--- a/bucket/gstreamer.json
+++ b/bucket/gstreamer.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.17.1",
+    "description": "A library for constructing graphs of media-handling components.",
+    "homepage": "https://gstreamer.freedesktop.org/",
+    "license": "LGPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://gstreamer.freedesktop.org/data/pkg/windows/1.17.1/gstreamer-1.0-msvc-x86_64-1.17.1.msi",
+            "hash": "40fe1ca86caa82a89accd417e4fb16d13f00a90412e34c66c7cc4bcf86076416"
+        },
+        "32bit": {
+            "url": "https://gstreamer.freedesktop.org/data/pkg/windows/1.17.1/gstreamer-1.0-mingw-x86-1.17.1.msi",
+            "hash": "fae22bcc06620076ae4bb742f8a62396fc02a84d203bf35ed9b5c71cc5fbc703"
+        }
+    },
+    "checkver": {
+        "github": "https://gitlab.freedesktop.org/gstreamer/gstreamer"
+    }
+}


### PR DESCRIPTION
Adds GStreamer version 1.17.1

This PR is not working right now. 
@Ash258  @r15ch13  Can you please have a look and help me finish this? Thanks!