### PR TITLE
plantuml: Fix shim parameters handling.

### DIFF
--- a/bucket/plantuml.json
+++ b/bucket/plantuml.json
@@ -11,9 +11,9 @@
         ]
     },
     "url": "https://downloads.sourceforge.net/project/plantuml/1.2020.24/plantuml.1.2020.24.jar#/plantuml.jar",
-    "hash": "sha1:6d7743ae38715e22f4d38f1e25f440d08f6a5d31",
-    "bin": "plantuml.cmd",
+    "hash": "sha1:105c52d884fd9e032889a8da2f6ed07989fbf151",
     "pre_install": "\"@java -jar \"\"$dir\\plantuml.jar\"\" %* -graphvizdot \"\"$(shimdir $global)\\dot.exe\"\"\" | out-file -en oem \"$dir\\plantuml.cmd\"",
+    "bin": "plantuml.cmd",
     "checkver": {
         "url": "http://plantuml.com/download",
         "regex": "PlantUML compiled Jar \\(Version ([\\d.]+)\\)"

--- a/bucket/plantuml.json
+++ b/bucket/plantuml.json
@@ -13,7 +13,7 @@
     "url": "https://downloads.sourceforge.net/project/plantuml/1.2020.22/plantuml.1.2020.22.jar#/plantuml.jar",
     "hash": "sha1:1ece779643e06549e3e76922898314cbaea07e6a",
     "bin": "plantuml.cmd",
-    "pre_install": "\"@java -jar \"\"$dir\\plantuml.jar\"\" -graphvizdot \"\"$(shimdir $global)\\dot.exe\"\" %*\" | out-file -en oem \"$dir\\plantuml.cmd\"",
+    "pre_install": "\"@java -jar \"\"$dir\\plantuml.jar\"\" %*\"\" -graphvizdot \"\"$(shimdir $global)\\dot.exe\" | out-file -en oem \"$dir\\plantuml.cmd\"",
     "checkver": {
         "url": "http://plantuml.com/download",
         "regex": "PlantUML compiled Jar \\(Version ([\\d.]+)\\)"

--- a/bucket/plantuml.json
+++ b/bucket/plantuml.json
@@ -13,7 +13,7 @@
     "url": "https://downloads.sourceforge.net/project/plantuml/1.2020.22/plantuml.1.2020.22.jar#/plantuml.jar",
     "hash": "sha1:1ece779643e06549e3e76922898314cbaea07e6a",
     "bin": "plantuml.cmd",
-    "pre_install": "\"@java -jar \"\"$dir\\plantuml.jar\"\" %*\"\" -graphvizdot \"\"$(shimdir $global)\\dot.exe\" | out-file -en oem \"$dir\\plantuml.cmd\"",
+    "pre_install": "\"@java -jar \"\"$dir\\plantuml.jar\"\" %* -graphvizdot \"\"$(shimdir $global)\\dot.exe\"\"\" | out-file -en oem \"$dir\\plantuml.cmd\"",
     "checkver": {
         "url": "http://plantuml.com/download",
         "regex": "PlantUML compiled Jar \\(Version ([\\d.]+)\\)"


### PR DESCRIPTION
- Closes #5336
- Closes #5335
- Closes #5332
- Closes #5331

When we use plantuml.cmd with command line option(s),
they will be added after an option for graphviz (dot).
If we use "-headless" option, it always shows
"Warning: -headless flag must be the first one in the command line".