### PR TITLE
kdiff3: Update to version 1.8.5

### DIFF
--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -1,23 +1,36 @@
 {
-    "version": "0.9.98",
-    "description": "A file and directory diff and merge tool",
-    "homepage": "http://kdiff3.sourceforge.net/",
+    "version": "1.8.5",
+    "description": "Utility for comparing and merging files and directories",
+    "homepage": "https://invent.kde.org/sdk/kdiff3",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.98/KDiff3-64bit-Setup_0.9.98-2.exe#/dl.7z",
-            "hash": "sha1:4b7358aec8de6a3e719065fce37dd966c92ed3d4"
-        },
-        "32bit": {
-            "url": "https://downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.98/KDiff3-32bit-Setup_0.9.98-3.exe#/dl.7z",
-            "hash": "sha1:9d7ec4fb0e2b83a321cb77ce47c86fd42fc8ec2b"
+            "url": "https://download.kde.org/stable/kdiff3/kdiff3-1.8.5-windows-64-cl.exe#/dl.7z",
+            "hash": "c0be76353161af622154993ed464a168a5cda38639deca76befe50f48e348ef5"
         }
     },
-    "bin": "kdiff3.exe",
+    "installer": {
+        "script": "Expand-7zipArchive \"$dir\\kdiff3*.7z\" -Removal"
+    },
+    "bin": "bin\\kdiff3.exe",
     "shortcuts": [
         [
-            "kdiff3.exe",
+            "bin\\kdiff3.exe",
             "KDiff3"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://download.kde.org/stable/kdiff3/?C=M;O=D",
+        "regex": "(?<file>kdiff3-(?<version>(\\d\\.\\d\\.\\d|\\d\\.\\d))-windows-64(-cl)?\\.exe)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.kde.org/stable/kdiff3/$matchFile#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
 }

--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -9,9 +9,10 @@
             "hash": "c0be76353161af622154993ed464a168a5cda38639deca76befe50f48e348ef5"
         }
     },
-    "installer": {
-        "script": "Expand-7zipArchive \"$dir\\kdiff3*.7z\" -Removal"
-    },
+    "pre_install": [
+        "Expand-7zipArchive \"$dir\\kdiff3*.7z\" -Removal",
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\" -Recurse"
+    ],
     "bin": "bin\\kdiff3.exe",
     "shortcuts": [
         [
@@ -21,12 +22,12 @@
     ],
     "checkver": {
         "url": "https://download.kde.org/stable/kdiff3/?C=M;O=D",
-        "regex": "(?<file>kdiff3-(?<version>(\\d\\.\\d\\.\\d|\\d\\.\\d))-windows-64(-cl)?\\.exe)"
+        "regex": "kdiff3-(([\\d.]+))-windows-64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.kde.org/stable/kdiff3/$matchFile#/dl.7z"
+                "url": "https://download.kde.org/stable/kdiff3/kdiff3-$version-windows-64-cl.exe#/dl.7z"
             }
         },
         "hash": {

--- a/bucket/kdiff3.json
+++ b/bucket/kdiff3.json
@@ -11,7 +11,7 @@
     },
     "pre_install": [
         "Expand-7zipArchive \"$dir\\kdiff3*.7z\" -Removal",
-        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\" -Recurse"
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninst*\", \"$dir\\7za.exe\" -Recurse"
     ],
     "bin": "bin\\kdiff3.exe",
     "shortcuts": [


### PR DESCRIPTION
The KDiff3 repository had been moved to KDE's GitLab.
Also, there was a download link for the stable version at `download.kde.org`, so I changed to download it from there.