### PR TITLE
WIP protonvpn

### DIFF
--- a/bucket/protonvpn.json
+++ b/bucket/protonvpn.json
@@ -28,14 +28,10 @@
         "jsonpath": "$.Categories[?(@.Name == 'Stable')].Releases[0].Version"
     },
     "autoupdate": {
-        "architecture": {
-            "32bit": {
-                "url": "https://protonvpn.com/download/ProtonVPN_win_v$version.exe",
-                "hash": {
-                    "url": "https://protonvpn.com/download/win-update.json",
-                    "jsonpath": "$.Categories[?(@.Name == 'Stable')].Releases[0].SHA512CheckSum"
-                }
-            }
+        "url": "https://protonvpn.com/download/ProtonVPN_win_v$version.exe",
+        "hash": {
+            "url": "https://protonvpn.com/download/win-update.json",
+            "jsonpath": "$.Categories[?(@.Name == 'Stable')].Releases[0].SHA512CheckSum"
         }
     }
 }

--- a/bucket/protonvpn.json
+++ b/bucket/protonvpn.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.16.3",
+    "description": "High-speed Swiss VPN that safeguards your privacy.",
+    "homepage": "https://protonvpn.com",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://raw.githubusercontent.com/ProtonVPN/win-app/master/LICENSE"
+    },
+    "url": "https://protonvpn.com/download/ProtonVPN_win_v1.16.3.exe",
+    "hash": "sha512:8c9b838302f1e3dccca1e7936a4d90f19fa821ffcd83267a4c87e1b1898a5d257a28e14ed759393f48b29ef4e8ef6ea405d6d4f7521aab86535a8a951dc9d0e9",
+    "bin": "ProtonVPN_win_v1.16.3.exe",
+    "installer": {
+        "file": "ProtonVPN_win_v1.16.3.exe",
+        "args": [
+            "/quiet",
+            "/norestart"
+        ]
+    },
+    "shortcuts": [
+        [
+            "ProtonVPN_win_v1.16.3.exe",
+            "ProtonVPN",
+            "protonvpn"
+        ]
+    ],
+    "checkver": {
+        "url": "https://protonvpn.com/download/win-update.json",
+        "jsonpath": "$.Categories[?(@.Name == 'Stable')].Releases[0].Version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://protonvpn.com/download/ProtonVPN_win_v$version.exe",
+                "hash": {
+                    "url": "https://protonvpn.com/download/win-update.json",
+                    "jsonpath": "$.Categories[?(@.Name == 'Stable')].Releases[0].SHA512CheckSum"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Install

Using exe
```
> ./ProtonVPN_win_v1.16.3.exe /quiet /norestart
```

Using Scoop
```
> scoop install ./protonvpn.json
Installing 'protonvpn' (1.16.3) [64bit]
Loading ProtonVPN_win_v1.16.3.exe from cache
Checking hash of ProtonVPN_win_v1.16.3.exe ... ok.
Running installer... error.
ERROR Exit code was 1603!
Installation aborted. You might need to run 'scoop uninstall protonvpn' before trying again.
```

## Uninstall

```
$ scoop uninstall protonvpn
Uninstalling 'protonvpn' (1.16.3).
'protonvpn' was uninstalled.
```

But this doesn't work as expected. ProtonVPN and ProtonVPNTap are still there. After running these commands, both are removed.

```
Uninstall-Package -Name "ProtonVPN"
Uninstall-Package -Name "ProtonVPNTap"
```

## Misc

1. How do I add additional logging to scoop?
1. How do I prevent the error after installing even thought the install worked?
1. How do I uninstall both the apps when executing `scoop uninstall protonvpn`?

Closes https://github.com/lukesampson/scoop-extras/issues/4678