### PR TITLE
Change google chrome autoupdate urls and update chrome packages

### DIFF
--- a/bucket/googlechrome-beta.json
+++ b/bucket/googlechrome-beta.json
@@ -1,5 +1,5 @@
 {
-    "version": "88.0.4324.27",
+    "version": "88.0.4324.104",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/beta",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/OAia1yXFLZADspGAtsoLRA_88.0.4324.27/88.0.4324.27_chrome_installer.exe#/dl.7z",
-            "hash": "2e00897cad6c373a81850ac03e80551264026ef3389fb98fc673f858a2f19bbf"
+            "url": "https://dl.google.com/release2/chrome/c8d4NzNO3Ok0-XckopwzQA_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "d6f787da9bc18da43a9da4f3e914f654aaa36554b2b318d0d2101a6a5fb4e547"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/AKzsrt3amnVOxKFglbyU5tM_88.0.4324.27/88.0.4324.27_chrome_installer.exe#/dl.7z",
-            "hash": "4e1e9d74b54d32704afd8e3298f3bca69263e374264d90e77bead03420e3ff34"
+            "url": "https://dl.google.com/release2/chrome/Kb5qv1aZlMDDCf93BzZWbg_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "caed253a3f7188f7cd270fea2a817a78f8f83d8de46d4eaba66247744521d383"
         }
     },
     "installer": {
@@ -32,7 +32,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
         "regex": "(?sm)<beta32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<beta64>.+release2/chrome/(?<64>[\\w-]+)_.+</beta64>"
     },
     "autoupdate": {
@@ -40,14 +40,14 @@
             "64bit": {
                 "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/beta64[version='$version']/sha256"
                 }
             },
             "32bit": {
                 "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/beta32[version='$version']/sha256"
                 }
             }

--- a/bucket/googlechrome-canary.json
+++ b/bucket/googlechrome-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "89.0.4349.3",
+    "version": "90.0.4398.0",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/canary",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/ALLIpT4Xvtp1or36MSzf1sQ_89.0.4349.3/89.0.4349.3_chrome_installer.exe#/dl.7z",
-            "hash": "1ab9c610eef4227c65d83371e0b5baaac85ffb136d4c0cc6180f70b977cd777b"
+            "url": "https://dl.google.com/release2/chrome/Yby1c1ucWQW5KuZ4f3c7Ig_90.0.4398.0/90.0.4398.0_chrome_installer.exe#/dl.7z",
+            "hash": "cd3a19ee828d4a6f2fc0ed636a47a520772a313b06f64061c7d9a7e939847127"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/APUXIFXpJs0mGSbmlbLzFV8_89.0.4349.3/89.0.4349.3_chrome_installer.exe#/dl.7z",
-            "hash": "35bc402b3bbfe6550e9b042c8f8e88a062bb069495c9dad3e1deb064ab425342"
+            "url": "https://dl.google.com/release2/chrome/AKiifMOQyYvQUm9m1o_KY-M_90.0.4398.0/90.0.4398.0_chrome_installer.exe#/dl.7z",
+            "hash": "5d5bcc9ec2c7a717ce7bd88a256e512117fb468bdc918a20b23b05ae93423017"
         }
     },
     "installer": {
@@ -32,7 +32,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
         "regex": "(?sm)<canary32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<canary64>.+release2/chrome/(?<64>[\\w-]+)_.+</canary64>"
     },
     "autoupdate": {
@@ -40,14 +40,14 @@
             "64bit": {
                 "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/canary64[version='$version']/sha256"
                 }
             },
             "32bit": {
                 "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/canary32[version='$version']/sha256"
                 }
             }

--- a/bucket/googlechrome-dev.json
+++ b/bucket/googlechrome-dev.json
@@ -1,5 +1,5 @@
 {
-    "version": "89.0.4343.0",
+    "version": "89.0.4389.9",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/dev",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/AO01UGGrYvlMieZe9TGtroc_89.0.4343.0/89.0.4343.0_chrome_installer.exe#/dl.7z",
-            "hash": "feb2c554729270d3a3be54c95f854287684f73f98fa21aca92ac3dae73a7278c"
+            "url": "https://dl.google.com/release2/chrome/AMHl5ygBwStDvR17ibE4nWE_89.0.4389.9/89.0.4389.9_chrome_installer.exe#/dl.7z",
+            "hash": "86d5ad3d310ba60133ad5e7d0e7158081d556d0e3d6e7c3ba581e66a85832132"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/VGXZ9BiNA-CQl5Thv1DYHQ_89.0.4343.0/89.0.4343.0_chrome_installer.exe#/dl.7z",
-            "hash": "dd97967fc63a6a024449c84f09458ab7e07c31e7688e800d3c42d66189b786d2"
+            "url": "https://dl.google.com/release2/chrome/APzGqAIWj-XQar9jZuC9aFY_89.0.4389.9/89.0.4389.9_chrome_installer.exe#/dl.7z",
+            "hash": "600d602164c770c38400237fa7a2eeed222551efa29aa5871ed62bfc91c5e179"
         }
     },
     "installer": {
@@ -32,7 +32,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
         "regex": "(?sm)<dev32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<dev64>.+release2/chrome/(?<64>[\\w-]+)_.+</dev64>"
     },
     "autoupdate": {
@@ -40,14 +40,14 @@
             "64bit": {
                 "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/dev64[version='$version']/sha256"
                 }
             },
             "32bit": {
                 "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/dev32[version='$version']/sha256"
                 }
             }

--- a/bucket/googlechrome-portable.json
+++ b/bucket/googlechrome-portable.json
@@ -1,5 +1,5 @@
 {
-    "version": "87.0.4280.88",
+    "version": "88.0.4324.104",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/CUtGVpXHPGLv_SbZcTshgQ_87.0.4280.88/87.0.4280.88_chrome_installer.exe#/dl.7z",
-            "hash": "44b128dc4a4c5fe6bfe6536220ffbd35e6daac3c9485a257ab20ea251625e688"
+            "url": "https://dl.google.com/release2/chrome/c8d4NzNO3Ok0-XckopwzQA_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "d6f787da9bc18da43a9da4f3e914f654aaa36554b2b318d0d2101a6a5fb4e547"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/ANR7-iQPdlrf-hVEj0LnTq4_87.0.4280.88/87.0.4280.88_chrome_installer.exe#/dl.7z",
-            "hash": "edbb7847b8b3bb6e91bf1a9b060a6ac4c54b1a04ee0cdcd41ea49751bce9998e"
+            "url": "https://dl.google.com/release2/chrome/Kb5qv1aZlMDDCf93BzZWbg_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "caed253a3f7188f7cd270fea2a817a78f8f83d8de46d4eaba66247744521d383"
         }
     },
     "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",
@@ -38,7 +38,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
         "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
     },
     "autoupdate": {
@@ -46,14 +46,14 @@
             "64bit": {
                 "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/stable64[version='$version']/sha256"
                 }
             },
             "32bit": {
                 "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/stable32[version='$version']/sha256"
                 }
             }

--- a/bucket/googlechrome.json
+++ b/bucket/googlechrome.json
@@ -1,5 +1,5 @@
 {
-    "version": "87.0.4280.88",
+    "version": "88.0.4324.104",
     "description": "Fast, secure, and free web browser, built for the modern web.",
     "homepage": "https://www.google.com/chrome/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.google.com/release2/chrome/CUtGVpXHPGLv_SbZcTshgQ_87.0.4280.88/87.0.4280.88_chrome_installer.exe#/dl.7z",
-            "hash": "44b128dc4a4c5fe6bfe6536220ffbd35e6daac3c9485a257ab20ea251625e688"
+            "url": "https://dl.google.com/release2/chrome/c8d4NzNO3Ok0-XckopwzQA_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "d6f787da9bc18da43a9da4f3e914f654aaa36554b2b318d0d2101a6a5fb4e547"
         },
         "32bit": {
-            "url": "https://dl.google.com/release2/chrome/ANR7-iQPdlrf-hVEj0LnTq4_87.0.4280.88/87.0.4280.88_chrome_installer.exe#/dl.7z",
-            "hash": "edbb7847b8b3bb6e91bf1a9b060a6ac4c54b1a04ee0cdcd41ea49751bce9998e"
+            "url": "https://dl.google.com/release2/chrome/Kb5qv1aZlMDDCf93BzZWbg_88.0.4324.104/88.0.4324.104_chrome_installer.exe#/dl.7z",
+            "hash": "caed253a3f7188f7cd270fea2a817a78f8f83d8de46d4eaba66247744521d383"
         }
     },
     "installer": {
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://chrome-dl.com/api/chrome.min.xml",
+        "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
         "regex": "(?sm)<stable32><version>(?<version>[\\d.]+)</version>.+release2/chrome/(?<32>[\\w-]+)_.+<stable64>.+release2/chrome/(?<64>[\\w-]+)_.+</stable64>"
     },
     "autoupdate": {
@@ -35,14 +35,14 @@
             "64bit": {
                 "url": "https://dl.google.com/release2/chrome/$match64_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/stable64[version='$version']/sha256"
                 }
             },
             "32bit": {
                 "url": "https://dl.google.com/release2/chrome/$match32_$version/$version_chrome_installer.exe#/dl.7z",
                 "hash": {
-                    "url": "https://chrome-dl.com/api/chrome.min.xml",
+                    "url": "https://42wim.github.io/chromeupdates/chrome.min.xml",
                     "xpath": "/chromechecker/stable32[version='$version']/sha256"
                 }
             }


### PR DESCRIPTION
https://chrome-dl.com/ doesn't seem to be maintained anymore, I'm
planning on maintaining chrome updates in my repo
https://github.com/42wim/chromeupdates / https://42wim.github.io/chromeupdates

This commit changes the autoupdate URL and adds the latest chrome
versions for googlechrome-beta, googlechrome-canary, googlechrome-dev,
googlechrome-portable, googlechrome