### PR TITLE
cfssl: Add version 1.5.0

### DIFF
--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -7,6 +7,7 @@
         "64bit": {
             "url": [
                 "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe#/cfssl.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-bundle_1.5.0_windows_amd64.exe#/cfssl-bundle.exe",
                 "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe#/cfssl-certinfo.exe",
                 "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe#/cfssl-newkey.exe",
                 "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe#/cfssl-scan.exe",
@@ -16,6 +17,7 @@
             ],
             "hash": [
                 "fce669f20d9f25dce20e4a39742613434e16c444ef5745aa91e546223031dbd5",
+                "3ecc18c7e168d611d63f84d63778a8c629b4223718d02094e4e8124cfc18440a",
                 "17282aba7a47205be7b937b541af1f33f75654afc66d3a54081a23a20273ad14",
                 "39cb0f739fec07ae8b16d3fd7e07929656748a1eb5b12e0632d1864282eb5d76",
                 "0e7371833942508e939beb051c09aa4112f3e4743460d549d23f8aace5ab0239",

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.5.0",
+    "description": "CloudFlare's PKI/TLS toolkit",
+    "homepage": "https://github.com/cloudflare/cfssl",
+    "license": "BSD-2-Clause",
+    "url": [
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/mkbundle_1.5.0_windows_amd64.exe",
+        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/multirootca_1.5.0_windows_amd64.exe"
+    ],
+    "hash": [
+        "fce669f20d9f25dce20e4a39742613434e16c444ef5745aa91e546223031dbd5",
+        "17282aba7a47205be7b937b541af1f33f75654afc66d3a54081a23a20273ad14",
+        "39cb0f739fec07ae8b16d3fd7e07929656748a1eb5b12e0632d1864282eb5d76",
+        "0e7371833942508e939beb051c09aa4112f3e4743460d549d23f8aace5ab0239",
+        "6fd4776e044489f1858ed33e7cfe09728396f1d01e5d5d5934b78c7ab5cddab9",
+        "aa3c8c84ac3c0e8ff69d798a01ea25fdd15934b92f7979c9c1cebca845446f7e",
+        "cea263e6e58aa20d924bc5f04aa67882a5a1660a2d05d473a192efdf8648b066"
+    ],
+    "extract_dir": "golang",
+    "bin": [
+        "cfssl.exe",
+        "cfssl-bundle.exe",
+        "cfssl-certinfo.exe",
+        "cfssl-newkey.exe",
+        "cfssl-scan.exe",
+        "cfssljson.exe",
+        "mkbundle.exe",
+        "multirootca.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl_$version_windows_amd64.exe",
+        "hash": {
+            "url": "$baseurl/cfssl_$version_checksums.txt"
+        }
+    }
+}

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -6,13 +6,13 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/mkbundle_1.5.0_windows_amd64.exe",
-                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/multirootca_1.5.0_windows_amd64.exe"
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe#/cfssl.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe#/cfssl-certinfo.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe#/cfssl-newkey.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe#/cfssl-scan.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_windows_amd64.exe#/cfssljson.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/mkbundle_1.5.0_windows_amd64.exe#/mkbundle.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/multirootca_1.5.0_windows_amd64.exe#/multirootca.exe"
             ],
             "hash": [
                 "fce669f20d9f25dce20e4a39742613434e16c444ef5745aa91e546223031dbd5",

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -22,16 +22,6 @@
                 "6fd4776e044489f1858ed33e7cfe09728396f1d01e5d5d5934b78c7ab5cddab9",
                 "aa3c8c84ac3c0e8ff69d798a01ea25fdd15934b92f7979c9c1cebca845446f7e",
                 "cea263e6e58aa20d924bc5f04aa67882a5a1660a2d05d473a192efdf8648b066"
-            ],
-            "bin": [
-                "cfssl.exe",
-                "cfssl-bundle.exe",
-                "cfssl-certinfo.exe",
-                "cfssl-newkey.exe",
-                "cfssl-scan.exe",
-                "cfssljson.exe",
-                "mkbundle.exe",
-                "multirootca.exe"
             ]
         }
     },

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -1,7 +1,7 @@
 {
     "version": "1.5.0",
-    "description": "CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line tool and an HTTP API server for signing, verifying, and bundling TLS certificates",
-    "homepage": "https://cfssl.org/",
+    "description": "Command line tool and an HTTP API server for signing, verifying, and bundling TLS certificates.",
+    "homepage": "https://cfssl.org",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -1,41 +1,41 @@
 {
     "version": "1.5.0",
-    "description": "CloudFlare's PKI/TLS toolkit",
-    "homepage": "https://github.com/cloudflare/cfssl",
+    "description": "CFSSL is CloudFlare's PKI/TLS swiss army knife. It is both a command line tool and an HTTP API server for signing, verifying, and bundling TLS certificates",
+    "homepage": "https://cfssl.org/",
     "license": "BSD-2-Clause",
-    "url": [
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/mkbundle_1.5.0_windows_amd64.exe",
-        "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/multirootca_1.5.0_windows_amd64.exe"
-    ],
-    "hash": [
-        "fce669f20d9f25dce20e4a39742613434e16c444ef5745aa91e546223031dbd5",
-        "17282aba7a47205be7b937b541af1f33f75654afc66d3a54081a23a20273ad14",
-        "39cb0f739fec07ae8b16d3fd7e07929656748a1eb5b12e0632d1864282eb5d76",
-        "0e7371833942508e939beb051c09aa4112f3e4743460d549d23f8aace5ab0239",
-        "6fd4776e044489f1858ed33e7cfe09728396f1d01e5d5d5934b78c7ab5cddab9",
-        "aa3c8c84ac3c0e8ff69d798a01ea25fdd15934b92f7979c9c1cebca845446f7e",
-        "cea263e6e58aa20d924bc5f04aa67882a5a1660a2d05d473a192efdf8648b066"
-    ],
-    "bin": [
-        "cfssl.exe",
-        "cfssl-bundle.exe",
-        "cfssl-certinfo.exe",
-        "cfssl-newkey.exe",
-        "cfssl-scan.exe",
-        "cfssljson.exe",
-        "mkbundle.exe",
-        "multirootca.exe"
-    ],
-    "checkver": "github",
-    "autoupdate": {
-        "url": "https://github.com/cloudflare/cfssl/releases/download/v$version/cfssl_$version_windows_amd64.exe",
-        "hash": {
-            "url": "$baseurl/cfssl_$version_checksums.txt"
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-certinfo_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-newkey_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssl-scan_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/cfssljson_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/mkbundle_1.5.0_windows_amd64.exe",
+                "https://github.com/cloudflare/cfssl/releases/download/v1.5.0/multirootca_1.5.0_windows_amd64.exe"
+            ],
+            "hash": [
+                "fce669f20d9f25dce20e4a39742613434e16c444ef5745aa91e546223031dbd5",
+                "17282aba7a47205be7b937b541af1f33f75654afc66d3a54081a23a20273ad14",
+                "39cb0f739fec07ae8b16d3fd7e07929656748a1eb5b12e0632d1864282eb5d76",
+                "0e7371833942508e939beb051c09aa4112f3e4743460d549d23f8aace5ab0239",
+                "6fd4776e044489f1858ed33e7cfe09728396f1d01e5d5d5934b78c7ab5cddab9",
+                "aa3c8c84ac3c0e8ff69d798a01ea25fdd15934b92f7979c9c1cebca845446f7e",
+                "cea263e6e58aa20d924bc5f04aa67882a5a1660a2d05d473a192efdf8648b066"
+            ],
+            "bin": [
+                "cfssl.exe",
+                "cfssl-bundle.exe",
+                "cfssl-certinfo.exe",
+                "cfssl-newkey.exe",
+                "cfssl-scan.exe",
+                "cfssljson.exe",
+                "mkbundle.exe",
+                "multirootca.exe"
+            ]
         }
+    },
+    "checkver": {
+        "github": "https://github.com/cloudflare/cfssl"
     }
 }

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -25,6 +25,16 @@
             ]
         }
     },
+    "bin": [
+        "cfssl.exe",
+        "cfssl-bundle.exe",
+        "cfssl-certinfo.exe",
+        "cfssl-newkey.exe",
+        "cfssl-scan.exe",
+        "cfssljson.exe",
+        "mkbundle.exe",
+        "multirootca.exe"
+    ],
     "checkver": {
         "github": "https://github.com/cloudflare/cfssl"
     }

--- a/bucket/cfssl.json
+++ b/bucket/cfssl.json
@@ -21,7 +21,6 @@
         "aa3c8c84ac3c0e8ff69d798a01ea25fdd15934b92f7979c9c1cebca845446f7e",
         "cea263e6e58aa20d924bc5f04aa67882a5a1660a2d05d473a192efdf8648b066"
     ],
-    "extract_dir": "golang",
     "bin": [
         "cfssl.exe",
         "cfssl-bundle.exe",


### PR DESCRIPTION
- Closes #5104

The `cfssl` is really a suite of utilities including `cfssl-bundle`, `cfssl-certinfo`, `cfssl-newkey`, `cfssl-scan`, `cfssljson`, `mkbundle`, `multirootca`. I've include them all in the `url`, `bin`, and `hash`

However, `autoupdate` only recognizes and updates the hash for the base app `cfssl`, but not the other utilities, even thought they are in the `autoupdate.hash` file

Do I:

1. Make individual app manifest for each utility, and have them listed as `depends/suggest` on `cfssl`?
2. Is there a special configuration I am missing for this use case?