### PR TITLE
openshot: Use native executable as shortcut target

### DIFF
--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -22,10 +22,8 @@
     "bin": "openshot.ps1",
     "shortcuts": [
         [
-            "launch-win.bat",
-            "OpenShot Video Editor",
-            "",
-            "openshot-qt.exe"
+            "openshot-qt.exe",
+            "OpenShot Video Editor"
         ]
     ],
     "checkver": {

--- a/bucket/openshot.json
+++ b/bucket/openshot.json
@@ -18,8 +18,6 @@
         }
     },
     "innosetup": true,
-    "pre_install": "Set-Content \"$dir\\openshot.ps1\" \"Start-Process '$dir\\launch-win.bat' -WorkingDirectory '$dir'\" -Encoding Ascii",
-    "bin": "openshot.ps1",
     "shortcuts": [
         [
             "openshot-qt.exe",


### PR DESCRIPTION
Fix: https://github.com/lukesampson/scoop-extras/issues/5476

`launch-win.bat` uses for debug, see https://github.com/OpenShot/openshot-qt/blob/8dffb2cd507e93576d24b671927e247614264c02/freeze.py#L185-L186