### PR TITLE
Update brave.json

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -8,11 +8,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-x64.exe#/dl.7z",
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.18.78/brave-v1.18.78-win32-x64.zip#/dl.7z",
             "hash": "d9e7dd4f7597b6cec73dd49a23c52f4da87a8c25ccf837b8c3a8c7a70895606f"
         },
         "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-ia32.exe#/dl.7z",
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.18.78/brave-v1.18.78-win32-ia32.zip#/dl.7z",
             "hash": "683a5f4e1295cb26acbff648864939e529243e1f6df4451a857aa8c2ed4794fe"
         }
     },


### PR DESCRIPTION
This Brave browser is very outdated so I updated it to the newest available release version. Unfortunately, I am not sure how to update the "autoupdate". I figured out that if it says "Release vXX.YY.ZZ" then it is the right one here: https://github.com/brave/brave-browser/releases?after=v1.20.71
However, I can't code this pattern in the json file.