### PR TITLE
php-xdebug: Update to version 3.0.1-8.0

### DIFF
--- a/bucket/php-nts-xdebug.json
+++ b/bucket/php-nts-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.1-7.4",
+    "version": "3.0.1-8.0",
     "description": "An extension for PHP to assist with debugging and development. (Non-Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,12 +12,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.0.1-7.4-vc15-nts-x86_64.dll#/php_xdebug.dll",
-            "hash": "92d626d66b25968ea24feb03b706f4515a1cae3f4fdc691dd9f020e395f8124c"
+            "url": "https://xdebug.org/files/php_xdebug-3.0.1-8.0-vs16-nts-x86_64.dll#/php_xdebug.dll",
+            "hash": "c6eac924292880fdafba6a6aa7c261cfa8eb6345e7255d9c3ee295979c4d96c9"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.0.1-7.4-vc15-nts.dll#/php_xdebug.dll",
-            "hash": "497790c2d5ddf99e269259835a975a01affe267eb1b696c3fcc3505aae7b024f"
+            "url": "https://xdebug.org/files/php_xdebug-3.0.1-8.0-vs16-nts.dll#/php_xdebug.dll",
+            "hash": "3f85d0751d3e44f8f980d5db5cc877970c7d8f8a193f21094587aedb9172fdf5"
         }
     },
     "post_install": [

--- a/bucket/php-xdebug.json
+++ b/bucket/php-xdebug.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.0.1-7.4",
+    "version": "3.0.1-8.0",
     "description": "An extension for PHP to assist with debugging and development. (Thread Safe)",
     "homepage": "https://xdebug.org/",
     "license": {
@@ -12,12 +12,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.0.1-7.4-vc15-x86_64.dll#/php_xdebug.dll",
-            "hash": "6194fed531921d267716e23605b1c41809a4a6f6f3bc24c5508c906741706458"
+            "url": "https://xdebug.org/files/php_xdebug-3.0.1-8.0-vs16-x86_64.dll#/php_xdebug.dll",
+            "hash": "14ee3593981ae38e8f6792deeb2e73ec60324cddfe02650d79ff733e9b3944bb"
         },
         "32bit": {
-            "url": "https://xdebug.org/files/php_xdebug-3.0.1-7.4-vc15.dll#/php_xdebug.dll",
-            "hash": "8be452983ec27983e09db71cce7669bbb992e829caea060789ffc984324a7715"
+            "url": "https://xdebug.org/files/php_xdebug-3.0.1-8.0-vs16.dll#/php_xdebug.dll",
+            "hash": "b198c8b1325ce66a5efad9310b33697efeee769668fcaad4f82994e91da0ffa2"
         }
     },
     "post_install": [


### PR DESCRIPTION
Update php-xdebug to match PHP version in the main bucket. fixes #5269 