### PR TITLE
MagicaVoxel: Update to version 0.99.6

### DIFF
--- a/bucket/MagicaVoxel.json
+++ b/bucket/MagicaVoxel.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.99.6",
-  "description": "A free lightweight 8-bit voxel art editor and GPU based interactive path tracing renderer.",
-  "homepage": "https://ephtracy.github.io/",
-  "license": "Unknown",
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win64.zip",
-      "hash": "sha512:a314f1db317437fda470e2d9b9141550f78be5c4fb7a2897ecd34828c8bd8daeb47ffb28bca771b08aeaf74eb4873b401b07c6b69ac3f8a837392006119f1de7",
-      "extract_dir": "MagicaVoxel-0.99.6-win64"
-    },
-    "32bit": {
-      "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win32.zip",
-      "hash": "sha512:ad085803eb0c0617e24e72e4ff90c10410b39db79a8137a57993240bebf679cfaf3000aec58957f6e48eb00c609b542adfdc966dfcdc6e74844dcb58b7d897e0",
-      "extract_dir": "MagicaVoxel-0.99.6-win32"
-    }
-  },
-  "bin": "MagicaVoxel.exe",
-  "shortcuts": [
-    [
-      "MagicaVoxel.exe",
-      "MagicaVoxel"
-    ]
-  ],
-  "checkver": {
-    "github": "https://github.com/ephtracy/ephtracy.github.io/"
-  },
-  "autoupdate": {
+    "version": "0.99.6",
+    "description": "A free lightweight 8-bit voxel art editor and GPU based interactive path tracing renderer.",
+    "homepage": "https://ephtracy.github.io/",
+    "license": "Unknown",
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win64.zip",
-        "extract_dir": "MagicaVoxel-$version-win64"
-      },
-      "32bit": {
-        "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win32.zip",
-        "extract_dir": "MagicaVoxel-$version-win32"
-      }
+        "64bit": {
+            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win64.zip",
+            "hash": "2de37d619ecc53f411cfcf914329685d57903288d2b993f9e5c3ec906521a9c2",
+            "extract_dir": "MagicaVoxel-0.99.6-win64"
+        },
+        "32bit": {
+            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win32.zip",
+            "hash": "4d6d8b277c2c2c5911b3f3b7be680e6368c7e7ce7754aba8efd847a14a826e54",
+            "extract_dir": "MagicaVoxel-0.99.6-win32"
+        }
+    },
+    "bin": "MagicaVoxel.exe",
+    "shortcuts": [
+        [
+            "MagicaVoxel.exe",
+            "MagicaVoxel"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ephtracy/ephtracy.github.io"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win64.zip",
+                "extract_dir": "MagicaVoxel-$version-win64"
+            },
+            "32bit": {
+                "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win32.zip",
+                "extract_dir": "MagicaVoxel-$version-win32"
+            }
+        }
     }
-  }
 }

--- a/bucket/MagicaVoxel.json
+++ b/bucket/MagicaVoxel.json
@@ -1,40 +1,40 @@
 {
-    "version": "0.99.4",
-    "description": "A free lightweight 8-bit voxel art editor and GPU based interactive path tracing renderer.",
-    "homepage": "https://ephtracy.github.io/",
-    "license": "Unknown",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.4/MagicaVoxel-0.99.4-alpha-win64.zip",
-            "hash": "5ec8df959b81ce9d0d338aa280b04998596188d60693fef333d90a7be92d9c2d",
-            "extract_dir": "MagicaVoxel-0.99.4-alpha-win64"
-        },
-        "32bit": {
-            "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.4/MagicaVoxel-0.99.4-alpha-win32.zip",
-            "hash": "be466e7852c06d544cb7bb41fe054cfe4751b8a290a4c7cc3496e95d5ee4dc13",
-            "extract_dir": "MagicaVoxel-0.99.4-alpha-win32"
-        }
+  "version": "0.99.6",
+  "description": "A free lightweight 8-bit voxel art editor and GPU based interactive path tracing renderer.",
+  "homepage": "https://ephtracy.github.io/",
+  "license": "Unknown",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win64.zip",
+      "hash": "sha512:a314f1db317437fda470e2d9b9141550f78be5c4fb7a2897ecd34828c8bd8daeb47ffb28bca771b08aeaf74eb4873b401b07c6b69ac3f8a837392006119f1de7",
+      "extract_dir": "MagicaVoxel-0.99.6-win64"
     },
-    "bin": "MagicaVoxel.exe",
-    "shortcuts": [
-        [
-            "MagicaVoxel.exe",
-            "MagicaVoxel"
-        ]
-    ],
-    "checkver": {
-        "github": "https://github.com/ephtracy/ephtracy.github.io/"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-alpha-win64.zip",
-                "extract_dir": "MagicaVoxel-$version-alpha-win64"
-            },
-            "32bit": {
-                "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-alpha-win32.zip",
-                "extract_dir": "MagicaVoxel-$version-alpha-win32"
-            }
-        }
+    "32bit": {
+      "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/0.99.6/MagicaVoxel-0.99.6-win32.zip",
+      "hash": "sha512:ad085803eb0c0617e24e72e4ff90c10410b39db79a8137a57993240bebf679cfaf3000aec58957f6e48eb00c609b542adfdc966dfcdc6e74844dcb58b7d897e0",
+      "extract_dir": "MagicaVoxel-0.99.6-win32"
     }
+  },
+  "bin": "MagicaVoxel.exe",
+  "shortcuts": [
+    [
+      "MagicaVoxel.exe",
+      "MagicaVoxel"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/ephtracy/ephtracy.github.io/"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win64.zip",
+        "extract_dir": "MagicaVoxel-$version-win64"
+      },
+      "32bit": {
+        "url": "https://github.com/ephtracy/ephtracy.github.io/releases/download/$version/MagicaVoxel-$version-win32.zip",
+        "extract_dir": "MagicaVoxel-$version-win32"
+      }
+    }
+  }
 }


### PR DESCRIPTION
The **-alpha** had been dropped from the versioning for some time now.