### PR TITLE
calibre: bump to 5.12.0

### DIFF
--- a/bucket/calibre-normal.json
+++ b/bucket/calibre-normal.json
@@ -1,17 +1,17 @@
 {
-    "version": "5.11.0",
+    "version": "5.12.0",
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-64bit-5.11.0.msi",
-            "hash": "86b8838ccd0ce08f9297349e67f5fd5f51176ed6e7d5e48d34879fb5ea7b7743",
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.12.0/calibre-64bit-5.12.0.msi",
+            "hash": "841777fe9762d0fbc960b6613bfa1fff368b23110141ca3310a365bd736cd47a",
             "extract_dir": "PFiles\\Calibre2"
         },
         "32bit": {
-            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-5.11.0.msi",
-            "hash": "344c8910bfb07ce87b9e13c4fae4e638a9fb28c81930b9f8ab9dba8d1df1dd81",
+            "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.12.0/calibre-5.12.0.msi",
+            "hash": "a23cd78ab7381648f1734c37d19de3b173e0bc35522b841f7dacf038ca5f5315",
             "extract_dir": "PFiles\\Calibre"
         }
     },

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -1,10 +1,10 @@
 {
-    "version": "5.11.0",
+    "version": "5.12.0",
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-portable-installer-5.11.0.exe",
-    "hash": "c6c18ed1720fa2f71638539228c9422c25040c9d4ff371463ca59226b62b6f46",
+    "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-portable-installer-5.12.0.exe",
+    "hash": "79184f4f42b805f1cacc370cf8314664074fcce6bdc05083c222d4ff6ebc1388",
     "installer": {
         "args": "\"$dir\""
     },

--- a/bucket/calibre.json
+++ b/bucket/calibre.json
@@ -3,7 +3,7 @@
     "description": "Powerful and easy to use e-book manager",
     "homepage": "https://calibre-ebook.com",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.11.0/calibre-portable-installer-5.12.0.exe",
+    "url": "https://github.com/kovidgoyal/calibre/releases/download/v5.12.0/calibre-portable-installer-5.12.0.exe",
     "hash": "79184f4f42b805f1cacc370cf8314664074fcce6bdc05083c222d4ff6ebc1388",
     "installer": {
         "args": "\"$dir\""


### PR DESCRIPTION
bump to 5.12.0, since 5.11.0 doesn't have download links anymore