### PR TITLE
x64dbg package is currently broken. Updating to snapshot_2020-11-12_05-12

### DIFF
--- a/bucket/x64dbg.json
+++ b/bucket/x64dbg.json
@@ -3,8 +3,8 @@
     "description": "x64/x32 debugger",
     "homepage": "https://x64dbg.com/",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2020-11-05_15-25.zip",
-    "hash": "02a4da087bbeae69d12c42dd18a58c9c9bc7926a571988061b640ffd882c8c92",
+    "url": "https://github.com/x64dbg/x64dbg/releases/download/snapshot/snapshot_2020-11-12_05-12.zip",
+    "hash": "4acce60183dc9f3ef25b04fd20eddec6015a430a089800f25bcc8c6721959f42",
     "pre_install": [
         "'release\\x96dbg.ini', 'release\\x32\\x32dbg.ini', 'release\\x64\\x64dbg.ini' | ForEach-Object {",
         "    if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null }",


### PR DESCRIPTION
Current x64dbg package is not usable as the previous URL/zip file is no longer available. This is an intermediary fix. I will do some more reading on Github's API and see if there is a way to fetch the current existing build/release's hash (I'll be honest, this is my first time contributing to a package management solution, so I am not sure what all to expect, but hope to learn).