### PR TITLE
pdfsam-visual: Add version 2.1.7

### DIFF
--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -28,8 +28,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual_$version-windows_x64.zip",
-                "extract_dir": "pdfsam-visual_$version-windows_x64"
+                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual_$version-windows_x64.zip"
             },
             "32bit": {
                 "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual-$version-windows_ia32.zip"

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -16,7 +16,6 @@
             "hash": "432250dded6b017e4423936db0bdd14ff1ac5bc0c4479a93c0b03c7c538403da"
         }
     },
-    "bin": "PDFsam Visual.exe",
     "shortcuts": [
         [
             "PDFsam Visual.exe",

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -31,8 +31,7 @@
                 "extract_dir": "pdfsam-visual_$version-windows_x64"
             },
             "32bit": {
-                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual_$version-windows_ia32.zip",
-                "extract_dir": "pdfsam-visual_$version-windows_ia32"
+                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual-$version-windows_ia32.zip"
             }
         }
     }

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -9,8 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual_2.1.7-windows_x64.zip",
-            "hash": "6D7C5FC418BFCD5B5DD42E4562C102AC88181CE61CE575317433F3152692A098",
-            "extract_dir": "./"
+            "hash": "6d7c5fc418bfcd5b5dd42e4562c102ac88181ce61ce575317433f3152692a098"
         },
         "32bit": {
             "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual-2.1.7-windows_ia32.zip",

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -11,8 +11,7 @@
         },
         "32bit": {
             "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual-2.1.7-windows_ia32.zip",
-            "hash": "432250DDED6B017E4423936DB0BDD14FF1AC5BC0C4479A93C0B03C7C538403DA",
-            "extract_dir": "pdfsam-visual_2.1.7-windows_ia32"
+            "hash": "432250dded6b017e4423936db0bdd14ff1ac5bc0c4479a93c0b03c7c538403da"
         }
     },
     "bin": "PDFsam Visual.exe",

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.1.7",
+    "description": "PDFsam Visual is a powerful tool to visually compose PDF files, reorder pages, delete pages, extract pages, split, merge and much more. The Merge PDF, Alternate Mix, Split by bookmarks and Split by size tools are free and will continue to work even after the trial period expires.",
+    "homepage": "https://github.com/torakiki/pdfsam-visual-public",
+    "license": "EULA",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual_2.1.7-windows_x64.zip",
+            "hash": "6D7C5FC418BFCD5B5DD42E4562C102AC88181CE61CE575317433F3152692A098",
+            "extract_dir": "./"
+        },
+        "32bit": {
+            "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual-2.1.7-windows_ia32.zip",
+            "hash": "432250DDED6B017E4423936DB0BDD14FF1AC5BC0C4479A93C0B03C7C538403DA",
+            "extract_dir": "pdfsam-visual_2.1.7-windows_ia32"
+        }
+    },
+    "bin": "PDFsam Visual.exe",
+    "shortcuts": [
+        [
+            "PDFsam Visual.exe",
+            "PDFsam Visual"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual_$version-windows_x64.zip",
+                "extract_dir": "pdfsam-visual_$version-windows_x64"
+            },
+            "32bit": {
+                "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v$version/pdfsam-visual_$version-windows_ia32.zip",
+                "extract_dir": "pdfsam-visual_$version-windows_ia32"
+            }
+        }
+    }
+}

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -1,8 +1,11 @@
 {
     "version": "2.1.7",
-    "description": "PDFsam Visual is a powerful tool to visually compose PDF files, reorder pages, delete pages, extract pages, split, merge and much more. The Merge PDF, Alternate Mix, Split by bookmarks and Split by size tools are free and will continue to work even after the trial period expires.",
-    "homepage": "https://github.com/torakiki/pdfsam-visual-public",
-    "license": "EULA",
+    "description": "A visual PDF tool to compose, combine, delete pages, crop and much more",
+    "homepage": "https://pdfsam.org/pdfsam-visual/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://pdfsam.org/pdfsam-visual/eula/"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/torakiki/pdfsam-visual-public/releases/download/v2.1.7/pdfsam-visual_2.1.7-windows_x64.zip",

--- a/bucket/pdfsam-visual.json
+++ b/bucket/pdfsam-visual.json
@@ -22,7 +22,9 @@
             "PDFsam Visual"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/torakiki/pdfsam-visual-public"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Hey guys. I add a new software pdfsam-visual. But when I install it, I encounter a problem below.

```
Installing 'pdfsam-visual' (2.1.7) [64bit]
Loading pdfsam-visual_2.1.7-windows_x64.zip from cache
Checking hash of pdfsam-visual_2.1.7-windows_x64.zip ... ok.
Extracting pdfsam-visual_2.1.7-windows_x64.zip ... done.
Linking ~\scoop\apps\pdfsam-visual\current => ~\scoop\apps\pdfsam-visual\2.1.7
Creating shim for 'PDFsam Visual'.
Can't shim 'PDFsam Visual.exe': File doesn't exist.
```

If you can help, please feel free to modify this PR.