### PR TITLE
fix axiom@1.9.5.4-alpha: hash check failed

### DIFF
--- a/bucket/axiom.json
+++ b/bucket/axiom.json
@@ -10,7 +10,7 @@
         ]
     },
     "url": "https://github.com/MattMcManis/Axiom/releases/download/v1.9.5.4-alpha/Axiom.zip",
-    "hash": "7788315e4cfee1962c1b8793454d8668da0ffb9ff810415f4f757ed57aa8230b",
+    "hash": "67c44e162cebe7172af86e7563afa87ad1a021a00e2c016ff6c93f916c0bb4c2",
     "bin": "Axiom.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
App:         extras/axiom
URL:         https://github.com/MattMcManis/Axiom/releases/download/v1.9.5.4-alpha/Axiom.zip
First bytes: 50 4B 03 04 15 00 00 00
Expected:    7788315e4cfee1962c1b8793454d8668da0ffb9ff810415f4f757ed57aa8230b
Actual:      67c44e162cebe7172af86e7563afa87ad1a021a00e2c016ff6c93f916c0bb4c2