### PR TITLE
nwjs(-sdk): Fix conflict with native scoop files

### DIFF
--- a/bucket/godot-mono.json
+++ b/bucket/godot-mono.json
@@ -16,7 +16,8 @@
     "pre_install": [
         "(Get-ChildItem \"$dir\\Godot_*\\Godot_*.exe\" | Rename-Item -NewName \"godot.exe\");",
         "(Get-ChildItem \"$dir\\Godot_*\\*\" | Move-Item -Destination \"$dir\");",
-        "Remove-Item \"$dir\\Godot_*\""
+        "Remove-Item \"$dir\\Godot_*\"",
+        "New-Item \"$dir\\_sc_\" -ItemType \"file\" | Out-Null"
     ],
     "bin": "godot.exe",
     "shortcuts": [
@@ -25,6 +26,7 @@
             "GodotMono"
         ]
     ],
+    "persist": "editor_data",
     "checkver": {
         "url": "https://godotengine.org/download",
         "regex": "<h2>Godot <em>([\\d.]+)</em></h2>"

--- a/bucket/godot.json
+++ b/bucket/godot.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.2",
+    "version": "3.2.2-2",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
@@ -13,7 +13,10 @@
             "hash": "5d99d41df6a9c46fb8da2c156df560e71a81c7d2a50bbc12ed210602d0f86a97"
         }
     },
-    "pre_install": "Get-ChildItem \"$dir\\Godot_*.exe\" | Rename-Item -NewName \"$dir\\godot.exe\"",
+    "pre_install": [
+        "Get-ChildItem \"$dir\\Godot_*.exe\" | Rename-Item -NewName \"$dir\\godot.exe\"",
+        "New-Item \"$dir\\_sc_\" -ItemType \"file\" | Out-Null"
+    ],
     "bin": "godot.exe",
     "shortcuts": [
         [
@@ -21,6 +24,7 @@
             "Godot"
         ]
     ],
+    "persist": "editor_data",
     "checkver": {
         "url": "https://godotengine.org/download",
         "regex": "<h2>Godot <em>([\\d.]+)</em></h2>"

--- a/bucket/nwjs-sdk.json
+++ b/bucket/nwjs-sdk.json
@@ -7,22 +7,20 @@
         "64bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-sdk-v0.47.2-win-x64.zip",
             "hash": "8720aeea031f5bf4f39ef7c7feaf4d2fdf398b28cca8c39581ce87a40f146f74",
-            "bin": [
-                "nwjs-sdk-v0.47.2-win-x64/nw.exe",
-                "nwjs-sdk-v0.47.2-win-x64/nwjc.exe",
-                "nwjs-sdk-v0.47.2-win-x64/payload.exe"
-            ]
+            "extract_dir": "nwjs-sdk-v0.47.2-win-x64"
         },
         "32bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-sdk-v0.47.2-win-ia32.zip",
             "hash": "231996252961b020c5434ac0acebc694e42879f7dba4287e6bc12244eb7bd581",
-            "bin": [
-                "nwjs-sdk-v0.47.2-win-ia32/nw.exe",
-                "nwjs-sdk-v0.47.2-win-ia32/nwjc.exe",
-                "nwjs-sdk-v0.47.2-win-ia32/payload.exe"
-            ]
+            "extract_dir": "nwjs-sdk-v0.47.2-win-ia32"
         }
     },
+    "extract_to": "nwjs-sdk",
+    "bin": [
+        "nwjs-sdk/nw.exe",
+        "nwjs-sdk/nwjc.exe",
+        "nwjs-sdk/payload.exe"
+    ],
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",
@@ -32,19 +30,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-sdk-v$version-win-x64.zip",
-                "bin": [
-                    "nwjs-sdk-v$version-win-x64/nw.exe",
-                    "nwjs-sdk-v$version-win-x64/nwjc.exe",
-                    "nwjs-sdk-v$version-win-x64/payload.exe"
-                ]
+                "extract_dir": "nwjs-sdk-v$version-win-x64"
             },
             "32bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-sdk-v$version-win-ia32.zip",
-                "bin": [
-                    "nwjs-sdk-v$version-win-ia32/nw.exe",
-                    "nwjs-sdk-v$version-win-ia32/nwjc.exe",
-                    "nwjs-sdk-v$version-win-ia32/payload.exe"
-                ]
+                "extract_dir": "nwjs-sdk-v$version-win-ia32"
             }
         },
         "hash": {

--- a/bucket/nwjs-sdk.json
+++ b/bucket/nwjs-sdk.json
@@ -1,25 +1,28 @@
 {
     "version": "0.47.2",
     "description": "An app runtime based on Chromium and NodeJS",
-    "homepage": "https://nwjs.io/",
+    "homepage": "https://nwjs.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-sdk-v0.47.2-win-x64.zip",
             "hash": "8720aeea031f5bf4f39ef7c7feaf4d2fdf398b28cca8c39581ce87a40f146f74",
-            "extract_dir": "nwjs-sdk-v0.47.2-win-x64"
+            "bin": [
+                "nwjs-sdk-v0.47.2-win-x64/nw.exe",
+                "nwjs-sdk-v0.47.2-win-x64/nwjc.exe",
+                "nwjs-sdk-v0.47.2-win-x64/payload.exe"
+            ]
         },
         "32bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-sdk-v0.47.2-win-ia32.zip",
             "hash": "231996252961b020c5434ac0acebc694e42879f7dba4287e6bc12244eb7bd581",
-            "extract_dir": "nwjs-sdk-v0.47.2-win-ia32"
+            "bin": [
+                "nwjs-sdk-v0.47.2-win-ia32/nw.exe",
+                "nwjs-sdk-v0.47.2-win-ia32/nwjc.exe",
+                "nwjs-sdk-v0.47.2-win-ia32/payload.exe"
+            ]
         }
     },
-    "bin": [
-        "nw.exe",
-        "nwjc.exe",
-        "payload.exe"
-    ],
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",
@@ -29,11 +32,19 @@
         "architecture": {
             "64bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-sdk-v$version-win-x64.zip",
-                "extract_dir": "nwjs-sdk-v$version-win-x64"
+                "bin": [
+                    "nwjs-sdk-v$version-win-x64/nw.exe",
+                    "nwjs-sdk-v$version-win-x64/nwjc.exe",
+                    "nwjs-sdk-v$version-win-x64/payload.exe"
+                ]
             },
             "32bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-sdk-v$version-win-ia32.zip",
-                "extract_dir": "nwjs-sdk-v$version-win-ia32"
+                "bin": [
+                    "nwjs-sdk-v$version-win-ia32/nw.exe",
+                    "nwjs-sdk-v$version-win-ia32/nwjc.exe",
+                    "nwjs-sdk-v$version-win-ia32/payload.exe"
+                ]
             }
         },
         "hash": {

--- a/bucket/nwjs-sdk.json
+++ b/bucket/nwjs-sdk.json
@@ -17,9 +17,9 @@
     },
     "extract_to": "nwjs-sdk",
     "bin": [
-        "nwjs-sdk/nw.exe",
-        "nwjs-sdk/nwjc.exe",
-        "nwjs-sdk/payload.exe"
+        "nwjs-sdk\nw.exe",
+        "nwjs-sdk\nwjc.exe",
+        "nwjs-sdk\payload.exe"
     ],
     "checkver": {
         "url": "https://nwjs.io/versions.json",

--- a/bucket/nwjs-sdk.json
+++ b/bucket/nwjs-sdk.json
@@ -17,9 +17,9 @@
     },
     "extract_to": "nwjs-sdk",
     "bin": [
-        "nwjs-sdk\nw.exe",
-        "nwjs-sdk\nwjc.exe",
-        "nwjs-sdk\payload.exe"
+        "nwjs-sdk\\nw.exe",
+        "nwjs-sdk\\nwjc.exe",
+        "nwjs-sdk\\payload.exe"
     ],
     "checkver": {
         "url": "https://nwjs.io/versions.json",

--- a/bucket/nwjs.json
+++ b/bucket/nwjs.json
@@ -7,14 +7,16 @@
         "64bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-v0.47.2-win-x64.zip",
             "hash": "a0943fa90c161e79aaea028c10ff887bac352a0adf12f06ad4c7d629398853f8",
-            "bin": "nwjs-v0.47.2-win-x64/nw.exe"
+            "extract_dir": "nwjs-v0.47.2-win-x64"
         },
         "32bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-v0.47.2-win-ia32.zip",
             "hash": "d382019f080a51ede286ac7977ba682317aa0d5042b558fdd925bc0138e66bee",
-            "bin": "nwjs-v0.47.2-win-ia32/nw.exe"
+            "extract_dir": "nwjs-v0.47.2-win-ia32"
         }
     },
+    "extract_to": "nwjs",
+    "bin": "nwjs/nw.exe",
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",
@@ -24,11 +26,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-v$version-win-x64.zip",
-                "bin": "nwjs-v$version-win-x64/nw.exe"
+                "extract_dir": "nwjs-v$version-win-x64"
             },
             "32bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-v$version-win-ia32.zip",
-                "bin": "nwjs-v$version-win-ia32/nw.exe"
+                "extract_dir": "nwjs-v$version-win-ia32"
             }
         },
         "hash": {

--- a/bucket/nwjs.json
+++ b/bucket/nwjs.json
@@ -16,7 +16,7 @@
         }
     },
     "extract_to": "nwjs",
-    "bin": "nwjs\nw.exe",
+    "bin": "nwjs\\nw.exe",
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",

--- a/bucket/nwjs.json
+++ b/bucket/nwjs.json
@@ -1,21 +1,20 @@
 {
     "version": "0.47.2",
     "description": "An app runtime based on Chromium and NodeJS",
-    "homepage": "https://nwjs.io/",
+    "homepage": "https://nwjs.io",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-v0.47.2-win-x64.zip",
             "hash": "a0943fa90c161e79aaea028c10ff887bac352a0adf12f06ad4c7d629398853f8",
-            "extract_dir": "nwjs-v0.47.2-win-x64"
+            "bin": "nwjs-v0.47.2-win-x64/nw.exe"
         },
         "32bit": {
             "url": "https://dl.nwjs.io/v0.47.2/nwjs-v0.47.2-win-ia32.zip",
             "hash": "d382019f080a51ede286ac7977ba682317aa0d5042b558fdd925bc0138e66bee",
-            "extract_dir": "nwjs-v0.47.2-win-ia32"
+            "bin": "nwjs-v0.47.2-win-ia32/nw.exe"
         }
     },
-    "bin": "nw.exe",
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",
@@ -25,11 +24,11 @@
         "architecture": {
             "64bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-v$version-win-x64.zip",
-                "extract_dir": "nwjs-v$version-win-x64"
+                "bin": "nwjs-v$version-win-x64/nw.exe"
             },
             "32bit": {
                 "url": "https://dl.nwjs.io/v$version/nwjs-v$version-win-ia32.zip",
-                "extract_dir": "nwjs-v$version-win-ia32"
+                "bin": "nwjs-v$version-win-ia32/nw.exe"
             }
         },
         "hash": {

--- a/bucket/nwjs.json
+++ b/bucket/nwjs.json
@@ -16,7 +16,7 @@
         }
     },
     "extract_to": "nwjs",
-    "bin": "nwjs/nw.exe",
+    "bin": "nwjs\nw.exe",
     "checkver": {
         "url": "https://nwjs.io/versions.json",
         "jsonpath": "$.stable",


### PR DESCRIPTION
Scoop's installation manifest was conflicting with NWjs' manifest system.

- Closes #3932