### PR TITLE
Added KiCAD nightly

### DIFF
--- a/bucket/kicad-nightly.json
+++ b/bucket/kicad-nightly.json
@@ -1,6 +1,6 @@
 {
     "version": "17403.fc1665ff2",
-    "description": "Electronics Design Automation Suite",
+    "description": "Nightly build of KiCAD: An Electronics Design Automation Suite",
     "homepage": "https://kicad-pcb.org",
     "license": "GPL-3.0-only",
     "architecture": {

--- a/bucket/kicad-nightly.json
+++ b/bucket/kicad-nightly.json
@@ -1,0 +1,44 @@
+{
+    "version": "17403.fc1665ff2",
+    "description": "Electronics Design Automation Suite",
+    "homepage": "https://kicad-pcb.org",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://kicad-downloads.s3.cern.ch/windows/nightly/kicad-r17403.fc1665ff2-x86_64.exe#/dl.7z",
+            "hash": "236816968bbb03b184071470794a94a9a98490266f09dc7f04efdc06728c0a26"
+        },
+        "32bit": {
+            "url": "https://kicad-downloads.s3.cern.ch/windows/nightly/kicad-r17403.fc1665ff2-i686.exe#/dl.7z",
+            "hash": "04b35dac8c985d7e3736955f358ff5e9cb1c5d25aa2b8b9f11e8976141d28562"
+        }
+    },
+    "pre_install": "Remove-Item \"$dir\\`$*\", \"$dir\\Uninst*\" -Recurse",
+    "bin": "bin\\kicad.exe",
+    "shortcuts": [
+        [
+            "bin\\kicad.exe",
+            "KiCad-nightly"
+        ]
+    ],
+    "env_set": {
+        "KICAD_PTEMPLATES": "$dir\\share\\kicad\\template\\",
+        "KISYS3DMOD": "$dir\\share\\kicad\\modules\\packages3d\\",
+        "KISYSMOD": "$dir\\share\\kicad\\modules\\"
+    },
+    "checkver": {
+        "url": "https://kicad-downloads.s3.cern.ch/?prefix=windows/nightly",
+        "regex": "kicad-r([\\d]+.[a-f0-9]+)-",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://kicad-downloads.s3.cern.ch/windows/nightly/kicad-r$version-x86_64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "https://kicad-downloads.s3.cern.ch/windows/nightly/kicad-r$version-i686.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently KiCAD doesn't provide hashes for the binaries. I'm asking if they could provide that, as it'd avoid a 1gb download just for calculating hashes when running checkver. 