### PR TITLE
dnspy: Update to version 6.1.6

### DIFF
--- a/bucket/dnspy.json
+++ b/bucket/dnspy.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.1.5",
+    "version": "6.1.6",
     "description": ".NET debugger and assembly editor.",
     "homepage": "https://github.com/0xd4d/dnSpy",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/0xd4d/dnSpy/releases/download/v6.1.5/dnSpy-netcore-win64.zip",
-            "hash": "4f6166f38ba331de242de219914ab2f78d115bbb6e536d324f133e5e4fc77b40"
+            "url": "https://github.com/0xd4d/dnSpy/releases/download/v6.1.6/dnSpy-netcore-win64.zip",
+            "hash": "080cae8f6519ae9b2ad02a438e526ebd816ce9fa9f2152bd5c47f4e05bdaaa42"
         },
         "32bit": {
-            "url": "https://github.com/0xd4d/dnSpy/releases/download/v6.1.5/dnSpy-netcore-win32.zip",
-            "hash": "bc1b6a85bb96107eb6ed76b8c11e760290057186c7e67a28de5be1685652d807"
+            "url": "https://github.com/0xd4d/dnSpy/releases/download/v6.1.6/dnSpy-netcore-win32.zip",
+            "hash": "2b92482cc3a3c3cf21acbfa4438ba24440db417ac0e76170b916578b9cfa1764"
         }
     },
     "bin": [


### PR DESCRIPTION
dnspy was deprecated in 5743104bd3e8200cc29f6a28df3b5ff37ff2caa7 because version 6.1.5 was identified as a virus and therefore the downloads were removed, see https://github.com/0xd4d/dnSpy/issues/1493#issuecomment-654166657

Now, the new version 6.1.6 is back in the GitHub releases.

The dnSpy-netcore-win32.zip for version 6.1.6 file is flagged by Chrome as dangerous, though. :-/ The 64-bits version is OK.