### PR TITLE
windowsdesktop-runtime: Update to version 3.1.11

### DIFF
--- a/bucket/windowsdesktop-runtime.json
+++ b/bucket/windowsdesktop-runtime.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.10",
+    "version": "3.1.11",
     "description": "Microsoft .NET Core Desktop Runtime",
     "homepage": "https://dotnet.microsoft.com/download/dotnet-core",
     "license": {
@@ -9,12 +9,12 @@
     "notes": "You can now remove this installer with 'scoop uninstall windowsdesktop-runtime'",
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.10/windowsdesktop-runtime-3.1.10-win-x64.exe",
-            "hash": "sha512:14a7d97fb258bee024cff3585492ed43c3ec6ac823b50980ddde8241a8bca3e578c38ca28e461630d38c180bd72323e1fcb0ee2e6e65ef9bfc8481df7beef142"
+            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.11/windowsdesktop-runtime-3.1.11-win-x64.exe",
+            "hash": "sha512:ad4c1fe410ddc3c97444882a4515d42829e428e0f8218b4d5edc67a6f6efa7b7629a736cf6ae52e56882f0707a9222180be5715d3f79a4ed39687404a5adfd5c"
         },
         "32bit": {
-            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.10/windowsdesktop-runtime-3.1.10-win-x86.exe",
-            "hash": "sha512:1697e69644a1df46922e440c1ea16e583660f79f3b9b109b493a24835ae543ea6180c5167d6dbe89d8dd8991f865dba717525e333e4a2f32319733afa6a320b5"
+            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/3.1.11/windowsdesktop-runtime-3.1.11-win-x86.exe",
+            "hash": "sha512:56b4aa80199e5e0bdc7ebea7ba812a0331b052d725d531194daba541307d50adb2e551eaab101882ff55959e4727ee213618d86642b9b84a33a36269d49fb778"
         }
     },
     "pre_install": "if (!(is_admin)) { error 'Admin privileges are required.'; break }",


### PR DESCRIPTION
Update windowsdesktop-runtime (dotnet-core desktop runtime) to latest version to date. 