### PR TITLE
q-dir: Persist start.qdr

### DIFF
--- a/bucket/q-dir.json
+++ b/bucket/q-dir.json
@@ -36,9 +36,7 @@
         }
     },
     "extract_dir": "Q-Dir",
-    "pre_install": [
-        "if (!(Test-Path \"$persist_dir\\start.qdr\")) { New-Item \"$dir\\start.qdr\" | Out-Null }"
-    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\start.qdr\")) { New-Item \"$dir\\start.qdr\" | Out-Null }",
     "persist": [
         "Favoriten",
         "start.qdr",

--- a/bucket/q-dir.json
+++ b/bucket/q-dir.json
@@ -36,18 +36,18 @@
         }
     },
     "extract_dir": "Q-Dir",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\start.qdr\")) { New-Item \"$dir\\start.qdr\" | Out-Null }"
+    ],
     "persist": [
         "Favoriten",
-        "Q-Dir.ini",
-        "start.qdr"
+        "start.qdr",
+        "Q-Dir.ini"
     ],
     "checkver": {
         "url": "https://www.softwareok.com/?seite=Microsoft/Q-Dir/History",
         "regex": "version ([\\d.]+)"
     },
-    "pre_install": [
-        "$null >> \"$persist_dir\\start.qdr\""
-    ],
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/q-dir.json
+++ b/bucket/q-dir.json
@@ -38,12 +38,16 @@
     "extract_dir": "Q-Dir",
     "persist": [
         "Favoriten",
-        "Q-Dir.ini"
+        "Q-Dir.ini",
+        "start.qdr"
     ],
     "checkver": {
         "url": "https://www.softwareok.com/?seite=Microsoft/Q-Dir/History",
         "regex": "version ([\\d.]+)"
     },
+    "pre_install": [
+        "$null >> \"$persist_dir\\start.qdr\""
+    ],
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Opened tabs are stored in the file not listed in the persistent section.
Q-DIr is happy with the empty _start.qdr_ and at it's updated at the first start

