### PR TITLE
qmk-toolbox: Add version 0.0.20

### DIFF
--- a/bucket/qmk-toolbox.json
+++ b/bucket/qmk-toolbox.json
@@ -1,8 +1,8 @@
 {
-    "description": "Toolbox to flash and manage keyboards running the QMK firmware",
+    "version": "0.0.20",
+    "description": "Toolbox to flash and manage keyboards running the QMK firmware.",
     "homepage": "https://qmk.fm/toolbox/",
     "license": "MIT",
-    "version": "0.0.20",
     "url": "https://github.com/qmk/qmk_toolbox/releases/download/0.0.20/qmk_toolbox.exe",
     "hash": "23fdea990450b1957b1f51949bbe52fe77a1336c5c8b1755a16e3b95d6161468",
     "bin": "qmk_toolbox.exe",

--- a/bucket/qmk-toolbox.json
+++ b/bucket/qmk-toolbox.json
@@ -9,7 +9,7 @@
     "shortcuts": [
         [
             "qmk_toolbox.exe",
-            "qmk_toolbox"
+            "QMK Toolbox"
         ]
     ],
     "checkver": {

--- a/bucket/qmk-toolbox.json
+++ b/bucket/qmk-toolbox.json
@@ -1,0 +1,21 @@
+{
+    "description": "Toolbox to flash and manage keyboards running the QMK firmware",
+    "homepage": "https://qmk.fm/toolbox/",
+    "license": "MIT",
+    "version": "0.0.20",
+    "url": "https://github.com/qmk/qmk_toolbox/releases/download/0.0.20/qmk_toolbox.exe",
+    "hash": "23fdea990450b1957b1f51949bbe52fe77a1336c5c8b1755a16e3b95d6161468",
+    "bin": "qmk_toolbox.exe",
+    "shortcuts": [
+        [
+            "qmk_toolbox.exe",
+            "qmk_toolbox"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/qmk/qmk_toolbox"
+    },
+    "autoupdate": {
+        "url": "https://github.com/qmk/qmk_toolbox/releases/download/$version/qmk_toolbox.exe"
+    }
+}


### PR DESCRIPTION
QMK toolbox is the main program used by newer users of the QMK firmware, who mainly just use a web interface to customize their keyboard layout, and then use qmk toolbox to flash this new firmware to their boards. 