### PR TITLE
qv2ray: Update to version 2.6.0

### DIFF
--- a/bucket/qv2ray.json
+++ b/bucket/qv2ray.json
@@ -9,12 +9,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Qv2ray/Qv2ray/releases/download/v2.5.0/Qv2ray.v2.5.0.Windows-x64.7z",
-            "hash": "5e48fe0e76b49c8860613e0ea9731ef82073119eae6ccd5593fe99a69406368f"
+            "url": "https://github.com/Qv2ray/Qv2ray/releases/download/v2.6.0/Qv2ray.v2.6.0.Windows-x64.7z",
+            "hash": "9e559c22899ec7640c8cf6846a06d503f1ab44c66689e0e9163c81739dfa713f"
         },
         "32bit": {
-            "url": "https://github.com/Qv2ray/Qv2ray/releases/download/v2.5.0/Qv2ray.v2.5.0.Windows-x86.7z",
-            "hash": "a70114eeebe2f6efee6ded378a530cb8521172cbf5fe968925cd796c53c9f9b3"
+            "url": "https://github.com/Qv2ray/Qv2ray/releases/download/v2.6.0/Qv2ray.v2.6.0.Windows-x86.7z",
+            "hash": "ea5f4de011916a7f7f6544f029ef8c6a656748136c2a91b124a349f426932a67"
         }
     },
     "extract_dir": "deployment",


### PR DESCRIPTION
[Qv2ray v2.6.0](https://github.com/Qv2ray/Qv2ray/releases/tag/v2.6.0) has been released.