### PR TITLE
Add youtube-dlc app manifest

### DIFF
--- a/bucket/youtube-dlc.json
+++ b/bucket/youtube-dlc.json
@@ -1,0 +1,25 @@
+{
+    "version": "2020.10.26",
+    "description": "Youtube-dlc is a fork of youtube-dl with the intention of getting features tested by the community merged in the tool faster.",
+    "homepage": "https://github.com/blackjack4494/yt-dlc",
+    "license": "Unlicense",
+    "suggest": {
+        "FFmpeg": [
+            "ffmpeg",
+            "ffmpeg-nightly"
+        ],
+        "vcredist": "extras/vcredist2010"
+    },
+    "url": "https://github.com/blackjack4494/yt-dlc/releases/download/2020.10.26/youtube-dlc.exe",
+    "hash": "763744714819c4a63ecda89e869eab4767e8d4304d544ff000298d267d198646",
+    "bin": "youtube-dlc.exe",
+    "checkver": {
+        "github": "https://github.com/blackjack4494/yt-dlc"
+    },
+    "autoupdate": {
+        "url": "https://github.com/blackjack4494/yt-dlc/releases/download/$version/youtube-dl.exe",
+        "hash": {
+            "url": "$baseurl/SHA2-256SUMS"
+        }
+    }
+}


### PR DESCRIPTION
Not adding to https://github.com/ScoopInstaller/Main because I don't consider it to be "a reasonably well-known and widely used developer tool". 

Youtube-dlc is at least as of now more actively developed than youtube-dl (over 300 commits ahead) and seems to have fixes for extractors that are buggy in the original project.