### PR TITLE
Fix winfetch.json

### DIFF
--- a/bucket/winfetch.json
+++ b/bucket/winfetch.json
@@ -6,13 +6,11 @@
     "suggest": {
         "imagemagick": "imagemagick"
     },
-    "url": "https://codeload.github.com/lptstr/winfetch/zip/v1.3.0#/dl.7z",
-    "hash": "88c4bb5cb213796c29322d590bf36b1353095a446edb80eac3a1cf7a81e32f58",
-    "extract_dir": "winfetch-1.3.0",
-    "bin": "src\\winfetch.ps1",
+    "url": "https://raw.githubusercontent.com/lptstr/winfetch/v1.3.0/src/posh-winfetch.ps1#/winfetch.ps1",
+    "hash": "8b6a31072dcc83b55344250e0aca11ab8c771dcb59817488053133019c7949e3",
+    "bin": "winfetch.ps1",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://codeload.github.com/lptstr/winfetch/zip/v$version#/dl.7z",
-        "extract_dir": "winfetch-$version"
+        "url": "https://raw.githubusercontent.com/lptstr/winfetch/v$version/src/posh-winfetch.ps1#/winfetch.ps1"
     }
 }


### PR DESCRIPTION
This PR fixes #5359.

The `winfetch.ps1` file was renamed to `posh-winfetch.ps1`.
It also downloads the `posh-winfetch.ps1` file directly as it is not dependent on anything else in the repo.