### PR TITLE
dasel: Add version 1.8.0

### DIFF
--- a/bucket/dasel.json
+++ b/bucket/dasel.json
@@ -1,6 +1,6 @@
 {
     "version": "1.8.0",
-    "description": "Query and update data structures from the command line. Comparable to jq/yq but supports JSON, TOML, YAML and XML with zero runtime dependencies",
+    "description": "Dasel (short for data-selector) allows you to query and update data structures from the command line. Comparable to jq/yq but supports JSON, TOML, YAML and XML with zero runtime dependencies",
     "homepage": "https://github.com/TomWright/dasel",
     "license": "MIT",
     "architecture": {

--- a/bucket/dasel.json
+++ b/bucket/dasel.json
@@ -1,6 +1,6 @@
 {
     "version": "1.8.0",
-    "description": "Dasel (short for data-selector) allows you to query and update data structures from the command line. Comparable to jq/yq but supports JSON, TOML, YAML and XML with zero runtime dependencies",
+    "description": "DAta-SELector. Command line utility for querying and modifying data structures inside JSON, TOML, YAML, ...",
     "homepage": "https://github.com/TomWright/dasel",
     "license": "MIT",
     "architecture": {

--- a/bucket/dasel.json
+++ b/bucket/dasel.json
@@ -5,21 +5,16 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/TomWright/dasel/releases/download/v1.8.0/dasel_windows_amd64.exe",
+            "url": "https://github.com/TomWright/dasel/releases/download/v1.8.0/dasel_windows_amd64.exe#/dasel.exe",
             "hash": "5173274e90868d6d51a3ee580a2806650fd47107f7cee3b81c06ce92f4272a5f"
         }
     },
-    "bin": [
-        [
-            "dasel_windows_amd64.exe",
-            "dasel"
-        ]
-    ],
+    "bin": "dasel.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/TomWright/dasel/releases/download/v$version/dasel_windows_amd64.exe"
+                "url": "https://github.com/TomWright/dasel/releases/download/v$version/dasel_windows_amd64.exe#/dasel.exe"
             }
         }
     }

--- a/bucket/dasel.json
+++ b/bucket/dasel.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.8.0",
+    "description": "Query and update data structures from the command line. Comparable to jq/yq but supports JSON, TOML, YAML and XML with zero runtime dependencies",
+    "homepage": "https://github.com/TomWright/dasel",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/TomWright/dasel/releases/download/v1.8.0/dasel_windows_amd64.exe",
+            "hash": "5173274e90868d6d51a3ee580a2806650fd47107f7cee3b81c06ce92f4272a5f"
+        }
+    },
+    "bin": [
+        [
+            "dasel_windows_amd64.exe",
+            "dasel"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/TomWright/dasel/releases/download/v$version/dasel_windows_amd64.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Use single selector DSL to query many of the data formats.

Demo: 
![demo](https://github.com/TomWright/dasel/blob/master/update_kubernetes.gif?raw=true)