### PR TITLE
epstool: Add version 3.09

### DIFF
--- a/bucket/epstool.json
+++ b/bucket/epstool.json
@@ -1,0 +1,18 @@
+{
+    "version": "3.09",
+    "homepage": "http://www.ghostgum.com.au/software/epstool.htm",
+    "description": "Epstool is a utility to create or extract preview images in EPS files, fix bounding boxes and convert to bitmaps.",
+    "license": "GPLv2",
+    "url": "http://www.ghostgum.com.au/download/epstool-3.09.zip",
+    "hash": "F56F2987B1A0CC759FD6EA80FD49F85C1D4D1CC3B8C60798F8DDD9B42AA3C080",
+    "extract_dir": "epstool-3.09",
+    "bin": "epstool.exe",
+    "checkver": {
+        "url": "http://www.ghostgum.com.au/software/epstool.htm",
+        "regex": "\\[Grap the epstool ([\\d.]+)\\]"
+    },
+    "autoupdate": {
+            "url":"http://www.ghostgum.com.au/download/epstool-$version.zip",
+            "extract_dir":"epstool-$version"
+    }
+}


### PR DESCRIPTION
Epstool is a utility to create or extract preview images in EPS files, fix bounding boxes and convert to bitmaps.