### PR TITLE
fvim: Add version 0.2.277

### DIFF
--- a/bucket/fvim.json
+++ b/bucket/fvim.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.273",
+    "version": "0.2.277",
     "description": "Neovim front-end UI",
     "homepage": "https://github.com/yatli/fvim",
     "license": "MIT",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/yatli/fvim/releases/download/v0.2.273-g41ce0c6/fvim-win-x64.zip",
-            "hash": "9404a43d52c17fbba9ef5fc5b708888b2e060c7d398a969bd5398ae99f3d72af"
+            "url": "https://github.com/yatli/fvim/releases/download/v0.2.277-gb99586d/fvim-win-x64.zip",
+            "hash": "b1633517f500bc8df207f0644d44ce0fd2fb99d15c8028dfe5b6d40cce34de12"
         }
     },
     "bin": "fvim.exe",
@@ -31,4 +31,3 @@
         }
     }
 }
-

--- a/bucket/fvim.json
+++ b/bucket/fvim.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.2.273",
+    "description": "Neovim front-end UI",
+    "homepage": "https://github.com/yatli/fvim",
+    "license": "MIT",
+    "suggest": {
+        "neovim": "extras/neovim"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yatli/fvim/releases/download/v0.2.273-g41ce0c6/fvim-win-x64.zip",
+            "hash": "9404a43d52c17fbba9ef5fc5b708888b2e060c7d398a969bd5398ae99f3d72af"
+        }
+    },
+    "bin": "fvim.exe",
+    "shortcuts": [
+        [
+            "fvim.exe",
+            "FVim"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/yatli/fvim",
+        "regex": "tag/v([\\d.]+)-g(?<commit>[\\w]{7})"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yatli/fvim/releases/download/v$version-g$matchCommit/fvim-win-x64.zip"
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This adds a frontend for neovim built with F# + Avalonia. I use this one a lot so I figured I'd add it to scoop to keep it updated more easily

