### PR TITLE
authy: Update to version 1.8.3

### DIFF
--- a/bucket/authy.json
+++ b/bucket/authy.json
@@ -1,25 +1,19 @@
 {
-    "version": "1.8.0",
+    "version": "1.8.3",
     "description": "Two factor authentication client",
     "homepage": "https://authy.com/",
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.8.0/win32/x64/authy-electron-1.8.0-full.nupkg",
-            "hash": "sha1:ae943dab20c5ea9ab262e0c6247501aedadbb570"
+            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.8.3/win32/x64/authy-1.8.3-full.nupkg",
+            "hash": "sha1:af8fba4c4b035c867c209253016c09a9c7dd2f83"
         },
         "32bit": {
-            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.8.0/win32/x32/authy-electron-1.8.0-full.nupkg",
-            "hash": "sha1:a0097d3b475ece59d3cf22688ae013d57573ba10"
+            "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/1.8.3/win32/x32/authy-1.8.3-full.nupkg",
+            "hash": "sha1:fa4392b0c94f156d932e1e9058fc801cdb5adb6a"
         }
     },
     "extract_dir": "lib\\net45",
-    "bin": [
-        [
-            "Authy Desktop.exe",
-            "authy"
-        ]
-    ],
     "shortcuts": [
         [
             "Authy Desktop.exe",
@@ -28,19 +22,19 @@
     ],
     "checkver": {
         "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES",
-        "regex": "authy-electron-([\\d.]+)-full\\.nupkg",
+        "regex": "authy-([\\d.]+)-full\\.nupkg",
         "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x64/authy-electron-$version-full.nupkg",
+                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x64/authy-$version-full.nupkg",
                 "hash": {
                     "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x64/RELEASES"
                 }
             },
             "32bit": {
-                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x32/authy-electron-$version-full.nupkg",
+                "url": "https://s3.amazonaws.com/authy-electron-repository-production/authy/stable/$version/win32/x32/authy-$version-full.nupkg",
                 "hash": {
                     "url": "https://s3.amazonaws.com/authy-electron-repository-production/_squirrel/authy/stable/x32/RELEASES"
                 }


### PR DESCRIPTION
The package name is now authy-$version-full.nupkg, so I have changed the regex in checkver and the file name in urls in autoupdate and remived the unnecessary bin part.