### PR TITLE
 powertoys: Update to version 0.29.3

### DIFF
--- a/bucket/powertoys.json
+++ b/bucket/powertoys.json
@@ -1,26 +1,27 @@
 {
-    "version": "0.21.1",
+    "version": "0.29.3",
     "description": "A set of utilities for power users to tune and streamline their Windows experience for greater productivity.",
     "homepage": "https://github.com/microsoft/PowerToys",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.21.1/PowerToysSetup-0.21.1-x64.msi",
-            "hash": "ef63a70fc1c4b718410d3129d1691ab3814b4f7d1cea402e6507b0133ca2f09c"
+            "url": "https://github.com/microsoft/PowerToys/releases/download/v0.29.3/PowerToysSetup-0.29.3-x64.exe",
+            "hash": "6e4ff3db261a0704659ce53346f2edf62af57c6736594889d9b60e099f246ba6",
+            "installer": {
+                "script": "Start-Process \"$dir\\$fname\" \"/S /D=$dir\" -PassThru -NoNewWindow | Wait-Process",
+                "keep": "true"
+            },
+            "uninstaller": {
+                "script": "Start-Process \"$dir\\PowerToysSetup-$version-x64.exe\" \"/S /D=$dir\" -PassThru -NoNewWindow | Wait-Process"
+            }
         }
     },
     "extract_dir": "PowerToys",
-    "shortcuts": [
-        [
-            "PowerToys.exe",
-            "PowerToys"
-        ]
-    ],
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.msi"
+                "url": "https://github.com/microsoft/PowerToys/releases/download/v$version/PowerToysSetup-$version-x64.exe"
             }
         }
     }


### PR DESCRIPTION
PowerToys dropped MSI Installer, which requires a change in the manifest. 

Changes made:
* changed version to latest stable release
* changed installer and uninstaller behavior
* dropped and cleaned up some unnecessary properties