### PR TITLE
antidupl.net: Add version 2.3.10

### DIFF
--- a/bucket/antidupl.net.json
+++ b/bucket/antidupl.net.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.3.10",
+    "description": "Finding duplicate images.",
+    "homepage": "https://ermig1979.github.io/AntiDupl/english",
+    "license": "MIT",
+    "url": "https://github.com/ermig1979/AntiDupl/releases/download/v2.3.10/AntiDupl.NET-2.3.10.exe#/dl.7z",
+    "hash": "c30774a4f22a0c5b21cf916f0d963aa2930605d4bd1ca27a2cdeac2665432623",
+    "extract_dir": "AntiDupl.NET-2.3.10",
+    "pre_install": [
+        "if(!(Test-Path \"$persist_dir\\user\")) {",
+        "    New-Item \"$dir\\user\" -ItemType directory | Out-Null",
+        "    Set-Content \"$dir\\user\\options.xml\" '<Options><checkingForUpdates>false</checkingForUpdates></Options>' -Encoding ascii",
+        "}"
+    ],
+    "bin": "AntiDupl.NET.exe",
+    "shortcuts": [
+        [
+            "AntiDupl.NET.exe",
+            "AntiDupl.NET"
+        ]
+    ],
+    "persist": "user",
+    "checkver": {
+        "github": "https://github.com/ermig1979/AntiDupl"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ermig1979/AntiDupl/releases/download/v$version/AntiDupl.NET-$version.exe#/dl.7z",
+        "extract_dir": "AntiDupl.NET-$version"
+    }
+}

--- a/bucket/antidupl.net.json
+++ b/bucket/antidupl.net.json
@@ -1,6 +1,6 @@
 {
     "version": "2.3.10",
-    "description": "Finding duplicate images.",
+    "description": "Image duplicate finder",
     "homepage": "https://ermig1979.github.io/AntiDupl/english",
     "license": "MIT",
     "url": "https://github.com/ermig1979/AntiDupl/releases/download/v2.3.10/AntiDupl.NET-2.3.10.exe#/dl.7z",

--- a/bucket/antidupl.net.json
+++ b/bucket/antidupl.net.json
@@ -1,7 +1,7 @@
 {
     "version": "2.3.10",
     "description": "Image duplicate finder",
-    "homepage": "https://ermig1979.github.io/AntiDupl/english",
+    "homepage": "https://ermig1979.github.io/AntiDupl/english/",
     "license": "MIT",
     "url": "https://github.com/ermig1979/AntiDupl/releases/download/v2.3.10/AntiDupl.NET-2.3.10.exe#/dl.7z",
     "hash": "c30774a4f22a0c5b21cf916f0d963aa2930605d4bd1ca27a2cdeac2665432623",

--- a/bucket/antidupl.net.json
+++ b/bucket/antidupl.net.json
@@ -8,7 +8,7 @@
     "extract_dir": "AntiDupl.NET-2.3.10",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\user\")) {",
-        "    New-Item \"$dir\\user\" -ItemType directory | Out-Null",
+        "    ensure \"$dir\\user\" | Out-Null",
         "    Set-Content \"$dir\\user\\options.xml\" '<Options><checkingForUpdates>false</checkingForUpdates></Options>' -Encoding ascii",
         "}"
     ],

--- a/bucket/antidupl.net.json
+++ b/bucket/antidupl.net.json
@@ -7,7 +7,7 @@
     "hash": "c30774a4f22a0c5b21cf916f0d963aa2930605d4bd1ca27a2cdeac2665432623",
     "extract_dir": "AntiDupl.NET-2.3.10",
     "pre_install": [
-        "if(!(Test-Path \"$persist_dir\\user\")) {",
+        "if (!(Test-Path \"$persist_dir\\user\")) {",
         "    New-Item \"$dir\\user\" -ItemType directory | Out-Null",
         "    Set-Content \"$dir\\user\\options.xml\" '<Options><checkingForUpdates>false</checkingForUpdates></Options>' -Encoding ascii",
         "}"


### PR DESCRIPTION
- Closes #4579

**AntiDupl.NET** ([homepage](https://ermig1979.github.io/AntiDupl/english)) ([Github repo](https://github.com/ermig1979/AntiDupl)) is a utility for finding duplicate images.

Notes:

* **naming** of the package: I named the package as `antidupl.net`. (following the pattern of `paint.net` and `database.net`)
