### PR TITLE
ytmdesktop@1.13.0: Fix URL

### DIFF
--- a/bucket/ytmdesktop.json
+++ b/bucket/ytmdesktop.json
@@ -5,7 +5,7 @@
     "license": "CC0-1.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v1.13.0/YouTube.Music.Desktop.App.Setup.1.13.0.exe#/dl.7z",
+            "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v1.13.0/YouTube-Music-Desktop-App-Setup-1.13.0.exe#/dl.7z",
             "hash": "sha512:6bcff62101fcf59babf584e6da82987d44bbc5bfb7408d83e48a7b83f7a4daa7a6a7fdd31add02eeacf734696242c39a7e0810f25ad75f9cf56cd90e026e034e",
             "pre_install": [
                 "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v$version/YouTube.Music.Desktop.App.Setup.$version.exe#/dl.7z"
+                "url": "https://github.com/ytmdesktop/ytmdesktop/releases/download/v$version/YouTube-Music-Desktop-App-Setup-$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
- Closes #4724

The author of ytmdesktop has apparently decided with version `1.13.0` (latest) to hyphenate the setup executable name.