### PR TITLE
darktable@3.4.1: Fix URL

### DIFF
--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.4.1.1",
+    "version": "3.4.1",
     "description": "Photography workflow application and raw developer. A virtual lighttable and darkroom for photographers.",
     "homepage": "https://www.darktable.org",
     "license": "GPL-3.0-only",

--- a/bucket/darktable.json
+++ b/bucket/darktable.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.4.1",
+    "version": "3.4.1.1",
     "description": "Photography workflow application and raw developer. A virtual lighttable and darkroom for photographers.",
     "homepage": "https://www.darktable.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/darktable-org/darktable/releases/download/release-3.4.1/darktable-3.4.1-win64.exe",
-            "hash": "94f6f0999378a541b25bd030838b508882d2bace86a95c898a30ca32c406c3f8"
+            "url": "https://github.com/darktable-org/darktable/releases/download/release-3.4.1/darktable-3.4.1.1-win64.exe",
+            "hash": "251453a776b7749b7f7701b7b58e6b9eba7747370c228bfa298f2053200d9fec"
         }
     },
     "installer": {


### PR DESCRIPTION
3.4.1 is no longer valid.

https://github.com/darktable-org/darktable/releases/download/release-3.4.1/darktable-3.4.1-win64.exe - is no longer available.
```ERROR Download failed! (Error 3) Resource was not found```