### PR TITLE
android-studio: Suggest android-clt

### DIFF
--- a/bucket/android-studio.json
+++ b/bucket/android-studio.json
@@ -30,7 +30,10 @@
     },
     "extract_dir": "android-studio",
     "suggest": {
-        "SDK": "android-clt"
+        "SDK": [
+            "android-clt",
+            "android-sdk"
+        ]
     },
     "checkver": "ide-zips/([\\d.]+)/android-studio-ide-(?<build>[\\d.]+)-windows",
     "autoupdate": {

--- a/bucket/android-studio.json
+++ b/bucket/android-studio.json
@@ -30,7 +30,7 @@
     },
     "extract_dir": "android-studio",
     "suggest": {
-        "SDK": "android-sdk"
+        "SDK": "android-clt"
     },
     "checkver": "ide-zips/([\\d.]+)/android-studio-ide-(?<build>[\\d.]+)-windows",
     "autoupdate": {


### PR DESCRIPTION
Now that ScoopInstaller/Main#1362 has been merged, we can suggest the new SDK instead.