### PR TITLE
add windows-terminal-quake

### DIFF
--- a/bucket/windows-terminal-quake.json
+++ b/bucket/windows-terminal-quake.json
@@ -1,0 +1,19 @@
+{
+  "version": "v0.11",
+  "description": "Companion program for the new Windows Terminal that enables Quake-style drop down",
+  "homepage": "https://github.com/flyingpie/windows-terminal-quake",
+  "bin": "windows-terminal-quake.exe",
+  "persist": "windows-terminal-quake.json",
+  "checkver": "github",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/flyingpie/windows-terminal-quake/releases/download/v0.11/windows-terminal-quake-v0.11-2020-11-02_0001.zip",
+      "hash": "2d49e5d10519c48e0ec63b6f8328e11bc95c53b9f0948adee6862ed88213c726"
+    }
+  },
+  "suggest": {
+    "terminal": [
+      "extras/windows-terminal"
+    ]
+  }
+}


### PR DESCRIPTION
windows-terminal-quake is a companion to windows-terminal. Enabling features such as opacity, quake-style dropdown and such.

disclaimer: I am not the maintainer of the program, I did this file and it works for me.