### PR TITLE
anaconda3: Update to version 2020.11

### DIFF
--- a/bucket/anaconda3.json
+++ b/bucket/anaconda3.json
@@ -14,14 +14,6 @@
         }
     },
     "pre_install": "Write-Host 'Installing Anaconda 3. This can take up to 30 minutes on an HDD.' -ForegroundColor Magenta",
-    "bin": [
-        "python.exe",
-        "pythonw.exe",
-        [
-            "python.exe",
-            "python3"
-        ]
-    ],
     "installer": {
         "args": [
             "/S",
@@ -35,6 +27,14 @@
         "file": "Uninstall-Anaconda3.exe",
         "args": "/S"
     },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
     "env_add_path": "Scripts",
     "persist": "envs",
     "checkver": {

--- a/bucket/anaconda3.json
+++ b/bucket/anaconda3.json
@@ -1,16 +1,16 @@
 {
-    "version": "2.0.0",
+    "version": "2020.11",
     "description": "The most popular Python distribution for data science.",
     "homepage": "https://www.anaconda.com/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://repo.continuum.io/archive/Anaconda3-2.0.0-Windows-x86_64.exe",
-            "hash": "a8046fc82da7463ef53cdeaba97c72433c37b211c50fa87f1bc19bdfe5163328"
+            "url": "https://repo.anaconda.com/archive/Anaconda3-2020.11-Windows-x86_64.exe",
+            "hash": "aa523115daf31c431bb392faf75e70d35ada935e36dc7b1dd8902baee240bcc1"
         },
         "32bit": {
-            "url": "https://repo.continuum.io/archive/Anaconda3-2.0.0-Windows-x86.exe",
-            "hash": "37986ce4c104ed3c82838de74b3a4de17918cc2f408235b9de9d4283d3a5561d"
+            "url": "https://repo.anaconda.com/archive/Anaconda3-2020.11-Windows-x86.exe",
+            "hash": "362de9bc1e9e368dcbcdee1a175a523983c48dd8c04f83caf8d7ceaf7956bddc"
         }
     },
     "pre_install": "Write-Host 'Installing Anaconda 3. This can take up to 30 minutes on an HDD.' -ForegroundColor Magenta",
@@ -38,20 +38,20 @@
     "env_add_path": "Scripts",
     "persist": "envs",
     "checkver": {
-        "url": "https://repo.continuum.io/archive",
+        "url": "https://docs.anaconda.com/anaconda/install/hashes/win-3-64/",
         "regex": "Anaconda3-([\\d.]+)-Windows"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.continuum.io/archive/Anaconda3-$version-Windows-x86_64.exe",
+                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86_64.exe",
                 "hash": {
                     "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86_64.exe-hash/",
                     "regex": "$sha256"
                 }
             },
             "32bit": {
-                "url": "https://repo.continuum.io/archive/Anaconda3-$version-Windows-x86.exe",
+                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86.exe",
                 "hash": {
                     "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/",
                     "regex": "$sha256"


### PR DESCRIPTION
- Closes #5168

  - [https://repo.continuum.io](https://repo.continuum.io) redirects to [https://repo.anaconda.com](https://repo.anaconda.com) now. The latter should be more consistant.
  - Installers are (no longer) ordered by released date on the [file index page](https://repo.anaconda.com/archive/). This made the manifest ["update" to `v2.0.0`](https://github.com/lukesampson/scoop-extras/commit/c8cc5073c24c09968072dda537832623c9721b85), which was released on 2014-05-27. Use the official document page instead.