### PR TITLE
openclosedriveeject: Fixed hash for 32bit & 64bit

### DIFF
--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.softwareok.com/Download/OpenCloseDriveEject_x64.zip",
-            "hash": "a5236b85d3f8bd0969fbe9d72c8b1c33df161026e3fd3309ab6b48b66c8e61cd",
+            "hash": "ecd09df6701ae813b03fd675fc4ac65030d4c57ad27fc03b8d1971181920f115",
             "bin": [
                 [
                     "OpenCloseDriveEject_x64_p.exe",
@@ -25,7 +25,7 @@
         },
         "32bit": {
             "url": "https://www.softwareok.com/Download/OpenCloseDriveEject.zip",
-            "hash": "0327bd77432cd1e77626e0278a4880b8d4b817a05185b2506fb6b7f6968c0ffa",
+            "hash": "8652fa00f1b8019a47ccd2daa46a5e77b745aa21f2c5b0228f5f37a68df02dd7",
             "bin": "OpenCloseDriveEject.exe",
             "shortcuts": [
                 [


### PR DESCRIPTION
Fix for https://github.com/lukesampson/scoop-extras/issues/4665