### PR TITLE
winsshterm: Add 64-bit architecture

### DIFF
--- a/bucket/winsshterm.json
+++ b/bucket/winsshterm.json
@@ -17,7 +17,7 @@
             "hash": "a13aba9ab58c87758f7deb3eada10621596992a9b36da448caaa8e06d0132282"
         }
     },
-    "extract_dir": "WinSSHTerm", 
+    "extract_dir": "WinSSHTerm",
     "bin": "WinSSHTerm.exe",
     "shortcuts": [
         [

--- a/bucket/winsshterm.json
+++ b/bucket/winsshterm.json
@@ -7,6 +7,10 @@
         "url": "https://winsshterm.blogspot.com/p/license.html"
     },
     "depends": "putty",
+    "suggest": {
+        "Copy files": "extras/winscp",
+        "X-server": "extras/vcxsrv"
+    },
     "architecture": {
         "64bit": {
             "url": "http://dl.winsshterm.net/WinSSHTerm-2.12.0-64.zip",
@@ -26,50 +30,36 @@
         ]
     ],
     "post_install": [
-        "New-Item -ItemType Directory -Force -Path \"$dir\\lib\" | Out-Null",
-        "New-Item -ItemType Directory -Force -Path \"$dir\\tools\" | Out-Null",
-        "New-Item -ItemType Directory -Force -Path \"$dir\\config\" | Out-Null",
+        "'lib', 'tools', 'config' | ForEach-Object { ensure \"$dir\\$_\" | Out-Null }",
         "",
         "$puttyDir = \"$(appdir putty $global)\\current\"",
-        "if (Test-Path \"$puttyDir\\putty.exe\") {",
-        "    cmd /c mklink /h \"$dir\\tools\\putty.exe\" \"$puttyDir\\putty.exe\"",
-        "} else { ",
-        "    Write-Output \"Error: putty.exe not found\";",
-        "}",
-        "if (Test-Path \"$puttyDir\\pageant.exe\") {",
-        "    cmd /c mklink /h \"$dir\\tools\\pageant.exe\" \"$puttyDir\\pageant.exe\"",
-        "} else {",
-        "    Write-Output \"Warning: putty's pageant.exe not found\";",
-        "}",
-        "if (Test-Path \"$puttyDir\\plink.exe\") {",
-        "    cmd /c mklink /h \"$dir\\tools\\plink.exe\" \"$puttyDir\\plink.exe\"",
-        "} else {",
-        "    Write-Output \"Warning: putty's plink.exe not found\";",
+        "'putty', 'pageant', 'plink' | ForEach-Object {",
+        "    if (Test-Path \"$puttyDir\\$_.exe\") {",
+        "        cmd /c mklink /h \"$dir\\tools\\$_.exe\" \"$puttyDir\\$_.exe\"",
+        "    } else {",
+        "         error \"$_.exe not found\"",
+        "    }",
         "}",
         "",
         "$winscpDir = \"$(appdir winscp $global)\\current\"",
         "if (Test-Path \"$winscpDir\\WinSCP.exe\") {",
         "    cmd /c mklink /j \"$dir\\tools\\WinSCP\" \"$winscpDir\"",
         "} else {",
-        "    Write-Output \"Note: Install WinSCP for File Transfer support\";",
+        "    info 'Install WinSCP for File Transfer support'",
         "}",
         "",
         "$vcxsrvDir = \"$(appdir vcxsrv $global)\\current\"",
         "if (Test-Path \"$vcxsrvDir\\vcxsrv.exe\") {",
         "    cmd /c mklink /j \"$dir\\tools\\VcXsrv\" \"$vcxsrvDir\" ",
         "} else {",
-        "    Write-Output \"Note: Install VcXsrv for X-Server support\";",
+        "    info 'Install VcXsrv for X-Server support'",
         "}",
         "",
         "if (!(Test-Path \"$dir\\config\\preferences.xml\")) { ",
         "    $preferencesXml = '<?xml version=\"1.0\" encoding=\"utf-8\"?><Settings><CheckForXServer>False</CheckForXServer><CheckForWinSCP>False</CheckForWinSCP><CheckForPageant>False</CheckForPageant></Settings>'",
-        "    Set-Content -Path \"$dir\\config\\preferences.xml\" -Encoding UTF8 -Value $preferencesXml ",
+        "    Set-Content -Path \"$dir\\config\\preferences.xml\" -Value $preferencesXml -Encoding Ascii",
         "}"
     ],
-    "suggest": {
-        "Copy files": "extras/winscp",
-        "X-server": "extras/vcxsrv"
-    },
     "persist": [
         "config",
         "tools"
@@ -81,14 +71,14 @@
                 "url": "http://dl.winsshterm.net/WinSSHTerm-$version-64.zip",
                 "hash": {
                     "url": "https://winsshterm.blogspot.com/",
-                    "find": "SHA256 \\(.ZIP64\\):\\s*([A-Fa-f0-9]{64})"
+                    "regex": "SHA256 \\(.ZIP64\\):\\s*$sha256"
                 }
             },
             "32bit": {
                 "url": "http://dl.winsshterm.net/WinSSHTerm-$version.zip",
                 "hash": {
                     "url": "https://winsshterm.blogspot.com/",
-                    "find": "SHA256 \\(.ZIP\\):\\s*([A-Fa-f0-9]{64})"
+                    "regex": "SHA256 \\(.ZIP\\):\\s*$sha256"
                 }
             }
         }

--- a/bucket/winsshterm.json
+++ b/bucket/winsshterm.json
@@ -16,7 +16,7 @@
             "url": "http://dl.winsshterm.net/WinSSHTerm-2.12.0.zip",
             "hash": "a13aba9ab58c87758f7deb3eada10621596992a9b36da448caaa8e06d0132282"
         }
-    },   
+    },
     "extract_dir": "WinSSHTerm", 
     "bin": "WinSSHTerm.exe",
     "shortcuts": [

--- a/bucket/winsshterm.json
+++ b/bucket/winsshterm.json
@@ -7,9 +7,17 @@
         "url": "https://winsshterm.blogspot.com/p/license.html"
     },
     "depends": "putty",
-    "url": "http://dl.winsshterm.net/WinSSHTerm-2.12.0.zip",
-    "extract_dir": "WinSSHTerm",
-    "hash": "a13aba9ab58c87758f7deb3eada10621596992a9b36da448caaa8e06d0132282",
+    "architecture": {
+        "64bit": {
+            "url": "http://dl.winsshterm.net/WinSSHTerm-2.12.0-64.zip",
+            "hash": "8dd789933fc61ecf09a238845733f2a687c610d18e964e73a826d6749452ab89"
+        },
+        "32bit": {
+            "url": "http://dl.winsshterm.net/WinSSHTerm-2.12.0.zip",
+            "hash": "a13aba9ab58c87758f7deb3eada10621596992a9b36da448caaa8e06d0132282"
+        }
+    },   
+    "extract_dir": "WinSSHTerm", 
     "bin": "WinSSHTerm.exe",
     "shortcuts": [
         [
@@ -68,10 +76,21 @@
     ],
     "checkver": "WinSSHTerm-([\\d.]+)\\.zip",
     "autoupdate": {
-        "url": "http://dl.winsshterm.net/WinSSHTerm-$version.zip",
-        "hash": {
-            "url": "https://winsshterm.blogspot.com/",
-            "find": "SHA256 \\(.ZIP\\):\\s*([A-Fa-f0-9]{64})"
+       "architecture": {
+            "64bit": {
+                "url": "http://dl.winsshterm.net/WinSSHTerm-$version-64.zip",
+                "hash": {
+                    "url": "https://winsshterm.blogspot.com/",
+                    "find": "SHA256 \\(.ZIP64\\):\\s*([A-Fa-f0-9]{64})"
+                }
+            },
+            "32bit": {
+                "url": "http://dl.winsshterm.net/WinSSHTerm-$version.zip",
+                "hash": {
+                    "url": "https://winsshterm.blogspot.com/",
+                    "find": "SHA256 \\(.ZIP\\):\\s*([A-Fa-f0-9]{64})"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Closes #4635

Starting with version 2.12.0, there is also a 64-bit version available. The architecture of WinSSHTerm must match the architecture of PuTTY.