### PR TITLE
quicklook: Adopt portable configuration

### DIFF
--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -7,12 +7,11 @@
     "hash": "7d078438fe20ac5e4b3b8b647307c3c1652c1dd9eb5a46d205614c3f507399fc",
     "pre_install": [
     "if (!(Test-Path \"$persist_dir\\UserData\") -and (Test-Path \"$Env:AppData\\pooi.moe\\QuickLook\")) {",
-    "    Write-Host -F yellow \"Copying old '$Env:AppData\\pooi.moe\\QuickLook' to '$persist_dir\\UserData'\"",
-    "    New-Item \"$persist_dir\\UserData\" -ItemType 'Directory' -Force | Out-Null",
-    "    Copy-Item \"$Env:AppData\\pooi.moe\\QuickLook\\*\" \"$persist_dir\\UserData\" -Recurse -Force",
-    "    Write-Host -F yellow \"Removing old UserData at '$Env:AppData\\pooi.moe\\QuickLook'\"",
-    "    Remove-Item \"$Env:AppData\\pooi.moe\\QuickLook\" -Force -Recurse",
-    "}"
+        "if (!(Test-Path \"$persist_dir\\UserData\") -and (Test-Path \"$env:AppData\\pooi.moe\\QuickLook\")) {",
+        "    info \"Migrating '$env:AppData\\pooi.moe\\QuickLook' to '$persist_dir\\UserData'\"",
+        "    ensure \"$persist_dir\\UserData\" | Out-Null",
+        "    Copy-Item \"$env:AppData\\pooi.moe\\QuickLook\\*\" \"$persist_dir\\UserData\" -Recurse -Force",
+        "    Remove-Item \"$env:AppData\\pooi.moe\\QuickLook\" -Force -Recurse",
   ],
     "shortcuts": [
         [

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -5,12 +5,22 @@
     "license": "GPL-3.0-or-later",
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.6.10/QuickLook-3.6.10.zip",
     "hash": "7d078438fe20ac5e4b3b8b647307c3c1652c1dd9eb5a46d205614c3f507399fc",
+    "pre_install": [
+    "if (!(Test-Path \"$persist_dir\\UserData\") -and (Test-Path \"$Env:AppData\\pooi.moe\\QuickLook\")) {",
+    "    Write-Host -F yellow \"Copying old '$Env:AppData\\pooi.moe\\QuickLook' to '$persist_dir\\UserData'\"",
+    "    New-Item \"$persist_dir\\UserData\" -ItemType 'Directory' -Force | Out-Null",
+    "    Copy-Item \"$Env:AppData\\pooi.moe\\QuickLook\\*\" \"$persist_dir\\UserData\" -Recurse -Force",
+    "    Write-Host -F yellow \"Removing old UserData at '$Env:AppData\\pooi.moe\\QuickLook'\"",
+    "    Remove-Item \"$Env:AppData\\pooi.moe\\QuickLook\" -Force -Recurse",
+    "}"
+  ],
     "shortcuts": [
         [
             "QuickLook.exe",
             "QuickLook"
         ]
     ],
+    "persist": "UserData",
     "checkver": {
         "github": "https://github.com/QL-Win/QuickLook"
     },

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -12,6 +12,7 @@
         "    ensure \"$persist_dir\\UserData\" | Out-Null",
         "    Copy-Item \"$env:AppData\\pooi.moe\\QuickLook\\*\" \"$persist_dir\\UserData\" -Recurse -Force",
         "    Remove-Item \"$env:AppData\\pooi.moe\\QuickLook\" -Force -Recurse",
+        "}"
   ],
     "shortcuts": [
         [

--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -6,7 +6,6 @@
     "url": "https://github.com/QL-Win/QuickLook/releases/download/3.6.10/QuickLook-3.6.10.zip",
     "hash": "7d078438fe20ac5e4b3b8b647307c3c1652c1dd9eb5a46d205614c3f507399fc",
     "pre_install": [
-    "if (!(Test-Path \"$persist_dir\\UserData\") -and (Test-Path \"$Env:AppData\\pooi.moe\\QuickLook\")) {",
         "if (!(Test-Path \"$persist_dir\\UserData\") -and (Test-Path \"$env:AppData\\pooi.moe\\QuickLook\")) {",
         "    info \"Migrating '$env:AppData\\pooi.moe\\QuickLook' to '$persist_dir\\UserData'\"",
         "    ensure \"$persist_dir\\UserData\" | Out-Null",


### PR DESCRIPTION
From v3.6.10 QuickLook stores user config data and plugins in the `UserData` folder
in the installation directory instead of the older `%APPDATA%\pooi.moe\QuickLook\`.
Therefore the config data and plugins are not persisted between updates.
So the app manifest is modified to persist the `UserData` folder and move user data and
plugins from the old location to the new one