### PR TITLE
glab: add version 1.12.1

### DIFF
--- a/bucket/glab.json
+++ b/bucket/glab.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.12.1",
+    "description": "An open-source GitLab CLI tool",
+    "homepage": "https://github.com/profclems/glab",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "http://github.com/profclems/glab/releases/download/v1.12.1/glab_1.12.1_windows_386.zip",
+            "hash": "9dd010bad88e755aa81b34e823b8dcab99591107a4db57f4331bb4e9edcee288"
+        },
+        "64bit": {
+            "url": "http://github.com/profclems/glab/releases/download/v1.12.1/glab_1.12.1_windows_amd64.zip",
+            "hash": "ddebd39ba72c12837702bcde6fc5695fcc0dee7b8ac572cb2d154a8a2b7fda96"
+        }
+    },
+    "bin": "bin\\glab.exe",
+    "checkver": {
+        "github": "https://github.com/profclems/glab"
+    },
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "http://github.com/profclems/glab/releases/download/v$version/glab_$version_windows_386.zip"
+            },
+            "64bit": {
+                "url": "http://github.com/profclems/glab/releases/download/v$version/glab_$version_windows_amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION
[`glab`](http://github.com/profclems/glab) is an open-source GitLab command line tool