### PR TITLE
Update darktable to 3.4.0

### DIFF
--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.2.1",
+    "version": "3.4.0",
     "description": "Photography workflow application and raw developer. A virtual lighttable and darkroom for photographers.",
     "homepage": "https://www.darktable.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/darktable-org/darktable/releases/download/release-3.2.1/darktable-3.2.1-win64.exe",
-            "hash": "7d21442aa31a627428cf9e56c85ecb4e985b544ea950d98b54ed0a6f123ad6d3"
+            "url": "https://github.com/darktable-org/darktable/releases/download/release-3.4.0/darktable-3.4.0-win64.exe",
+            "hash": "29dee565292a4a72443874bb970663d46420f5a9ba74a5acfcb3251a48c86f7c"
         }
     },
     "installer": {


### PR DESCRIPTION
Checked, seems to work okay, and the hash matches the one found in https://github.com/darktable-org/darktable/releases/tag/release-3.4.0