### PR TITLE
deepgit: Fix manifest

### DIFF
--- a/bucket/deepgit.json
+++ b/bucket/deepgit.json
@@ -23,7 +23,7 @@
                     "DeepGit"
                 ]
             ]
-        },
+        }
     },
     "persist": ".settings",
     "checkver": {


### PR DESCRIPTION
- Closes #5202 

The syntax error in the JSON file prevents installation.