### PR TITLE
mumble: Fixed hash for version 1.3.2

### DIFF
--- a/bucket/mumble.json
+++ b/bucket/mumble.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.mumble.info/",
     "license": "BSD-3-Clause",
     "url": "https://github.com/mumble-voip/mumble/releases/download/1.3.2/mumble-1.3.2.msi",
-    "hash": "abddb4158f34bef0522b828dbca8e00d57f6a63098fc545f28b00a31a98725a3",
+    "hash": "a5d4814cfdb2cb3e455320e3149318466f61eaa6673f99a6644e5720e5da09e4",
     "extract_dir": "Mumble",
     "bin": [
         "mumble.exe",


### PR DESCRIPTION
The hash present in the manifest does not match the correct hash of the `mumble-1.3.2.msi` file as verified by GPG.

This PR updates the hash to its correct value for that version.