### PR TITLE
Update ProcessHacker and add nightly

### DIFF
--- a/bucket/processhacker-nightly.json
+++ b/bucket/processhacker-nightly.json
@@ -1,0 +1,54 @@
+{
+    "version": "3.0.3456",
+    "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "32bit": {
+            "url": "https://ci.appveyor.com/api/buildjobs/ip6ecd40i8ib1wiu/artifacts/processhacker-3.0.3456-bin.zip",
+            "hash": "f2d7eb21018d8fc9ea461fbca99c264aba9076ddd8ded453654cc286f07f1291",
+            "extract_dir": "32bit"
+        },
+        "64bit": {
+            "url": "https://ci.appveyor.com/api/buildjobs/ip6ecd40i8ib1wiu/artifacts/processhacker-3.0.3456-bin.zip",
+            "hash": "f2d7eb21018d8fc9ea461fbca99c264aba9076ddd8ded453654cc286f07f1291",
+            "extract_dir": "64bit"
+        }
+    },
+    "pre_install": "if (Test-Path \"$persist_dir\\ProcessHacker.exe.settings.xml\") { Copy-Item \"$persist_dir\\ProcessHacker.exe.settings.xml\" \"$dir\" }",
+    "uninstaller": {
+        "script": "if (Test-Path \"$dir\\ProcessHacker.exe.settings.xml\") { Copy-Item \"$dir\\ProcessHacker.exe.settings.xml\" \"$persist_dir\" -Force }"
+    },
+    "checkver": {
+        "url": "https://wj32.org/processhacker/nightly.php?phupdater",
+        "jsonpath": "$.bin_url",
+        "regex": "https://ci.appveyor.com/api/buildjobs/(?<job>[a-z0-9]+)/artifacts/processhacker-([\\d.]+)-bin.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ci.appveyor.com/api/buildjobs/$matchJob/artifacts/processhacker-$version-bin.zip",
+                "extract_dir": "64bit"
+            },
+            "32bit": {
+                "url": "https://ci.appveyor.com/api/buildjobs/$matchJob/artifacts/processhacker-$version-bin.zip",
+                "extract_dir": "32bit"
+            }
+        },
+        "hash": {
+            "mode": "json",
+            "url": "https://wj32.org/processhacker/nightly.php?phupdater",
+            "jsonpath": "$.bin_hash"
+        }
+    },
+    "homepage": "https://processhacker.sourceforge.io/",
+    "bin": [
+        "processhacker.exe",
+        "peview.exe"
+    ],
+    "shortcuts": [
+        [
+            "processhacker.exe",
+            "Process Hacker"
+        ]
+    ]
+}

--- a/bucket/processhacker.json
+++ b/bucket/processhacker.json
@@ -4,17 +4,17 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/processhacker2/processhacker2/releases/download/v2.39/processhacker-2.39-bin.zip",
+            "url": "https://github.com/processhacker/processhacker/releases/download/v2.39/processhacker-2.39-bin.zip",
             "hash": "2afb5303e191dde688c5626c3ee545e32e52f09da3b35b20f5e0d29a418432f5",
             "extract_dir": "x86"
         },
         "64bit": {
-            "url": "https://github.com/processhacker2/processhacker2/releases/download/v2.39/processhacker-2.39-bin.zip",
+            "url": "https://github.com/processhacker/processhacker/releases/download/v2.39/processhacker-2.39-bin.zip",
             "hash": "2afb5303e191dde688c5626c3ee545e32e52f09da3b35b20f5e0d29a418432f5",
             "extract_dir": "x64"
         }
     },
-    "homepage": "http://processhacker.sourceforge.net/",
+    "homepage": "https://processhacker.sourceforge.io/",
     "bin": [
         "processhacker.exe",
         "peview.exe"
@@ -26,9 +26,9 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/processhacker2/processhacker2"
+        "github": "https://github.com/processhacker/processhacker"
     },
     "autoupdate": {
-        "url": "https://github.com/processhacker2/processhacker2/releases/download/v$version/processhacker-$version-bin.zip"
+        "url": "https://github.com/processhacker/processhacker/releases/download/v$version/processhacker-$version-bin.zip"
     }
 }


### PR DESCRIPTION
Updated links in `processhacker.json` so they don't have to redirect, and added a `processhacker-nightly.json` that tracks their nightly builds.

The way ProcessHacker checks for updates is found in their code [here](
https://github.com/processhacker/processhacker/blob/872bb111afe49a1d4b209924f7d37f9edf93f949/plugins/Updater/updater.c#L328) which is called from [here](https://github.com/processhacker/processhacker/blob/872bb111afe49a1d4b209924f7d37f9edf93f949/plugins/Updater/updater.c#L472), which shows it checks `wj32.org` first then `processhacker.sourceforge.io` (so I decided to just check wj32.org).  I got checkver and autoupdate to work so far with this config.

Let me know if I need to change anything, this is my first pr to this repo!  Thanks!