### PR TITLE
miniconda3: Update to version 4.9.2

### DIFF
--- a/bucket/miniconda3.json
+++ b/bucket/miniconda3.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.2.8",
+    "version": "4.9.2",
     "description": "A cross-platform, Python-agnostic binary package manager.",
     "homepage": "https://conda.io/miniconda.html",
     "license": "BSD-3-Clause",
@@ -10,12 +10,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda3-2.2.8-Windows-x86_64.exe",
-            "hash": "md5:c3b1d72d83840e60b566abf301cde799"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Windows-x86_64.exe",
+            "hash": "md5:6f7e4c725a07b128da25df68ffd32003"
         },
         "32bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda3-2.2.8-Windows-x86.exe",
-            "hash": "md5:259e34e0e941f40cf7b43e71e6b159c3"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py38_4.9.2-Windows-x86.exe",
+            "hash": "md5:4027035b04f66b2cab30d26683e333ed"
         }
     },
     "installer": {


### PR DESCRIPTION
The current version of Miniconda as of 2020-11-23 is 4.9.2, so this pull request bumps the version in the config file.