### PR TITLE
deskpins: Add version 1.32

### DIFF
--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -14,9 +14,5 @@
             "deskpins.exe",
             "DeskPins"
         ]
-    ],
-    "checkver": "DeskPins-([\\d.]+)-setup\\.exe",
-    "autoupdate": {
-        "url": "https://efotinis.neocities.org/downloads/DeskPins-$version-setup.exe#/dl.7z"
-    }
+    ]
 }

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -13,6 +13,9 @@
             "DeskPins"
         ]
     ],
+    "suggest": {
+        "Visual C++ 2008 Redistributable": "extras/vcredist2008"
+    },
     "checkver": "DeskPins-([\\d.]+)-setup\\.exe",
     "autoupdate": {
         "url": "https://efotinis.neocities.org/downloads/DeskPins-$version-setup.exe#/dl.7z"

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.32",
+    "description": "Make any application always on top.",
+    "homepage": "https://efotinis.neocities.org/deskpins",
+    "license": "MIT",
+    "url": "https://efotinis.neocities.org/downloads/DeskPins-1.32-setup.exe#/dl.7z",
+    "hash": "70bfd44e774837e52bc83f2c128de7d164251e513f6ebea4a70e2073e28ecd2a",
+    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
+    "bin": "deskpins.exe",
+    "shortcuts": [
+        [
+            "deskpins.exe",
+            "DeskPins"
+        ]
+    ],
+    "checkver": {
+        "regex": "DeskPins-([\\d.]+)-setup\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://efotinis.neocities.org/downloads/DeskPins-$version-setup.exe#/dl.7z"
+    }
+}

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -1,7 +1,7 @@
 {
     "version": "1.32",
     "description": "Make any application always on top.",
-    "homepage": "https://efotinis.neocities.org/deskpins",
+    "homepage": "https://efotinis.neocities.org/deskpins/",
     "license": "Freeware",
     "suggest": {
         "Visual C++ 2008 Redistributable": "extras/vcredist2008"

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -6,7 +6,6 @@
     "url": "https://efotinis.neocities.org/downloads/DeskPins-1.32-setup.exe#/dl.7z",
     "hash": "70bfd44e774837e52bc83f2c128de7d164251e513f6ebea4a70e2073e28ecd2a",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
-    "bin": "deskpins.exe",
     "shortcuts": [
         [
             "deskpins.exe",

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -2,7 +2,7 @@
     "version": "1.32",
     "description": "Make any application always on top.",
     "homepage": "https://efotinis.neocities.org/deskpins",
-    "license": "MIT",
+    "license": "Freeware",
     "url": "https://efotinis.neocities.org/downloads/DeskPins-1.32-setup.exe#/dl.7z",
     "hash": "70bfd44e774837e52bc83f2c128de7d164251e513f6ebea4a70e2073e28ecd2a",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -3,6 +3,9 @@
     "description": "Make any application always on top.",
     "homepage": "https://efotinis.neocities.org/deskpins",
     "license": "Freeware",
+    "suggest": {
+        "Visual C++ 2008 Redistributable": "extras/vcredist2008"
+    },
     "url": "https://efotinis.neocities.org/downloads/DeskPins-1.32-setup.exe#/dl.7z",
     "hash": "70bfd44e774837e52bc83f2c128de7d164251e513f6ebea4a70e2073e28ecd2a",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse",
@@ -12,9 +15,6 @@
             "DeskPins"
         ]
     ],
-    "suggest": {
-        "Visual C++ 2008 Redistributable": "extras/vcredist2008"
-    },
     "checkver": "DeskPins-([\\d.]+)-setup\\.exe",
     "autoupdate": {
         "url": "https://efotinis.neocities.org/downloads/DeskPins-$version-setup.exe#/dl.7z"

--- a/bucket/deskpins.json
+++ b/bucket/deskpins.json
@@ -13,9 +13,7 @@
             "DeskPins"
         ]
     ],
-    "checkver": {
-        "regex": "DeskPins-([\\d.]+)-setup\\.exe"
-    },
+    "checkver": "DeskPins-([\\d.]+)-setup\\.exe",
     "autoupdate": {
         "url": "https://efotinis.neocities.org/downloads/DeskPins-$version-setup.exe#/dl.7z"
     }


### PR DESCRIPTION
- Closes #4628

**DeskPins** ([homepage](https://efotinis.neocities.org/deskpins/)) is a tool used to make any application topmost, that is, to keep it above all other windows.

Notes:

* **license**: ~The MIT license can be found at `license.txt` of [the source code package](https://efotinis.neocities.org/downloads/efotinis-deskpins-e3caef22897e.zip)~. Use "Freeware" instead.

* **persist** is not needed because DeskPins stores its config data at `HKCU:\SOFTWARE\Elias Fotinis\DeskPins`.