### PR TITLE
sqlitestudio: make config local and persist

### DIFF
--- a/bucket/sqlitestudio.json
+++ b/bucket/sqlitestudio.json
@@ -6,6 +6,8 @@
     "url": "https://github.com/pawelsalawa/sqlitestudio/releases/download/3.2.1/SQLiteStudio-3.2.1.zip",
     "hash": "eb5ac6d2ea89027f07c879f59122e0a722cb0ea46ac18af8185af6a222d4ee57",
     "extract_dir": "SQLiteStudio",
+    "pre_install": ["if (!(test-path \"$persist_dir\")) { mkdir \"$persist_dir\" > $null }"],
+    "persist": ["sqlitestudio-cfg"],
     "bin": "SQLiteStudio.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
This PR makes SQLiteStudio keep its config locally, as stated in [its wiki](https://github.com/pawelsalawa/sqlitestudio/wiki/Configuration_directory_location#portable-configuration), and persists the settings folder.