### PR TITLE
markdown-monster: Update to version 1.23.17.3

### DIFF
--- a/bucket/markdown-monster.json
+++ b/bucket/markdown-monster.json
@@ -1,13 +1,15 @@
 {
     "version": "1.23.17.3",
-    "description": "Markdown editing and weblog publishing tool.",
+    "description": "Markdown editing and weblog publishing tool",
     "homepage": "https://markdownmonster.west-wind.com",
     "license": {
         "identifier": "Proprietary",
         "url": "https://markdownmonster.west-wind.com/purchase.aspx#License"
     },
-    "url": "https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/CurrentRelease/MarkdownMonsterSetup.exe",
-    "hash": "30A2911AE377F1CE408DEAAC439F4A1F7CAC2B64B7977FC01FE53E30A0854DF4",
+    "url": "https://raw.githubusercontent.com/RickStrahl/MarkdownMonsterReleases/master/v1.23/MarkdownMonsterSetup-1.23.17.3.exe",
+    "hash": "30a2911ae377f1ce408deaac439f4a1f7cac2b64b7977fc01fe53e30a0854df4",
+    "innosetup": true,
+    "pre_install": "New-Item \"$dir\\_IsPortable\" | Out-Null",
     "bin": [
         "mm.exe",
         "MarkdownMonster.exe"

--- a/bucket/markdown-monster.json
+++ b/bucket/markdown-monster.json
@@ -24,7 +24,7 @@
         "xpath": "/VersionInfo/Version"
     },
     "autoupdate": {
-        "url": "https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/CurrentRelease/MarkdownMonsterSetup.exe"
+        "url": "https://raw.githubusercontent.com/RickStrahl/MarkdownMonsterReleases/master/v$majorVersion.$minorVersion/MarkdownMonsterSetup-$version.exe"
     },
     "innosetup": true
 }

--- a/bucket/markdown-monster.json
+++ b/bucket/markdown-monster.json
@@ -25,6 +25,5 @@
     },
     "autoupdate": {
         "url": "https://raw.githubusercontent.com/RickStrahl/MarkdownMonsterReleases/master/v$majorVersion.$minorVersion/MarkdownMonsterSetup-$version.exe"
-    },
-    "innosetup": true
+    }
 }

--- a/bucket/markdown-monster.json
+++ b/bucket/markdown-monster.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.23.17.4",
+    "version": "1.23.17.3",
     "description": "Markdown editing and weblog publishing tool.",
     "homepage": "https://markdownmonster.west-wind.com",
     "license": {
         "identifier": "Proprietary",
         "url": "https://markdownmonster.west-wind.com/purchase.aspx#License"
     },
-    "url": "https://west-wind.com/files/MarkdownMonsterPortable.zip",
-    "hash": "212da9be372794858e949778b3a4533d0bbe295b69235be8445c4be8595762f8",
+    "url": "https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/CurrentRelease/MarkdownMonsterSetup.exe",
+    "hash": "30A2911AE377F1CE408DEAAC439F4A1F7CAC2B64B7977FC01FE53E30A0854DF4",
     "bin": [
         "mm.exe",
         "MarkdownMonster.exe"
@@ -20,10 +20,11 @@
     ],
     "persist": "PortableSettings",
     "checkver": {
-        "url": "https://markdownmonster.west-wind.com/download.aspx",
+        "url": "https://raw.githubusercontent.com/RickStrahl/MarkdownMonsterReleases/master/CurrentRelease/MarkdownMonster_Version.xml",
         "regex": "<[vV]ersion>([\\d.]+)</[vV]ersion>"
     },
     "autoupdate": {
-        "url": "https://west-wind.com/files/MarkdownMonsterPortable.zip"
-    }
+        "url": "https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/CurrentRelease/MarkdownMonsterSetup.exe"
+    },
+    "innosetup": true
 }

--- a/bucket/markdown-monster.json
+++ b/bucket/markdown-monster.json
@@ -21,7 +21,7 @@
     "persist": "PortableSettings",
     "checkver": {
         "url": "https://raw.githubusercontent.com/RickStrahl/MarkdownMonsterReleases/master/CurrentRelease/MarkdownMonster_Version.xml",
-        "regex": "<[vV]ersion>([\\d.]+)</[vV]ersion>"
+        "xpath": "/VersionInfo/Version"
     },
     "autoupdate": {
         "url": "https://github.com/RickStrahl/MarkdownMonsterReleases/raw/master/CurrentRelease/MarkdownMonsterSetup.exe"


### PR DESCRIPTION
Use the full installer and use official release Source location as well as an official release file.