### PR TITLE
nfbc: Add version 1.6.3

### DIFF
--- a/bucket/nbfc.json
+++ b/bucket/nbfc.json
@@ -3,7 +3,7 @@
   "description": "NoteBook FanControl, a cross-platform fan control service for notebooks",
   "homepage": "https://github.com/hirschmann/nbfc/",
   "checkver": "github",
-  "license": "GPL-3.0-only"},
+  "license": "GPL-3.0-only",
   "hash": "5A42531F3A051DBD9664B1FF41A6CDBFBB34BC71A91DB719B8FE94829594EBAA",
   "url": "https://github.com/hirschmann/nbfc/releases/download/1.6.3/NoteBookFanControl.1.6.3.setup.exe",
   "pre_install": [

--- a/bucket/nbfc.json
+++ b/bucket/nbfc.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.6.3",
+  "description": "NoteBook FanControl, a cross-platform fan control service for notebooks",
+  "homepage": "https://github.com/hirschmann/nbfc/",
+  "checkver": "github",
+  "license": {
+    "identifier": "GPL-3.0-only"
+  },
+  "hash": "5A42531F3A051DBD9664B1FF41A6CDBFBB34BC71A91DB719B8FE94829594EBAA",
+  "url": "https://github.com/hirschmann/nbfc/releases/download/1.6.3/NoteBookFanControl.1.6.3.setup.exe#/setup.exe",
+  "pre_install": [
+    "Get-ChildItem \"$dir\\setup.exe\" | ForEach-Object { Expand-DarkArchive $_ \"$dir\\nbfc\" -Removal }",
+    "Get-ChildItem \"$dir\\nbfc\\AttachedContainer\\NbfcSetup.msi\" | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
+    "Remove-Item \"$dir\\nbfc\" -Recurse"
+  ],
+  "shortcuts": [[
+    "NoteBook FanControl\\NoteBookFanControl.exe",
+    "NoteBook FanControl"
+  ]],
+  "autoupdate": {
+    "url": "https://github.com/hirschmann/nbfc/releases/download/$version/NoteBookFanControl.$version.setup.exe#/setup.exe"
+  }
+}

--- a/bucket/nbfc.json
+++ b/bucket/nbfc.json
@@ -3,13 +3,11 @@
   "description": "NoteBook FanControl, a cross-platform fan control service for notebooks",
   "homepage": "https://github.com/hirschmann/nbfc/",
   "checkver": "github",
-  "license": {
-    "identifier": "GPL-3.0-only"
-  },
+  "license": "GPL-3.0-only"},
   "hash": "5A42531F3A051DBD9664B1FF41A6CDBFBB34BC71A91DB719B8FE94829594EBAA",
-  "url": "https://github.com/hirschmann/nbfc/releases/download/1.6.3/NoteBookFanControl.1.6.3.setup.exe#/setup.exe",
+  "url": "https://github.com/hirschmann/nbfc/releases/download/1.6.3/NoteBookFanControl.1.6.3.setup.exe",
   "pre_install": [
-    "Get-ChildItem \"$dir\\setup.exe\" | ForEach-Object { Expand-DarkArchive $_ \"$dir\\nbfc\" -Removal }",
+    "Get-ChildItem \"$dir\\$fname\" | ForEach-Object { Expand-DarkArchive $_ \"$dir\\nbfc\" -Removal }",
     "Get-ChildItem \"$dir\\nbfc\\AttachedContainer\\NbfcSetup.msi\" | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
     "Remove-Item \"$dir\\nbfc\" -Recurse"
   ],
@@ -18,6 +16,6 @@
     "NoteBook FanControl"
   ]],
   "autoupdate": {
-    "url": "https://github.com/hirschmann/nbfc/releases/download/$version/NoteBookFanControl.$version.setup.exe#/setup.exe"
+    "url": "https://github.com/hirschmann/nbfc/releases/download/$version/NoteBookFanControl.$version.setup.exe"
   }
 }


### PR DESCRIPTION
Hi, first contribution. Hope full name in description and no autoupdate on the hash are the right ways to do things (hash has to be generated from downloaded file). This uses Expand-DarkArchive as done for example in the [portable vcreddist 2013 manifest](https://github.com/lukesampson/scoop-extras/blob/a8bcb1b43b0230a9348a422017be31fe625cea70/bucket/vcredist2013-portable.json)).