### PR TITLE
musescore@3.6.2.548021803: Fix URL

### DIFF
--- a/bucket/musescore.json
+++ b/bucket/musescore.json
@@ -5,11 +5,11 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6/MuseScore-3.6.2.548021803-x86_64.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021803-x86_64.msi",
             "hash": "fa3ca0f8cc5b0e8b0c0bb8ef11e227b9b27b2a5c9da28dab58bafcbb0eb657d0"
         },
         "32bit": {
-            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6/MuseScore-3.6.2.548021803-x86.msi",
+            "url": "https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021803-x86.msi",
             "hash": "aa5fa721a2229735dcb992eb5e847eaf8667eaf81e9e81bf766756888daa0409"
         }
     },
@@ -35,14 +35,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/musescore/MuseScore/releases/download/v$majorVersion.$minorVersion/MuseScore-$version-x86_64.msi",
+                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchHead/MuseScore-$version-x86_64.msi",
                 "hash": {
                     "url": "https://musescore.org/en/download/musescore.msi",
                     "regex": ">SHA256 Checksum:\\s+$sha256</"
                 }
             },
             "32bit": {
-                "url": "https://github.com/musescore/MuseScore/releases/download/v$majorVersion.$minorVersion/MuseScore-$version-x86.msi",
+                "url": "https://github.com/musescore/MuseScore/releases/download/v$matchHead/MuseScore-$version-x86.msi",
                 "hash": {
                     "url": "https://musescore.org/en/download/musescore-32bit.msi",
                     "regex": ">SHA256 Checksum:\\s+$sha256</"


### PR DESCRIPTION
- Closes #5684 
- Closes #5670
- Closes #5692 
- Closes #5721

autoupdate urls now use `$matchHead.`
I'm not 100% sure about how futureproof it's gonna be but it should work for conventional version numbers for now. 