### PR TITLE
Update EasyRSA v3.0.8 SHA256 hash for both 32bit and 64bit archs

### DIFF
--- a/bucket/easyrsa.json
+++ b/bucket/easyrsa.json
@@ -6,11 +6,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.8/EasyRSA-3.0.8-win64.zip",
-            "hash": "b4a7735bd23137dd9fa7120f5b10ed60cd9a01431e9b1472b572a2123a1ae9a6"
+            "hash": "e5e5ec857b9221535aed53fd7a8b92f990ccfa1cdbd0f926207980b2721d828d"
         },
         "32bit": {
             "url": "https://github.com/OpenVPN/easy-rsa/releases/download/v3.0.8/EasyRSA-3.0.8-win32.zip",
-            "hash": "d5b791175ca1488e0638ff07fb0b411e54f1e830f41ed36fa5c5d7eaac9bb362"
+            "hash": "a39b7b42f499a54891215d5723ee573b7c94d0ceb06aed7c7295f2b0ff1fe639"
         }
     },
     "extract_dir": "EasyRSA-3.0.8",


### PR DESCRIPTION
Updated hashes from binaries in https://github.com/OpenVPN/easy-rsa/releases/tag/v3.0.8