### PR TITLE
structurizr-cli: Add version 1.4.2

### DIFF
--- a/bucket/structurizr-cli.json
+++ b/bucket/structurizr-cli.json
@@ -1,0 +1,21 @@
+{
+    "version": "1.4.2",
+    "description": "A command line interface to push/pull workspaces to/from the Structurizr cloud service/on-premises installation, and export views to PlantUML, Mermaid, and WebSequenceDiagrams formats.",
+    "homepage": "https://github.com/structurizr/cli",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/structurizr/cli/blob/master/LICENSE"
+    },
+    "suggest": {
+        "java": "java/oraclejre8"
+    },
+    "url": "https://github.com/structurizr/cli/releases/download/v1.4.2/structurizr-cli-1.4.2.zip",
+    "hash": "5354905782de59ff9c6c051f3f9c17db90925d2bd14070c6d862df5c08467aad",
+    "bin": "structurizr.bat",
+    "checkver": {
+        "github": "https://github.com/structurizr/cli"
+    },
+    "autoupdate": {
+        "url": "https://github.com/structurizr/cli/releases/download/v$version/structurizr-cli-$version.zip"
+    }
+}

--- a/bucket/structurizr-cli.json
+++ b/bucket/structurizr-cli.json
@@ -2,19 +2,14 @@
     "version": "1.4.2",
     "description": "A command line interface to push/pull workspaces to/from the Structurizr cloud service/on-premises installation, and export views to PlantUML, Mermaid, and WebSequenceDiagrams formats.",
     "homepage": "https://github.com/structurizr/cli",
-    "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://github.com/structurizr/cli/blob/master/LICENSE"
-    },
+    "license": "Apache-2.0",
     "suggest": {
         "java": "java/oraclejre8"
     },
     "url": "https://github.com/structurizr/cli/releases/download/v1.4.2/structurizr-cli-1.4.2.zip",
     "hash": "5354905782de59ff9c6c051f3f9c17db90925d2bd14070c6d862df5c08467aad",
     "bin": "structurizr.bat",
-    "checkver": {
-        "github": "https://github.com/structurizr/cli"
-    },
+    "checkver": "github",
     "autoupdate": {
         "url": "https://github.com/structurizr/cli/releases/download/v$version/structurizr-cli-$version.zip"
     }


### PR DESCRIPTION
Add manifest for [Structurizr CLI](https://github.com/structurizr/cli) v1.4.2

[Structurizr](https://structurizr.com/help/about) is a collection of tooling to create software architecture diagrams and documentation based upon the [C4 model](https://c4model.com/).

[Structurizr CLI](https://github.com/structurizr/cli) is a command line interface to push/pull workspaces to/from the Structurizr cloud service/on-premises installation, and export views to PlantUML, Mermaid, and WebSequenceDiagrams formats. 

Test results

:white_check_mark: Should install structurizr-cli from the manifest file (previous version).
```
> scoop install .\bucket\structurizr-cli.json
Installing 'structurizr-cli' (1.4.1) [64bit]
Loading structurizr-cli-1.4.1.zip from cache
Checking hash of structurizr-cli-1.4.1.zip ... ok.
Extracting structurizr-cli-1.4.1.zip ... done.
Linking ~\scoop\apps\structurizr-cli\current => ~\scoop\apps\structurizr-cli\1.4.1
Creating shim for 'structurizr'.
'structurizr-cli' (1.4.1) was installed successfully!
```

:white_check_mark: Should autoupdate manifest to the latest version.
```
> .\bin\checkver.ps1 structurizr-cli -u
structurizr-cli: 1.4.2 (scoop version is 1.4.1) autoupdate available
Autoupdating structurizr-cli
DEBUG[1600010410] $substitutions (hashtable) -> C:\Users\Safor\scoop\apps\scoop\current\lib\autoupdate.ps1:181:5
DEBUG[1600010410] $substitutions.$preReleaseVersion             1.4.2
DEBUG[1600010410] $substitutions.$basename                      structurizr-cli-1.4.2.zip
DEBUG[1600010410] $substitutions.$dashVersion                   1-4-2
DEBUG[1600010410] $substitutions.$majorVersion                  1
DEBUG[1600010410] $substitutions.$cleanVersion                  142
DEBUG[1600010410] $substitutions.$baseurl                       https://github.com/structurizr/cli/releases/download/v1.4.2
DEBUG[1600010410] $substitutions.$underscoreVersion             1_4_2
DEBUG[1600010410] $substitutions.$matchHead                     1.4.2
DEBUG[1600010410] $substitutions.$buildVersion
DEBUG[1600010410] $substitutions.$url                           https://github.com/structurizr/cli/releases/download/v1.4.2/structurizr-cli-1.4.2.zip
DEBUG[1600010410] $substitutions.$minorVersion                  4
DEBUG[1600010410] $substitutions.$matchTail
DEBUG[1600010410] $substitutions.$patchVersion                  2
DEBUG[1600010410] $substitutions.$match1                        1.4.2
DEBUG[1600010410] $substitutions.$version                       1.4.2
DEBUG[1600010410] $hashfile_url = $null -> C:\Users\Safor\scoop\apps\scoop\current\lib\autoupdate.ps1:184:5
Downloading structurizr-cli-1.4.2.zip to compute hashes!
Loading structurizr-cli-1.4.2.zip from cache
Computed hash: 5354905782de59ff9c6c051f3f9c17db90925d2bd14070c6d862df5c08467aad
Writing updated structurizr-cli manifest
```

:white_check_mark: Should detect newer version.
```
> scoop status structurizr-cli
Scoop is up to date.
Updates are available for:
    structurizr-cli: 1.4.1 -> 1.4.2
Everything is ok!
```

:white_check_mark: Should update to the latest version.
```
> scoop update structurizr-cli
structurizr-cli: 1.4.1 -> 1.4.2
Updating one outdated app:
Updating 'structurizr-cli' (1.4.1 -> 1.4.2)
Downloading new version
Loading structurizr-cli-1.4.2.zip from cache
Checking hash of structurizr-cli-1.4.2.zip ... ok.
Uninstalling 'structurizr-cli' (1.4.1)
Removing shim for 'structurizr'.
Unlinking ~\scoop\apps\structurizr-cli\current
Installing 'structurizr-cli' (1.4.2) [64bit]
Loading structurizr-cli-1.4.2.zip from cache
Extracting structurizr-cli-1.4.2.zip ... done.
Linking ~\scoop\apps\structurizr-cli\current => ~\scoop\apps\structurizr-cli\1.4.2
Creating shim for 'structurizr'.
'structurizr-cli' (1.4.2) was installed successfully!
```

:white_check_mark: Should locate and run structurizr-cli.
```
> structurizr
Structurizr CLI v1.4.2
Usage: structurizr push|pull|export [options]
```

:white_check_mark: Should uninstall structurizr-cli.
```
> scoop uninstall structurizr-cli
Uninstalling 'structurizr-cli' (1.4.1).
Unlinking ~\scoop\apps\structurizr-cli\current
'structurizr-cli' was uninstalled.
```