### PR TITLE
macintosh.js: Add version 1.0.6

### DIFF
--- a/bucket/macintosh.js.json
+++ b/bucket/macintosh.js.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.0.6",
+    "description": "Macintosh Quadra (1991) emulator",
+    "homepage": "https://github.com/felixrieseberg/macintosh.js",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/felixrieseberg/macintosh.js/releases/download/v1.0.6/macintosh.js-win32-x64-1.0.6.zip",
+            "hash": "893a265b14a96c6cf0e501da80e335405da7ac24d093b3ce9bc6fdf939f5118a"
+        },
+        "32bit": {
+            "url": "https://github.com/felixrieseberg/macintosh.js/releases/download/v1.0.6/macintosh.js-win32-ia32-1.0.6.zip",
+            "hash": "392a74e6cafc17ddd321e12fc5f7831da3d7d5fc597e9dc3572d412270d88b02"
+        }
+    },
+    "shortcuts": [
+        [
+            "macintosh.js.exe",
+            "macintosh.js"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/felixrieseberg/macintosh.js/releases/download/v$version/macintosh.js-win32-x64-$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/felixrieseberg/macintosh.js/releases/download/v$version/macintosh.js-win32-ia32-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* **macintosh.js** ([Github repo](https://github.com/felixrieseberg/macintosh.js)) is a Macintosh Quadra (1991) emulator.

* **persist** is not needed because *macintosh.js* stores its config data at `$Env:AppData\macintosh.js`.