### PR TITLE
dukto: Add version 6

### DIFF
--- a/bucket/dukto.json
+++ b/bucket/dukto.json
@@ -2,7 +2,7 @@
     "version": "6",
     "description": "An easy file transfer tool designed for LAN use.",
     "homepage": "https://www.msec.it/blog/dukto/",
-    "license": "GPL-2.0-only",
+    "license": "Freeware",
     "url": "https://downloads.sourceforge.net/project/dukto/DuktoR6-Portable.zip",
     "hash": "d32ab402e288dc80cfe9699459605f6b680f0e78b5ef2d04e4bd65e25ca270c9",
     "extract_dir": "DuktoR6",

--- a/bucket/dukto.json
+++ b/bucket/dukto.json
@@ -1,0 +1,15 @@
+{
+    "version": "6",
+    "description": "An easy file transfer tool designed for LAN use.",
+    "homepage": "https://www.msec.it/blog/dukto/",
+    "license": "GPL-2.0-only",
+    "url": "https://downloads.sourceforge.net/project/dukto/DuktoR6-Portable.zip",
+    "hash": "d32ab402e288dc80cfe9699459605f6b680f0e78b5ef2d04e4bd65e25ca270c9",
+    "extract_dir": "DuktoR6",
+    "shortcuts": [
+        [
+            "dukto.exe",
+            "Dukto"
+        ]
+    ]
+}


### PR DESCRIPTION
- Closes #5157

Provide no `autoupdate` as it is no longer maintained. ([homepage](https://www.msec.it/blog/dukto/))