### PR TITLE
vcredist2017: Update to version 14.16.27033.0

### DIFF
--- a/bucket/vcredist2017.json
+++ b/bucket/vcredist2017.json
@@ -1,19 +1,19 @@
 {
-    "version": "14.16.27027.1",
+    "version": "14.16.27033.0",
     "description": "Microsoft Visual C++ Redistributable for Visual Studio 2017.",
     "homepage": "https://www.visualstudio.com/downloads/",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
     },
-    "notes": "You can now remove this installer with 'scoop uninstall vcredist2017'",
+    "notes": "You can now remove this installer with 'scoop uninstall vcredist2017', and vcredist2019 superseeds this installer",
     "url": [
-        "https://download.visualstudio.microsoft.com/download/pr/36c5faaf-bd8b-433f-b3d7-2af73bae10a8/212f41f2ccffee6d6dc27f901b7d77a1/vc_redist.x64.exe",
-        "https://download.visualstudio.microsoft.com/download/pr/e9e1e87c-5bba-49fa-8bad-e00f0527f9bc/8e641901c2257dda7f0d3fd26541e07a/vc_redist.x86.exe"
+        "https://download.visualstudio.microsoft.com/download/pr/4100b84d-1b4d-487d-9f89-1354a7138c8f/5B0CBB977F2F5253B1EBE5C9D30EDBDA35DBD68FB70DE7AF5FAAC6423DB575B5/VC_redist.x64.exe",
+        "https://download.visualstudio.microsoft.com/download/pr/2b5bcd2f-0dbc-4b83-90a3-3b1c5ae77e62/0252474394129dbab6ff9ce24f1c6a3c/vc_redist.x86.exe"
     ],
     "hash": [
-        "b192e143d55257a0a2f76be42e44ff8ee14014f3b1b196c6e59829b6b3ec453c",
-        "7355962b95d6a5441c304cd2b86baf37bc206f63349f4a02289bcfb69ef142d3"
+        "5b0cbb977f2f5253b1ebe5c9d30edbda35dbd68fb70de7af5faac6423db575b5",
+        "54ad46ae80984aa48cae6361213692c96b3639e322730d28c7fb93b183c761da"
     ],
     "post_install": [
         "Invoke-ExternalCommand -FilePath \"$dir\\vc_redist.x64.exe\" -ArgumentList \"/fo /quiet /norestart\" -RunAs | Out-Null",


### PR DESCRIPTION
this is just a dud update for the last 14.16.xxxxxx, we should just replace this entirely with vcredist2019