### PR TITLE
pskubectlcompletion: Add version 1.0.4

### DIFF
--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -5,6 +5,7 @@
     "license": "Apache-2.0",
     "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg#/dl.7z",
     "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",
+    "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {
         "name": "PSKubectlCompletion"
     },

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -13,6 +13,6 @@
         "regex": "<h2>([\\d.]+)</h2>"
     },
     "autoupdate": {
-        "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.$version.nupkg#/dl.7z"
+        "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.$version.nupkg"
     }
 }

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -3,7 +3,7 @@
     "description": "kubectl auto-completion for PowerShell",
     "homepage": "https://github.com/mziyabo/PSKubectlCompletion",
     "license": "Apache-2.0",
-    "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg#/dl.7z",
+    "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg",
     "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",
     "pre_install": "Remove-Item \"$dir\\_rels\", \"$dir\\package\", \"$dir\\*Content*.xml\" -Recurse",
     "psmodule": {

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.4",
-    "description": "kubectl auto-completion for PowerShell.",
-    "homepage": "https://github.com/mziyabo/PSKubectlCompletion/",
+    "description": "kubectl auto-completion for PowerShell",
+    "homepage": "https://github.com/mziyabo/PSKubectlCompletion",
     "license": "Apache-2.0",
     "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg#/dl.7z",
     "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -1,0 +1,24 @@
+{
+    "version": "1.0.4",
+    "description": "kubectl auto-completion for PowerShell.",
+    "homepage": "https://github.com/mziyabo/PSKubectlCompletion/",
+    "license": "Apache-2.0",
+    "notes": [
+        "Use the module by running: 'Import-Module PSKubectlCompletion'",
+        "Add that command to your $PROFILE to make it permanent",
+        "",
+        "See usage: https://github.com/mziyabo/PSKubectlCompletion#powershell-auto-completion-for-kubectl"
+    ],
+    "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg#/dl.7z",
+    "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",
+    "psmodule": {
+        "name": "PSKubectlCompletion"
+    },
+    "checkver": {
+        "url": "https://www.powershellgallery.com/packages/PSKubectlCompletion",
+        "regex": "<h2>([\\d.]+)</h2>"
+    },
+    "autoupdate": {
+        "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.$version.nupkg#/dl.7z"
+    }
+}

--- a/bucket/pskubectlcompletion.json
+++ b/bucket/pskubectlcompletion.json
@@ -3,12 +3,6 @@
     "description": "kubectl auto-completion for PowerShell.",
     "homepage": "https://github.com/mziyabo/PSKubectlCompletion/",
     "license": "Apache-2.0",
-    "notes": [
-        "Use the module by running: 'Import-Module PSKubectlCompletion'",
-        "Add that command to your $PROFILE to make it permanent",
-        "",
-        "See usage: https://github.com/mziyabo/PSKubectlCompletion#powershell-auto-completion-for-kubectl"
-    ],
     "url": "https://psg-prod-eastus.azureedge.net/packages/pskubectlcompletion.1.0.4.nupkg#/dl.7z",
     "hash": "497d7c0724b5946176d8a6a250e074d1bf3848e9e75adaf2d73d623f57d1716e",
     "psmodule": {


### PR DESCRIPTION
This can be use to enable kubectl auto-completion for PowerShell