### PR TITLE
jellyfin: Add version 10.6.4

### DIFF
--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,9 +1,9 @@
 {
-    "version": "10.7.0-rc1",
-    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.7.0~rc1.zip",
+    "version": "10.6.3",
+    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.6.3.zip",
     "bin": "jellyfin.exe",
-    "extract_dir": "jellyfin_10.7.0~rc1",
-    "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90",
+    "extract_dir": "jellyfin_$version",
+    "hash": "c7e09669c41889590ed3f612154c8a2dbc6f9ab779690d3ae66075a534946e85",
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
     "autoupdate": {

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -5,5 +5,8 @@
     "extract_dir": "jellyfin_10.7.0~rc1",
     "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90",
     "license": "GPL-2.0-only",
-    "homepage": "https://jellyfin.org/"
+    "homepage": "https://jellyfin.org/",
+    "autoupdate": {
+        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_$version.zip"
+    }
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -3,5 +3,6 @@
     "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.7.0~rc1.zip",
     "bin": "jellyfin.exe",
     "extract_dir": "jellyfin_10.7.0~rc1",
-    "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90"
+    "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90",
+    "license": "GPL-2.0-only"
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -8,5 +8,8 @@
     "homepage": "https://jellyfin.org/",
     "autoupdate": {
         "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_$version.zip"
+    },
+    "checkver": {
+        "github": "https://github.com/jellyfin/jellyfin"
     }
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,6 +1,7 @@
 {
-    "version": "10.7.0",
+    "version": "10.7.0-rc1",
     "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.7.0~rc1.zip",
-    "extract_dir": "jellyfin",
-    "bin": "jellyfin.exe"
+    "bin": "jellyfin.exe",
+    "extract_dir": "jellyfin_10.7.0~rc1",
+    "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90"
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,19 +1,45 @@
 {
     "version": "10.6.4",
-    "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.4/jellyfin_10.6.4.zip",
-    "bin": "jellyfin.exe",
-    "extract_dir": "jellyfin_10.6.4",
-    "hash": "24e6c832b82fba9cdc6ef0a7a79ae0f1a4fed73fd3119e38369f68913c1a5945",
+    "description": "Software Media System",
+    "homepage": "https://jellyfin.org",
     "license": "GPL-2.0-only",
-    "homepage": "https://jellyfin.org/",
+    "suggest": {
+        "ffmpeg": [
+            "ffmpeg",
+            "ffmpeg-nightly"
+        ],
+        "nssm": "nssm"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.4/jellyfin_10.6.4.zip",
+            "hash": "24e6c832b82fba9cdc6ef0a7a79ae0f1a4fed73fd3119e38369f68913c1a5945"
+        }
+    },
+    "extract_dir": "jellyfin_10.6.4",
+    "extract_to": "system",
+    "bin": [
+        [
+            "system\\jellyfin.exe",
+            "jellyfin",
+            "-d \"$dir\\data\""
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/",
+        "regex": "\"([\\d.]+)/",
+        "reverse": true
+    },
     "autoupdate": {
-        "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/$version/jellyfin_$version.zip",
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/$version/jellyfin_$version.zip"
+            }
+        },
         "hash": {
-            "url": "$baseurl/jellyfin_$version.zip.sha256sum"
+            "url": "$url.sha256sum"
         },
         "extract_dir": "jellyfin_$version"
-    },
-    "checkver": {
-        "github": "https://github.com/jellyfin/jellyfin"
     }
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,13 +1,13 @@
 {
     "version": "10.6.3",
-    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/10.6.3/jellyfin_10.6.3.zip",
+    "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.3/jellyfin_10.6.3.zip",
     "bin": "jellyfin.exe",
     "extract_dir": "jellyfin_$version",
     "hash": "c7e09669c41889590ed3f612154c8a2dbc6f9ab779690d3ae66075a534946e85",
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
     "autoupdate": {
-        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/$version/jellyfin_$version.zip",
+        "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/$version/jellyfin_$version.zip",
         "hash": {
             "url": "$baseurl/jellyfin_$version.zip.sha256sum"
         }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,0 +1,6 @@
+{
+    "version": "10.7.0",
+    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.7.0~rc1.zip",
+    "extract_dir": "jellyfin",
+    "bin": "jellyfin.exe"
+}

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,13 +1,13 @@
 {
     "version": "10.6.3",
-    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_10.6.3.zip",
+    "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/10.6.3/jellyfin_10.6.3.zip",
     "bin": "jellyfin.exe",
     "extract_dir": "jellyfin_$version",
     "hash": "c7e09669c41889590ed3f612154c8a2dbc6f9ab779690d3ae66075a534946e85",
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
     "autoupdate": {
-        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_$version.zip",
+        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/$version/jellyfin_$version.zip",
         "hash": {
             "url": "$baseurl/jellyfin_$version.zip.sha256sum"
         }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -7,7 +7,10 @@
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
     "autoupdate": {
-        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_$version.zip"
+        "url": "https://repo.jellyfin.org/releases/server/windows/stable/combined/jellyfin_$version.zip",
+        "hash": {
+            "url": "$baseurl/jellyfin_$version.zip.sha256sum"
+        }
     },
     "checkver": {
         "github": "https://github.com/jellyfin/jellyfin"

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -2,7 +2,7 @@
     "version": "10.6.3",
     "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.3/jellyfin_10.6.3.zip",
     "bin": "jellyfin.exe",
-    "extract_dir": "jellyfin_$version",
+    "extract_dir": "jellyfin_10.6.3",
     "hash": "c7e09669c41889590ed3f612154c8a2dbc6f9ab779690d3ae66075a534946e85",
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
@@ -10,7 +10,8 @@
         "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/$version/jellyfin_$version.zip",
         "hash": {
             "url": "$baseurl/jellyfin_$version.zip.sha256sum"
-        }
+        },
+        "extract_dir": "jellyfin_$version"
     },
     "checkver": {
         "github": "https://github.com/jellyfin/jellyfin"

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -4,5 +4,6 @@
     "bin": "jellyfin.exe",
     "extract_dir": "jellyfin_10.7.0~rc1",
     "hash": "91ad74ecfe04b77ba2d432255b373cf9b2ff27980dde4a26f3fda9fede319f90",
-    "license": "GPL-2.0-only"
+    "license": "GPL-2.0-only",
+    "homepage": "https://jellyfin.org/"
 }

--- a/bucket/jellyfin.json
+++ b/bucket/jellyfin.json
@@ -1,9 +1,9 @@
 {
-    "version": "10.6.3",
-    "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.3/jellyfin_10.6.3.zip",
+    "version": "10.6.4",
+    "url": "https://repo.jellyfin.org/releases/server/windows/versions/stable/combined/10.6.4/jellyfin_10.6.4.zip",
     "bin": "jellyfin.exe",
-    "extract_dir": "jellyfin_10.6.3",
-    "hash": "c7e09669c41889590ed3f612154c8a2dbc6f9ab779690d3ae66075a534946e85",
+    "extract_dir": "jellyfin_10.6.4",
+    "hash": "24e6c832b82fba9cdc6ef0a7a79ae0f1a4fed73fd3119e38369f68913c1a5945",
     "license": "GPL-2.0-only",
     "homepage": "https://jellyfin.org/",
     "autoupdate": {


### PR DESCRIPTION
Hi,

Jellyfin is a open source fork of Emby, a media server similar to Plex.
This is my first manifest, so I am happy about any feedback I can get.

Also, please squash and merge these changes (if you don't do this anyway) when ready, as my commits are small and many.