### PR TITLE
Replaces ACLs with default inherited ACLs for rolloutfile.tv13

### DIFF
--- a/bucket/teamviewer.json
+++ b/bucket/teamviewer.json
@@ -9,6 +9,7 @@
     "url": "https://download.teamviewer.com/download/version_15x/TeamViewerPortable.zip",
     "hash": "0748d1efeee59785178842f7b1dae49457c1ded7d5f48d2eaf9478478cb84ea5",
     "bin": "teamviewer.exe",
+    "pre_uninstall": "icacls.exe \"$dir\\rolloutfile.tv13\" /reset",
     "shortcuts": [
         [
             "TeamViewer.exe",


### PR DESCRIPTION
When running teamviewer, it changes the ACLs of `rolloutfile.tv13` so that a normal uninstall isn't possible with Scoop/Shovel. 

More info at https://community.teamviewer.com/English/discussion/49721/teamviewerportable-rolloutfile-tv13-only-adminrights

This PR adds a `pre_uninstall` property (supported only by Shovel), so that it replaces ACLs with default inherited ACLs for rolloutfile.tv13, and then the file isn't locked when trying to uninstall.

cc @Ash258 