### PR TITLE
brave: Update to version 1.14.81

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/brave-v1.14.81-win32-x64.zip",
-            "hash": "703ca8d7b9cc7aac7ec7cc610167701f18d68d1a26176d3dc12eeb5241a7aa34"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/BraveBrowserStandaloneSilentSetup.exe",
+            "hash": "C65443C06C6B5F2FC497F698D19CB9AB601D5A1A9E5BABD31E38E38C43AE6572"
         },
         "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/brave-v1.14.81-win32-ia32.zip",
-            "hash": "b17fd8a8bba9b67b83e4edd8c16d1c739c19700712f6463436649d9335f77758"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/BraveBrowserStandaloneSilentSetup32.exe",
+            "hash": "7B59269F54266A036244B93F351400F9A93BFFF34C398B11DD789555B1BF79FE"
         }
     },
     "bin": "brave.exe",
@@ -26,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-x64.zip"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/BraveBrowserStandaloneSetup.exe"
             },
             "32bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-ia32.zip"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/BraveBrowserStandaloneSilentSetup32.exe"
             }
         }
     }

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.96",
+    "version": "1.14.81",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
     "license": {
@@ -8,15 +8,14 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-x64.exe#/dl.7z",
-            "hash": "d9e7dd4f7597b6cec73dd49a23c52f4da87a8c25ccf837b8c3a8c7a70895606f"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/brave-v1.14.81-win32-x64.zip",
+            "hash": "703ca8d7b9cc7aac7ec7cc610167701f18d68d1a26176d3dc12eeb5241a7aa34"
         },
         "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-ia32.exe#/dl.7z",
-            "hash": "683a5f4e1295cb26acbff648864939e529243e1f6df4451a857aa8c2ed4794fe"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.14.81/brave-v1.14.81-win32-ia32.zip",
+            "hash": "b17fd8a8bba9b67b83e4edd8c16d1c739c19700712f6463436649d9335f77758"
         }
     },
-    "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",
     "bin": "brave.exe",
     "shortcuts": [
         [
@@ -27,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-x64.exe#/dl.7z"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-ia32.exe#/dl.7z"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-ia32.zip"
             }
         }
     }


### PR DESCRIPTION
~~Newer releases of brave offer zip files for win32, simplifying the installation process.~~

Closes #4606.