### PR TITLE
ghidra: Add version 9.1.2-20200212

### DIFF
--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.1.2-20200212",
+    "version": "9.2-20201113",
     "description": "Software reverse engineering (SRE) framework",
     "homepage": "https://ghidra-sre.org",
     "license": "Apache-2.0",
@@ -9,9 +9,9 @@
             "java/openjdk"
         ]
     },
-    "url": "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip",
-    "hash": "ebe3fa4e1afd7d97650990b27777bb78bd0427e8e70c1d0ee042aeb52decac61",
-    "extract_dir": "ghidra_9.1.2_PUBLIC",
+    "url": "https://ghidra-sre.org/ghidra_9.2_PUBLIC_20201113.zip",
+    "hash": "ffebd3d87bc7c6d9ae1766dd3293d1fdab3232a99b170f8ea8b57497a1704ff6",
+    "extract_dir": "ghidra_9.2_PUBLIC",
     "bin": [
         "ghidraRun.bat",
         [

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -1,24 +1,46 @@
 {
-    "version": "9.1.2",
-    "description": "Ghidra is a software reverse engineering (SRE) framework.",
-    "homepage": "https://www.nsa.gov/resources/everyone/ghidra/",
-    "license": "Apache-2.0 License",
+    "version": "9.1.2-20200212",
+    "description": "Software reverse engineering (SRE) framework",
+    "homepage": "https://ghidra-sre.org",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    },
     "url": "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip",
     "hash": "ebe3fa4e1afd7d97650990b27777bb78bd0427e8e70c1d0ee042aeb52decac61",
     "extract_dir": "ghidra_9.1.2_PUBLIC",
-    "bin": [["ghidraRun.bat", "ghidra"]],
-    "shortcuts": [["ghidraRun.bat", "Ghidra", "", "support\\ghidra.ico"]],
+    "bin": [
+        "ghidraRun.bat",
+        [
+            "ghidraRun.bat",
+            "ghidra"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "ghidraRun.bat",
+            "Ghidra",
+            "",
+            "support\\ghidra.ico"
+        ]
+    ],
+    "persist": [
+        "Ghidra\\Extensions",
+        "Ghidra\\patch"
+    ],
     "checkver": {
-        "url": "https://github.com/NationalSecurityAgency/ghidra/releases",
-        "regex": "Ghidra_(?<version>[\\d.]+)_build",
-        "replace": "${version}"
+        "regex": "ghidra_([\\d.]+)_PUBLIC_(\\d+)\\.zip",
+        "replace": "${1}-${2}"
     },
     "autoupdate": {
-        "url": "https://ghidra-sre.org/ghidra_$version_PUBLIC_.zip",
-        "extract_dir": "ghidra_$version_PUBLIC",
+        "url": "https://ghidra-sre.org/ghidra_$matchHead_PUBLIC_$preReleaseVersion.zip",
         "hash": {
-            "url": "https://ghidra-sre.org/releaseNotes_$version.html",
+            "url": "https://ghidra-sre.org/releaseNotes_$matchHead.html",
             "regex": "<code>$sha256</code>"
-        }
+        },
+        "extract_dir": "ghidra_$matchHead_PUBLIC"
     }
 }

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -6,12 +6,8 @@
     "url": "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip",
     "hash": "ebe3fa4e1afd7d97650990b27777bb78bd0427e8e70c1d0ee042aeb52decac61",
     "extract_dir": "ghidra_9.1.2_PUBLIC",
-    "bin": [
-        ["ghidraRun.bat", "ghidra"]
-    ],
-    "shortcuts": [
-        ["ghidraRun.bat", "Ghidra", "", "support\\ghidra.ico"]
-    ],
+    "bin": [["ghidraRun.bat", "ghidra"]],
+    "shortcuts": [["ghidraRun.bat", "Ghidra", "", "support\\ghidra.ico"]],
     "checkver": {
         "url": "https://github.com/NationalSecurityAgency/ghidra/releases",
         "regex": "Ghidra_(?<version>[\\d.]+)_build",

--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -1,0 +1,28 @@
+{
+    "version": "9.1.2",
+    "description": "Ghidra is a software reverse engineering (SRE) framework.",
+    "homepage": "https://www.nsa.gov/resources/everyone/ghidra/",
+    "license": "Apache-2.0 License",
+    "url": "https://ghidra-sre.org/ghidra_9.1.2_PUBLIC_20200212.zip",
+    "hash": "ebe3fa4e1afd7d97650990b27777bb78bd0427e8e70c1d0ee042aeb52decac61",
+    "extract_dir": "ghidra_9.1.2_PUBLIC",
+    "bin": [
+        ["ghidraRun.bat", "ghidra"]
+    ],
+    "shortcuts": [
+        ["ghidraRun.bat", "Ghidra", "", "support\\ghidra.ico"]
+    ],
+    "checkver": {
+        "url": "https://github.com/NationalSecurityAgency/ghidra/releases",
+        "regex": "Ghidra_(?<version>[\\d.]+)_build",
+        "replace": "${version}"
+    },
+    "autoupdate": {
+        "url": "https://ghidra-sre.org/ghidra_$version_PUBLIC_.zip",
+        "extract_dir": "ghidra_$version_PUBLIC",
+        "hash": {
+            "url": "https://ghidra-sre.org/releaseNotes_$version.html",
+            "regex": "<code>$sha256</code>"
+        }
+    }
+}


### PR DESCRIPTION
- Closes #1814 

Ghidra is a tool used for software reverse engineering developed by the CIA and open sourced to the software security research community.