### PR TITLE
foldingathome: Add version 7.6.13

### DIFF
--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -1,17 +1,18 @@
 {
     "version": "7.6.13",
     "description": "Distributed computing project focused on disease research",
+    "homepage": "https://foldingathome.org",
     "license": {
         "identifier": "Freeware",
         "url": "https://foldingathome.org/support/faq/opensource"
     },
-    "homepage": "https://foldingathome.org",
     "url": "https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit/v7.6/fah-installer_7.6.13_x86.exe#/dl.7z",
     "hash": "7618f1d98e1283442767f9735ae5f6c35a0c86b03c3ae62f45ee7be59509ec3e",
     "pre_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
-        "if(!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
-        "if(!(Test-Path \"$persist_dir\\GPUs.txt\")) { New-Item \"$dir\\GPUs.txt\" | Out-Null }",
+        "('log.txt', 'GPUs.txt') | ForEach-Object {",
+        "    if(!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "}",
         "if(!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
     ],
     "bin": "FAHClient.exe",

--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -1,0 +1,42 @@
+{
+    "version": "7.6.13",
+    "description": "Distributed computing project focused on disease research",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://foldingathome.org/support/faq/opensource"
+    },
+    "homepage": "https://foldingathome.org",
+    "url": "https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit/v7.6/fah-installer_7.6.13_x86.exe#/dl.7z",
+    "hash": "7618f1d98e1283442767f9735ae5f6c35a0c86b03c3ae62f45ee7be59509ec3e",
+    "pre_install": [
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
+        "if(!(Test-Path \"$persist_dir\\log.txt\")) { New-Item \"$dir\\log.txt\" | Out-Null }",
+        "if(!(Test-Path \"$persist_dir\\GPUs.txt\")) { New-Item \"$dir\\GPUs.txt\" | Out-Null }",
+        "if(!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
+    ],
+    "bin": "FAHClient.exe",
+    "shortcuts": [
+        [
+            "FAHClient.exe",
+            "Folding@home"
+        ],
+        [
+            "FAHControl.exe",
+            "FAHControl"
+        ],
+        [
+            "FAHViewer.exe",
+            "FAHViewer"
+        ]
+    ],
+    "persist": [
+        "work",
+        "log.txt",
+        "GPUs.txt",
+        "config.xml"
+    ],
+    "checkver": "fah-installer_([\\d.]+)_x86\\.exe",
+    "autoupdate": {
+        "url": "https://download.foldingathome.org/releases/public/release/fah-installer/windows-10-32bit/v$majorVersion.$minorVersion/fah-installer_$version_x86.exe#/dl.7z"
+    }
+}

--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -11,9 +11,9 @@
     "pre_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
         "'log.txt', 'GPUs.txt' | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "    if (-not (Test-Path \"$persist_dir\\$_\") ) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "if (!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
+        "if (-not (Test-Path \"$persist_dir\\config.xml\") ) { Set-Content \"$dir\\config.xml\" '<config></config>' -Encoding ascii | Out-Null }"
     ],
     "bin": "FAHClient.exe",
     "shortcuts": [

--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -11,9 +11,9 @@
     "pre_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
         "('log.txt', 'GPUs.txt') | ForEach-Object {",
-        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "    if !(Test-Path \"$persist_dir\\$_\") { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "if (!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
+        "if !(Test-Path \"$persist_dir\\config.xml\") { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
     ],
     "bin": "FAHClient.exe",
     "shortcuts": [

--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -11,9 +11,9 @@
     "pre_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
         "('log.txt', 'GPUs.txt') | ForEach-Object {",
-        "    if(!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "if(!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
     ],
     "bin": "FAHClient.exe",
     "shortcuts": [

--- a/bucket/foldingathome.json
+++ b/bucket/foldingathome.json
@@ -10,10 +10,10 @@
     "hash": "7618f1d98e1283442767f9735ae5f6c35a0c86b03c3ae62f45ee7be59509ec3e",
     "pre_install": [
         "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall.exe.nsis\" -Force -Recurse",
-        "('log.txt', 'GPUs.txt') | ForEach-Object {",
-        "    if !(Test-Path \"$persist_dir\\$_\") { New-Item \"$dir\\$_\" | Out-Null }",
+        "'log.txt', 'GPUs.txt' | ForEach-Object {",
+        "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",
         "}",
-        "if !(Test-Path \"$persist_dir\\config.xml\") { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
+        "if (!(Test-Path \"$persist_dir\\config.xml\")) { Set-Content \"$dir\\config.xml\" '<config></config>' | Out-Null }"
     ],
     "bin": "FAHClient.exe",
     "shortcuts": [


### PR DESCRIPTION
* Closes #3694.

* Previously proposed in #3818. (the author closed the PR)

* **Folding@Home** ([homepage](https://foldingathome.org/)) is a distributed computing project focused on disease research.

* The installer fah-installer_7.6.13_**x86**.exe applies to both 32 and 64 bit.
> Windows (All versions, 32 & 64 bit)
> (https://foldingathome.org/alternative-downloads/)

* **bin**: `FAHClient.exe` is a command-line application. (See https://foldingathome.org/support/faq/installation-guides/windows/command-line-option/ for parameters)

* **shortcuts**: The installer creates the shortcuts to `fahcontrol.exe` and `fahviewer.exe` as "FAHControl" and "FAHViewer". Therefore I keep the names as it is.

* Running multiple instance of Folding@home at the same time will cause an error. (`Exception: Failed to register systray icon`)(see https://github.com/FoldingAtHome/fah-issues/issues/1190)
