### PR TITLE
playnite: Update to version 8.10

### DIFF
--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -28,7 +28,8 @@
         "library"
     ],
     "checkver": {
-        "github": "https://github.com/JosefNemec/Playnite"
+        "url": "https://playnite.link/download.html",
+        "regex": "Latest version: <span class=\"text-info\">([\\d.]+)"
     },
     "autoupdate": {
         "url": "https://playnite.link/update/stable/$version/Playnite$cleanVersion.zip"

--- a/bucket/playnite.json
+++ b/bucket/playnite.json
@@ -1,10 +1,10 @@
 {
-    "version": "8.8",
-    "description": "An open source video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net and Uplay. Includes game emulation support, providing one unified interface for your games.",
-    "homepage": "https://playnite.link/",
+    "version": "8.10",
+    "description": "Video game library manager and launcher with support for 3rd party libraries like Steam, GOG, Origin, Battle.net, ...",
+    "homepage": "https://playnite.link",
     "license": "MIT",
-    "url": "https://playnite.link/update/stable/8.8/Playnite88.zip",
-    "hash": "49ba0d6dd2a0c87d9bca351ea0f65e4348273d46273bd3774cb6d65f74c1c72d",
+    "url": "https://playnite.link/update/stable/8.10/Playnite810.zip",
+    "hash": "39be7de23bcb2be8bf105adeec2a63c446ae0613dbedcbdefab6522cf8967e81",
     "pre_install": "Copy-Item \"$persist_dir\\config.json\" \"$dir\" -ErrorAction SilentlyContinue",
     "uninstaller": {
         "script": "Copy-Item \"$dir\\config.json\" \"$persist_dir\" -ErrorAction SilentlyContinue -Force"
@@ -29,7 +29,7 @@
     ],
     "checkver": {
         "url": "https://playnite.link/download.html",
-        "regex": "Latest version: <span class=\"text-info\">([\\d.]+)"
+        "regex": "/update/stable/([\\d.]+)/Playnite"
     },
     "autoupdate": {
         "url": "https://playnite.link/update/stable/$version/Playnite$cleanVersion.zip"


### PR DESCRIPTION
The last few playnite version were not released on github. For this reason the version is lacking behind in this bucket. To fix this a changed the `checkver` url to the current release site and added the required regex