### PR TITLE
windows95: Add version 2.2.2

### DIFF
--- a/bucket/windows95.json
+++ b/bucket/windows95.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.2.2",
+    "description": "Windows 95 emulator",
+    "homepage": "https://github.com/felixrieseberg/windows95",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://github.com/felixrieseberg/windows95/blob/master/LICENSE.md"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/felixrieseberg/windows95/releases/download/v2.2.2/windows95-win32-x64-2.2.2.zip",
+            "hash": "b8925c9a9a7ff77032a3508b3ef9b0dc0c372053c010d2e07b9bf0afc2a72c22"
+        },
+        "32bit": {
+            "url": "https://github.com/felixrieseberg/windows95/releases/download/v2.2.2/windows95-win32-ia32-2.2.2.zip",
+            "hash": "68d56ab36183626bc053cc47cfd6c66de4f5c00bfe4ade6832aa027714d58bac"
+        }
+    },
+    "shortcuts": [
+        [
+            "windows95.exe",
+            "Windows 95"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/felixrieseberg/windows95/releases/download/v$version/windows95-win32-x64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/felixrieseberg/windows95/releases/download/v$version/windows95-win32-ia32-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* **"Windows95"** ([Github repo](https://github.com/felixrieseberg/windows95)) is a Windows 95 emulator running in an Electron app.

* **persist** is not needed because "Windows 95" stores its config data at `$Env:AppData\windows95`.