### PR TITLE
standardnotes@3.4.2: Fix url

### DIFF
--- a/bucket/standardnotes.json
+++ b/bucket/standardnotes.json
@@ -3,7 +3,7 @@
     "description": "A safe place for your notes, thoughts, and life's work.",
     "homepage": "https://standardnotes.org/",
     "license": "AGPL-3.0-or-later",
-    "url": "https://github.com/standardnotes/desktop/releases/download/v3.4.2/standard-notes-setup-3.4.2.exe#/dl.7z",
+    "url": "https://github.com/standardnotes/desktop/releases/download/v3.4.2/standard-notes-3.4.2-win.exe#/dl.7z",
     "hash": "sha512:bb21adfe7b4b6d6074abe2b46bf7675bd86156e2ef0cef8fb1f197163efb011a1472ec1d5add70ce48af757694acd01a22b5d21ecdc079082188e277a4813ca3",
     "architecture": {
         "64bit": {

--- a/bucket/standardnotes.json
+++ b/bucket/standardnotes.json
@@ -25,7 +25,7 @@
         "github": "https://github.com/standardnotes/desktop"
     },
     "autoupdate": {
-        "url": "https://github.com/standardnotes/desktop/releases/download/v$version/standard-notes-setup-$version.exe#/dl.7z",
+        "url": "https://github.com/standardnotes/desktop/releases/download/v$version/standard-notes-$version-win.exe#/dl.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512:\\s+$base64"


### PR DESCRIPTION
The URL changed:
OLD: https://github.com/standardnotes/desktop/releases/download/v3.4.2/standard-notes-setup-3.4.2.exe
NEW: https://github.com/standardnotes/desktop/releases/download/v3.4.2/standard-notes-3.4.2-win.exe