### PR TITLE
musescore: Actually update to 3.6.2.548021803

### DIFF
--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6/MuseScore-3.6.2.548021803-x86_64.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021803-x86_64.msi",
             "hash": "fa3ca0f8cc5b0e8b0c0bb8ef11e227b9b27b2a5c9da28dab58bafcbb0eb657d0"
         },
         "32bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6/MuseScore-3.6.2.548021803-x86.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021803-x86.msi",
             "hash": "aa5fa721a2229735dcb992eb5e847eaf8667eaf81e9e81bf766756888daa0409"
         }
     },


### PR DESCRIPTION
Wrong tag name leads to a 404 from Github