### PR TITLE
panwriter: Add version 0.6.5

### DIFF
--- a/bucket/panwriter.json
+++ b/bucket/panwriter.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.6.5",
+    "license": "GPL-3.0-only",
+    "description": "Markdown editor with pandoc integration and paginated preview",
+    "url": "https://github.com/mb21/panwriter/releases/download/v0.6.5/PanWriter-Setup-0.6.5.exe#dl.7z",
+    "homepage": "https://panwriter.com/",
+    "hash": "66275b2ccf8981beb4d42ca0e2655c5f667db1b2df6217fefcfbd2e9dc726c4b",
+    "depends": "pandoc",
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
+    ],
+    "bin": "PanWriter.exe",
+    "shortcuts": [
+        [
+            "PanWriter.exe",
+            "PanWriter"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/mb21/panwriter"
+    },
+    "autoupdate": {
+        "url": "https://github.com/mb21/panwriter/releases/download/v$version/PanWriter-Setup-$version.exe#dl.7z"
+    }
+}

--- a/bucket/panwriter.json
+++ b/bucket/panwriter.json
@@ -14,7 +14,6 @@
             ]
         }
     },
-    "bin": "PanWriter.exe",
     "shortcuts": [
         [
             "PanWriter.exe",

--- a/bucket/panwriter.json
+++ b/bucket/panwriter.json
@@ -1,15 +1,19 @@
 {
     "version": "0.6.5",
-    "license": "GPL-3.0-only",
     "description": "Markdown editor with pandoc integration and paginated preview",
-    "url": "https://github.com/mb21/panwriter/releases/download/v0.6.5/PanWriter-Setup-0.6.5.exe#dl.7z",
-    "homepage": "https://panwriter.com/",
-    "hash": "66275b2ccf8981beb4d42ca0e2655c5f667db1b2df6217fefcfbd2e9dc726c4b",
+    "homepage": "https://panwriter.com",
+    "license": "GPL-3.0-only",
     "depends": "pandoc",
-    "pre_install": [
-        "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
-    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/mb21/panwriter/releases/download/v0.6.5/PanWriter-Setup-0.6.5.exe#/dl.7z",
+            "hash": "66275b2ccf8981beb4d42ca0e2655c5f667db1b2df6217fefcfbd2e9dc726c4b",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
+            ]
+        }
+    },
     "bin": "PanWriter.exe",
     "shortcuts": [
         [
@@ -21,6 +25,10 @@
         "github": "https://github.com/mb21/panwriter"
     },
     "autoupdate": {
-        "url": "https://github.com/mb21/panwriter/releases/download/v$version/PanWriter-Setup-$version.exe#dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/mb21/panwriter/releases/download/v$version/PanWriter-Setup-$version.exe#/dl.7z"
+            }
+        }
     }
 }


### PR DESCRIPTION
Note, technically pandoc is not required but [homepage](https://panwriter.com/) says
> You also have to install pandoc to export to most formats.

That's why I put pandoc in "depends', without it the app is not so useful.