### PR TITLE
Update PowerToys to 0.29.3

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,15 +1,20 @@
 {
-    "version": "0.21.1",
+    "version": "0.29.3",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.21.1/PowerToysSetup-0.21.1-x64.msi",
-            "hash": "ef63a70fc1c4b718410d3129d1691ab3814b4f7d1cea402e6507b0133ca2f09c"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.29.3/PowerToysSetup-0.29.3-x64.exe",
+            "hash": "6e4ff3db261a0704659ce53346f2edf62af57c6736594889d9b60e099f246ba6",
+            "installer": {
+                "args": [
+                    "-s",
+                    "--install_dir \"$dir\""
+                ]
+            }
         }
     },
-    "extract_dir": "PowerToys",
     "shortcuts": [
         [
             "PowerToys.exe",
@@ -20,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.msi"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe"
             }
         }
     }


### PR DESCRIPTION
Uses new `.exe` installer as the original `msi` installer is no longer provided.