### PR TITLE
workspacer: Update to version 0.9.10

### DIFF
--- a/bucket/workspacer.json
+++ b/bucket/workspacer.json
@@ -1,15 +1,15 @@
 {
-    "version": "0.9.9",
+    "version": "0.9.10",
     "description": "A tiling window manager for Windows 10",
     "homepage": "https://www.workspacer.org",
     "license": "MIT",
+    "notes": "Add \"context.Branch = Branch.None;\" at the start of your config to disable auto-updates.",
     "architecture": {
         "64bit": {
-            "url": "https://workspacer.blob.core.windows.net/installers/stable/workspacer-stable-0.9.9.msi",
-            "hash": "647b171fa8420ccd07e997a50d440cdbdcdb1cd3472fe50dda8a120ae70cd58d"
+            "url": "https://github.com/rickbutton/workspacer/releases/download/v0.9.10/workspacer-stable-0.9.10.zip",
+            "hash": "120843e963b5826e746df9ea0ed51eb3eb729c94ad4fd4086687d30fac0b5455"
         }
     },
-    "extract_dir": "workspacer",
     "shortcuts": [
         [
             "workspacer.exe",
@@ -17,13 +17,12 @@
         ]
     ],
     "checkver": {
-        "url": "https://workspacer.blob.core.windows.net/installers/stable.xml",
-        "xpath": "/item/version"
+        "github": "https://github.com/rickbutton/workspacer"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://workspacer.blob.core.windows.net/installers/stable/workspacer-stable-$version.msi"
+                "url": "https://github.com/rickbutton/workspacer/releases/download/v$version/workspacer-stable-$version.zip"
             }
         }
     }


### PR DESCRIPTION
workspacer has moved to GitHub Actions.