### PR TITLE
gpu-z@2.37.0: Fix URL

### DIFF
--- a/bucket/gpu-z.json
+++ b/bucket/gpu-z.json
@@ -3,7 +3,7 @@
     "description": "Lightweight system utility designed to provide vital information about your video card and graphics processor.",
     "homepage": "https://www.techpowerup.com/gpuz/",
     "license": "Freeware",
-    "url": "http://nl1-dl.techpowerup.com/files/GPU-Z.2.37.0.exe#/GPU-Z.exe",
+    "url": "http://us2-dl.techpowerup.com/files/GPU-Z.2.37.0.exe#/GPU-Z.exe",
     "hash": "md5:d9f45181b6df70ef02205eff6d1a9132",
     "bin": "GPU-Z.exe",
     "shortcuts": [
@@ -17,7 +17,7 @@
         "regex": "TechPowerUp GPU-Z v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "http://nl1-dl.techpowerup.com/files/GPU-Z.$version.exe#/GPU-Z.exe",
+        "url": "http://us2-dl.techpowerup.com/files/GPU-Z.$version.exe#/GPU-Z.exe",
         "hash": {
             "url": "https://www.techpowerup.com/download/techpowerup-gpu-z/",
             "regex": "(?sm)$basename.*?$md5"


### PR DESCRIPTION
- Closes #5741
- Closes #5743
- Closes #5744 
- Closes #5745 
- Closes #5746
- Closes #5751

`nl1` doesn't work anymore (for some reason), but `us2` works.
