### PR TITLE
powertoys: update to version 0.29.0

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,26 +1,28 @@
 {
-    "version": "0.21.1",
+    "version": "0.29.0",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.21.1/PowerToysSetup-0.21.1-x64.msi",
-            "hash": "ef63a70fc1c4b718410d3129d1691ab3814b4f7d1cea402e6507b0133ca2f09c"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.29.0/PowerToysSetup-0.29.0-x64.exe",
+            "hash": "bc635394b092a11958b2c6af66dbfe0f8d1c2dd52ce758d5963125061241ac64"
         }
     },
-    "extract_dir": "PowerToys",
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
+    "installer": {
+        "args": [
+            "--silent",
+            "--install_dir $dir"
         ]
-    ],
+    },
+    "uninstaller": {
+        "script": "(Get-WmiObject Win32_Product | Where-Object Name -Eq 'PowerToys (Preview)').uninstall()"
+    },
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.msi"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe"
             }
         }
     }


### PR DESCRIPTION
This uses the new --install_dir argument to install the app into the correct scoop directory.

A "proper" uninstall requires invocation of .uninstall() on the WMI object. however I have found no issues with uninstalling and re-installing without the use of this, however I believe it should be cleaner using this method.

This should hopefully solve #5084