### PR TITLE
dont-sleep: Hash fix

### DIFF
--- a/bucket/dont-sleep.json
+++ b/bucket/dont-sleep.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.softwareok.com/Download/DontSleep_x64.zip",
-            "hash": "08c4749f448a8de3f5800a27796b438251532a3fd9038568a0b1d96867f7de87",
+            "hash": "08259a9d410112ab962f6925c0a2ab62af6c4f27675a547e09b626f66be64aec",
             "shortcuts": [
                 [
                     "DontSleep_x64.exe",
@@ -19,7 +19,7 @@
         },
         "32bit": {
             "url": "https://www.softwareok.com/Download/DontSleep.zip",
-            "hash": "c7938a92b0d5dc7b4d0bc44d0cfe9ed6c827e4d17ed920322c67f7522d894da3",
+            "hash": "62e3a92c302bfa1dc95707342dbcab2b489d9fbcd825d722dcb3679c49ee5d27",
             "shortcuts": [
                 [
                     "DontSleep.exe",


### PR DESCRIPTION
Fixed hashes of [Don't Sleep](https://www.softwareok.com/?Download=DontSleep) v7.89 as reported by the author website.