### PR TITLE
clumsy: Add version 0.2

### DIFF
--- a/bucket/clumsy.json
+++ b/bucket/clumsy.json
@@ -1,26 +1,23 @@
 {
     "version": "0.2",
-    "description": "an utility for simulating broken network for Windows Vista / Windows 7 and above",
+    "description": "Broken network simulator",
     "homepage": "https://jagt.github.io/clumsy/",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win64.zip",
-            "bin": [
-                "clumsy.exe"
-            ]
+            "hash": "19042ae5e28412a8eb2dc67f4bc3b606ef04cb6f46ef72563f25e41b2bc67609"
         },
         "32bit": {
             "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win32.zip",
-            "bin": [
-                "clumsy.exe"
-            ]
+            "hash": "ad79829832996024981d0161d4862cf28f0d7839a6c6b1b81b55d6335a1b4df9"
         }
     },
+    "bin": "clumsy.exe",
     "shortcuts": [
         [
             "clumsy.exe",
-            "clumsy - broken network simulator"
+            "clumsy"
         ]
     ],
     "persist": "config.txt",
@@ -30,7 +27,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/jagt/clumsy/releases/download/$versionclumsy-$version-win32.zip"
+                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win64.zip"
             },
             "32bit": {
                 "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win32.zip"

--- a/bucket/clumsy.json
+++ b/bucket/clumsy.json
@@ -1,9 +1,8 @@
 {
-	"version": "0.2",
-	"description": "an utility for simulating broken network for Windows Vista / Windows 7 and above",
-	"homepage": "https://jagt.github.io/clumsy/",
+    "version": "0.2",
+    "description": "an utility for simulating broken network for Windows Vista / Windows 7 and above",
+    "homepage": "https://jagt.github.io/clumsy/",
     "license": "MIT",
-    
     "architecture": {
         "64bit": {
             "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win64.zip",
@@ -24,7 +23,7 @@
             "clumsy - broken network simulator"
         ]
     ],
-	"persist": "config.txt",
+    "persist": "config.txt",
     "checkver": {
         "github": "https://github.com/jagt/clumsy"
     },

--- a/bucket/clumsy.json
+++ b/bucket/clumsy.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win64.zip",
-            "hash": "19042ae5e28412a8eb2dc67f4bc3b606ef04cb6f46ef72563f25e41b2bc67609"
+            "hash": "md5:c5117edad320930d14d18c1cac2a4ccd"
         },
         "32bit": {
             "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win32.zip",
-            "hash": "ad79829832996024981d0161d4862cf28f0d7839a6c6b1b81b55d6335a1b4df9"
+            "hash": "md5:9aab0d257661a4f75831a7186254725b"
         }
     },
     "bin": "clumsy.exe",
@@ -32,6 +32,10 @@
             "32bit": {
                 "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win32.zip"
             }
+        },
+        "hash": {
+            "url": "https://jagt.github.io/clumsy/download.html",
+            "regex": "$basename</a>\\s*\\(MD5:$md5\\)"
         }
     }
 }

--- a/bucket/clumsy.json
+++ b/bucket/clumsy.json
@@ -1,0 +1,41 @@
+{
+	"version": "0.2",
+	"description": "an utility for simulating broken network for Windows Vista / Windows 7 and above",
+	"homepage": "https://jagt.github.io/clumsy/",
+    "license": "MIT",
+    
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win64.zip",
+            "bin": [
+                "clumsy.exe"
+            ]
+        },
+        "32bit": {
+            "url": "https://github.com/jagt/clumsy/releases/download/0.2/clumsy-0.2-win32.zip",
+            "bin": [
+                "clumsy.exe"
+            ]
+        }
+    },
+    "shortcuts": [
+        [
+            "clumsy.exe",
+            "clumsy - broken network simulator"
+        ]
+    ],
+	"persist": "config.txt",
+    "checkver": {
+        "github": "https://github.com/jagt/clumsy"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/jagt/clumsy/releases/download/$versionclumsy-$version-win32.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/jagt/clumsy/releases/download/$version/clumsy-$version-win32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
clumsy makes your network condition on Windows significantly worse, but in a managed and interactive manner. 

Fantastic for network testing games or other software