### PR TITLE
vnote: update homepage

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -1,7 +1,7 @@
 {
     "version": "2.10",
     "description": "A Vim-inspired note-taking application that knows programmers and Markdown better.",
-    "homepage": "https://tamlok.github.io/vnote/",
+    "homepage": "https://tamlok.gitee.io/vnote/en_us/",
     "license": "MIT",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
The old homepage (https://tamlok.github.io/vnote/) is no longer available.