### PR TITLE
cura: Update to version 4.8.0

### DIFF
--- a/bucket/cura.json
+++ b/bucket/cura.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.7.1",
+    "version": "4.8.0",
     "description": "Model editing tools for 3D printing",
     "homepage": "https://ultimaker.com/en/products/ultimaker-cura-software",
     "license": "LGPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Ultimaker/Cura/releases/download/4.7.1/Ultimaker_Cura-4.7.1-win64.exe#/dl.7z",
-            "hash": "47eb9b4f42a32f8a57f5b3df9e15774a114499ebd79e41f3a389539260b13d9b"
+            "url": "https://github.com/Ultimaker/Cura/releases/download/4.8/Ultimaker_Cura-4.8.0-amd64.exe#/dl.7z",
+            "hash": "3823b2132472ff7906b32c9763cf1fb9cf436726534ad9c2d0b8e93916433f3d"
         }
     },
     "pre_install": "Remove-Item \"$dir\\Uninstall*\", \"$dir\\`$*\", \"$dir\\vcredist_*.exe\" -Recurse",
@@ -26,7 +26,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker_Cura-$version-win64.exe#/dl.7z"
+                "url": "https://github.com/Ultimaker/Cura/releases/download/$version/Ultimaker_Cura-$version-amd64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
Somehow version numbers are weird in this release as "4.8" and "4.8.0" occurs in the URL. I think we will need to wait for the next release if this becomes the new norm, or if it was a one-time glitch. For now, I changed the link manually as autoupdate failed.