### PR TITLE
session@1.4.5: Fix URL

### DIFF
--- a/bucket/session.json
+++ b/bucket/session.json
@@ -5,7 +5,7 @@
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/loki-project/session-desktop/releases/download/v1.4.5/session-messenger-desktop-win-1.4.5.exe#/dl.7z",
+            "url": "https://github.com/oxen-io/session-desktop/releases/download/v1.4.5/session-desktop-win-1.4.5.exe#/dl.7z",
             "hash": "sha512:079f856ae3c534c458b87b375db4a7366226ca2a3b3bf4f4861a16bc63493eb58207fc3240c3b676dac4d9213540612068b84340356024a8b05e2f5aa6e50ef8",
             "installer": {
                 "script": [
@@ -23,12 +23,12 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/loki-project/session-desktop"
+        "github": "https://github.com/oxen-io/session-desktop"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/loki-project/session-desktop/releases/download/v$version/session-messenger-desktop-win-$version.exe#/dl.7z"
+                "url": "https://github.com/oxen-io/session-desktop/releases/download/v$version/session-desktop-win-$version.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
- Closes #5534
- Closes #5524 

Loki has been rebranded to Oxen, as noted in #5524 .