### PR TITLE
gimp: Add gimp-console bin

### DIFF
--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -42,7 +42,7 @@
         [
             "bin\\gimp-console-2.10.exe",
             "gimp-console",
-            "gimp",
+            "gimp"
         ],
         "bin\\gimptool-2.0.exe",
         [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -41,17 +41,13 @@
         "bin\\gimp-console-2.10.exe",
         [
             "bin\\gimp-console-2.10.exe",
-            "gimp-console"
+            "gimp-console",
+            "gimp",
         ],
         "bin\\gimptool-2.0.exe",
         [
             "bin\\gimptool-2.0.exe",
             "gimptool"
-        ],
-        "bin\\gimp-2.10.exe",
-        [
-            "bin\\gimp-2.10.exe",
-            "gimp"
         ]
     ],
     "shortcuts": [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -12,7 +12,6 @@
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
             "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,2.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   New-Item '32\\etc', '32\\share', 'share\\gimp\\2.0\\fonts' -ItemType 'Directory' | Out-Null",

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -47,12 +47,17 @@
         [
             "bin\\gimptool-2.0.exe",
             "gimptool"
+        ],
+        "bin\\gimp-2.10.exe",
+        [
+            "bin\\gimp-2.10.exe",
+            "gimp"
         ]
     ],
     "shortcuts": [
         [
             "bin\\gimp-2.10.exe",
-            "gimp"
+            "GIMP"
         ]
     ],
     "persist": [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -12,7 +12,7 @@
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
             "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
-            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,3.exe'",
+            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,*.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   New-Item '32\\etc', '32\\share', 'share\\gimp\\2.0\\fonts' -ItemType 'Directory' | Out-Null",

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -12,6 +12,7 @@
             "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
             "if ($architecture -eq '64bit') {",
             "   Rename-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,1.exe' 'twain.exe'",
+            "   Remove-Item 'lib\\gimp\\2.0\\plug-ins\\twain\\twain,3.exe'",
             "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
             "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
             "   New-Item '32\\etc', '32\\share', 'share\\gimp\\2.0\\fonts' -ItemType 'Directory' | Out-Null",

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -41,8 +41,12 @@
         "bin\\gimp-console-2.10.exe",
         [
             "bin\\gimp-console-2.10.exe",
-            "gimp-console",
             "gimp"
+        ],
+        "bin\\gimp-console-2.10.exe",
+        [
+            "bin\\gimp-console-2.10.exe",
+            "gimp-console"
         ],
         "bin\\gimptool-2.0.exe",
         [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -41,7 +41,7 @@
         "bin\\gimp-console-2.10.exe",
         [
             "bin\\gimp-console-2.10.exe",
-            "gimp"
+            "gimp-console"
         ],
         "bin\\gimptool-2.0.exe",
         [
@@ -52,7 +52,7 @@
     "shortcuts": [
         [
             "bin\\gimp-2.10.exe",
-            "GIMP"
+            "gimp"
         ]
     ],
     "persist": [

--- a/bucket/gimp.json
+++ b/bucket/gimp.json
@@ -43,7 +43,6 @@
             "bin\\gimp-console-2.10.exe",
             "gimp"
         ],
-        "bin\\gimp-console-2.10.exe",
         [
             "bin\\gimp-console-2.10.exe",
             "gimp-console"


### PR DESCRIPTION
* Fixes install error `twain,2.exe` renamed to `twain,3.exe`, fixes: (**Edit:** fixed prior via #3814)
    ```diff
    Extracting gimp-2.10.20-setup-1.exe ... done.
    Running installer script..
    - Remove-Item : Cannot find path 'C:\Users\owner\scoop\apps\gimp\2.10.20-1\lib\gimp\2.0\plug-ins\twain\twain,2.exe' because it does not exist.
    - At line:5 char:4
    -    Remove-Item 'lib\gimp\2.0\plug-ins\twain\twain,2.exe'
    -    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    - CategoryInfo          : ObjectNotFound: (C:\Users\owner\...ain\twain,2.exe:String) [Remove-Item], ItemNotFoundException
    - FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand
    ```



* Add command-line tool to match Windows:`gimp-console` (was `gimp`).
* ~~Adds `gimp` as command to start GUI~~<br>Removed, see https://github.com/lukesampson/scoop-extras/pull/4444#pullrequestreview-454620032