### PR TITLE
imageglass: Update to version 8.0.12.8

### DIFF
--- a/bucket/imageglass.json
+++ b/bucket/imageglass.json
@@ -1,19 +1,14 @@
 {
-    "version": "7.6.4.30",
+    "version": "8.0.12.8",
     "description": "A lightweight, versatile image viewer",
     "homepage": "https://imageglass.org",
     "license": "GPL-3.0-only",
     "notes": "If this app doesn't work maybe you need to clean '$dir\\igconfig.xml'.",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/7.6.4.30/ImageGlass_7.6.4.30_x64.zip",
-            "hash": "sha1:5d9781319eb6d2bd474080c4a9a5ee9b9bb9e0f7",
-            "extract_dir": "ImageGlass_7.6.4.30_x64"
-        },
-        "32bit": {
-            "url": "https://github.com/d2phap/ImageGlass/releases/download/7.6.4.30/ImageGlass_7.6.4.30_x86.zip",
-            "hash": "sha1:00765b57c051107e8a4bd1ef2246e4f3b8c1c8d3",
-            "extract_dir": "ImageGlass_7.6.4.30_x86"
+            "url": "https://github.com/d2phap/ImageGlass/releases/download/8.0.12.8/ImageGlass_8.0.12.8_x64.zip",
+            "hash": "sha1:49ab1bfecd1d2a7a90836b93aa53f1e71e81a9b9",
+            "extract_dir": "ImageGlass_8.0.12.8_x64"
         }
     },
     "pre_install": [
@@ -49,14 +44,6 @@
                     "regex": "(?sm)Download portable x64 version.*?$sha1"
                 },
                 "extract_dir": "ImageGlass_$version_x64"
-            },
-            "32bit": {
-                "url": "https://github.com/d2phap/ImageGlass/releases/download/$version/ImageGlass_$version_x86.zip",
-                "hash": {
-                    "url": "https://imageglass.org/download",
-                    "regex": "(?sm)Download portable x86 version.*?$sha1"
-                },
-                "extract_dir": "ImageGlass_$version_x86"
             }
         }
     }


### PR DESCRIPTION
It seems that ImageGlass only provides 64bit builds since version 8, and the `32bit` key is preventing auto-update.