### PR TITLE
conemu: Ugly onetime fix for 20.11.23a and #5173

### DIFF
--- a/bucket/conemu.json
+++ b/bucket/conemu.json
@@ -3,8 +3,8 @@
     "description": "Customizable Windows terminal with tabs, splits, quake-style, hotkeys and more.",
     "homepage": "https://conemu.github.io/",
     "license": "BSD-3-Clause",
-    "url": "https://github.com/Maximus5/ConEmu/releases/download/v20.11.23/ConEmuPack.201123.7z",
-    "hash": "89cd69f68b19576571bdd60a477f0b6a4329570be4c2cb9d185051a9ab421426",
+    "url": "https://github.com/Maximus5/ConEmu/releases/download/v20.11.23a/ConEmuPack.201123a.7z",
+    "hash": "898a8e1fcd0eb9301ad144f5e742b5389c484641e673625c020546848235d141",
     "pre_install": [
         "$xml = \"$dir\\ConEmu\\ConEmu.xml\"",
         "if(!(Test-Path \"$xml\")) {",


### PR DESCRIPTION
fixes #5173 

Seems like there was a hotfix for 20.11.23 and now the GitHub version (20.11.23) and the tag (20.11.23a) don't match anymore.
This fix here should be a one-time fix, assuming the conemu project releases will follow the previous namings...