### PR TITLE
chromium@84.0.4147.125: Fix installation

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -8,7 +8,7 @@
         "64bit": {
             "url": "https://github.com/macchrome/winchrome/releases/download/v84.0.4147.125-r768962-Win64/ungoogled-chromium-84.0.4147.125-1_windows.7z",
             "hash": "sha1:dfc197d7d05192e44e9ad93f12a2116655e13b85",
-            "extract_dir": "ungoogled-chromium-84.0.4147.125-1_windows"
+            "extract_dir": "ungoogled-chromium-84.0.4147.125_windows"
         },
         "32bit": {
             "url": "https://github.com/macchrome/winchrome/releases/download/v84.0.4147.125-r768962-Win64/Ungoogled-Chromium-84.0.4147.125-Win32.7z",
@@ -37,7 +37,7 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/ungoogled-chromium-$version-1_windows.7z",
-                "extract_dir": "ungoogled-chromium-$version-1_windows"
+                "extract_dir": "ungoogled-chromium-$version_windows"
             },
             "32bit": {
                 "url": "https://github.com/macchrome/winchrome/releases/download/v$version-r$matchBuild-Win64/Ungoogled-Chromium-$version-Win32.7z",


### PR DESCRIPTION
The folder name seem to have changed as the -1 suffix was dropped in the latest version.