### PR TITLE
keepassxc@2.6.0: Persist config folder

### DIFF
--- a/bucket/keepassxc.json
+++ b/bucket/keepassxc.json
@@ -35,18 +35,15 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/keepassxreboot/keepassxc/releases/download/$version/KeePassXC-$version-Win64-Portable.zip",
-                "hash": {
-                    "url": "$url.DIGEST"
-                },
                 "extract_dir": "KeePassXC-$version-Win64"
             },
             "32bit": {
                 "url": "https://github.com/keepassxreboot/keepassxc/releases/download/$version/KeePassXC-$version-Win32-Portable.zip",
-                "hash": {
-                    "url": "$url.DIGEST"
-                },
                 "extract_dir": "KeePassXC-$version-Win32"
             }
+        },
+        "hash": {
+            "url": "$url.DIGEST"
         }
     }
 }

--- a/bucket/keepassxc.json
+++ b/bucket/keepassxc.json
@@ -15,15 +15,6 @@
             "extract_dir": "KeePassXC-2.6.0-Win32"
         }
     },
-    "installer": {
-        "script": "if (Test-Path \"$persist_dir\\keepassxc.ini\") { Copy-Item \"$persist_dir\\keepassxc.ini\" \"$dir\" -Force }"
-    },
-    "uninstaller": {
-        "script": [
-            "New-Item \"$persist_dir\" -ItemType Directory -ErrorAction SilentlyContinue | Out-Null",
-            "if (Test-Path \"$dir\\keepassxc.ini\") { Copy-Item \"$dir\\keepassxc.ini\" \"$persist_dir\" -Force }"
-        ]
-    },
     "bin": [
         "KeePassXC.exe",
         "keepassxc-cli.exe",
@@ -35,6 +26,7 @@
             "KeePassXC"
         ]
     ],
+    "persist": "config",
     "checkver": {
         "github": "https://github.com/keepassxreboot/keepassxc"
     },

--- a/bucket/keepassxc.json
+++ b/bucket/keepassxc.json
@@ -15,6 +15,7 @@
             "extract_dir": "KeePassXC-2.6.0-Win32"
         }
     },
+    "post_install": "if (Test-Path \"$persist_dir\\keepassxc.ini\") { Move-Item \"$persist_dir\\keepassxc.ini\" \"$dir\\config\" -Force }",
     "bin": [
         "KeePassXC.exe",
         "keepassxc-cli.exe",


### PR DESCRIPTION
- Closes #4395 

Since version 2.6.0 KeePassXC stores its portable configuration in the 'config' folder. Which makes it very convenient to persist.