### PR TITLE
meshlab@2020.12: Fix installation

### DIFF
--- a/bucket/meshlab.json
+++ b/bucket/meshlab.json
@@ -12,9 +12,9 @@
             "hash": "aed659b380b3d366dc5a267021bd8149412e11ada104975e391bb99cf7d40601"
         }
     },
+    "extract_dir": "meshlab_windows_portable",
     "bin": [
         "meshlab.exe",
-        "meshlabserver.exe"
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
meshlabserver.exe is not in the released zip file.