### PR TITLE
dont-sleep: Hash fix

### DIFF
--- a/bucket/dont-sleep.json
+++ b/bucket/dont-sleep.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.softwareok.com/Download/DontSleep_x64.zip",
-            "hash": "d775087e878126ca2ad9ef0824ffaee8b4edd404a8d92d6708ef98f19d23044c",
+            "hash": "e991c96226bad8a4c8fcb428020ce3b4b7ddfec625f541a4d1065b4211bcd067",
             "shortcuts": [
                 [
                     "DontSleep_x64.exe",
@@ -19,7 +19,7 @@
         },
         "32bit": {
             "url": "https://www.softwareok.com/Download/DontSleep.zip",
-            "hash": "b8d1052a33ee2f94507fb596fa3664f10b3048bb9816889cd99a15e53e1a36b2",
+            "hash": "ecf564db61235b2c276a75f71704bb546613aa7c1a0b1f2950aa3565b5e8455c",
             "shortcuts": [
                 [
                     "DontSleep.exe",


### PR DESCRIPTION
Fixed hashes of [Don't Sleep](https://www.softwareok.com/?Download=DontSleep) v7.71 as reported by the author website.