### PR TITLE
TortoiseSVN: Fix path to TortoiseOverlays

### DIFF
--- a/scripts/tortoisesvn/tortoisesvn-install.reg.templ
+++ b/scripts/tortoisesvn/tortoisesvn-install.reg.templ
@@ -121,63 +121,63 @@ REGEDIT4
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994560-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994561-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994561-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994562-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994562-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994563-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994563-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994564-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994564-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994565-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994565-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994566-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994566-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994567-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994567-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994568-53D9-4125-87C9-F193FC689CB2}]
 @="TortoiseSVN"
 
 [HKEY_CLASSES_ROOT\CLSID\{C5994568-53D9-4125-87C9-F193FC689CB2}\InProcServer32]
-@="%TSVNHOME%\\TortoiseOverlays\\TortoiseOverlays.dll"
+@="%TSVNHOME%\\Common\\TortoiseOverlays\\TortoiseOverlays.dll"
 "ThreadingModel"="Apartment"
 
 [HKEY_CLASSES_ROOT\CLSID\{F26E2640-0CFF-43DC-8325-575A3261D885}]
@@ -366,15 +366,15 @@ REGEDIT4
 "{C5994568-53D9-4125-87C9-F193FC689CB2}"="TortoiseOverlays"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\TortoiseOverlays]
-"NormalIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\NormalIcon.ico"
-"ModifiedIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\ModifiedIcon.ico"
-"ConflictIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\ConflictIcon.ico"
-"DeletedIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\DeletedIcon.ico"
-"ReadOnlyIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\ReadOnlyIcon.ico"
-"LockedIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\LockedIcon.ico"
-"AddedIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\AddedIcon.ico"
-"IgnoredIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\IgnoredIcon.ico"
-"UnversionedIcon"="%TSVNHOME%\\TortoiseOverlays\\icons\\XPStyle\\UnversionedIcon.ico"
+"NormalIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\NormalIcon.ico"
+"ModifiedIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\ModifiedIcon.ico"
+"ConflictIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\ConflictIcon.ico"
+"DeletedIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\DeletedIcon.ico"
+"ReadOnlyIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\ReadOnlyIcon.ico"
+"LockedIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\LockedIcon.ico"
+"AddedIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\AddedIcon.ico"
+"IgnoredIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\IgnoredIcon.ico"
+"UnversionedIcon"="%TSVNHOME%\\Common\\TortoiseOverlays\\icons\\XPStyle\\UnversionedIcon.ico"
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\TortoiseOverlays\Added]
 "SVN"="{3035134E-7B7D-4FCC-81B4-1E394CA267EB}"


### PR DESCRIPTION
TortoiseSVN installs TortoiseOverlays by default to `D:\scoop\apps\tortoisesvn\current\Common\TortoiseOverlays`, but the registry file that is generated points to `D:\scoop\apps\tortoisesvn\current\TortoiseOverlays`. This PR fixes that.