### PR TITLE
librewolf: Add version 86.0-2

### DIFF
--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -3,8 +3,12 @@
     "description": "A fork of Firefox, focused on privacy, security and freedom.",
     "homepage": "https://librewolf-community.gitlab.io/",
     "license": "MPL-2.0",
-    "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/b6b3189fc1c0042ff0503e8b2546b00d/librewolf-86.0.en-US.win64.zip",
-    "hash": "EA14B2138553E6FB1DA3C0C1D81972924F7584214A9695D0DC50B70901805B0C",
+    "architecture": {
+        "64bit": {
+        "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/b6b3189fc1c0042ff0503e8b2546b00d/librewolf-86.0.en-US.win64.zip",
+        "hash": "EA14B2138553E6FB1DA3C0C1D81972924F7584214A9695D0DC50B70901805B0C"
+        }
+    },
     "extract_dir": "librewolf",
     "bin": "librewolf.exe",
     "shortcuts": [

--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -1,0 +1,16 @@
+{
+    "version": "86.0-2",
+    "description": "A fork of Firefox, focused on privacy, security and freedom.",
+    "homepage": "https://librewolf-community.gitlab.io/",
+    "license": "MPL-2.0",
+    "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/b6b3189fc1c0042ff0503e8b2546b00d/librewolf-86.0.en-US.win64.zip",
+    "hash": "EA14B2138553E6FB1DA3C0C1D81972924F7584214A9695D0DC50B70901805B0C",
+    "extract_dir": "librewolf",
+    "bin": "librewolf.exe",
+    "shortcuts": [
+        [
+            "librewolf.exe",
+            "LibreWolf"
+        ]
+    ]
+}

--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -5,8 +5,8 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-        "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/b6b3189fc1c0042ff0503e8b2546b00d/librewolf-86.0.en-US.win64.zip",
-        "hash": "EA14B2138553E6FB1DA3C0C1D81972924F7584214A9695D0DC50B70901805B0C"
+            "url": "https://gitlab.com/librewolf-community/browser/windows/uploads/b6b3189fc1c0042ff0503e8b2546b00d/librewolf-86.0.en-US.win64.zip",
+            "hash": "ea14b2138553e6fb1da3c0c1d81972924f7584214a9695d0dc50b70901805b0c"
         }
     },
     "extract_dir": "librewolf",

--- a/bucket/librewolf.json
+++ b/bucket/librewolf.json
@@ -16,5 +16,10 @@
             "librewolf.exe",
             "LibreWolf"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://gitlab.com/api/v4/projects/13852981/repository/tags",
+        "jsonpath": "$[0].name",
+        "regex": "v([\\w.-]+)"
+    }
 }


### PR DESCRIPTION
- Closes #6333

In a similar fashion from Chromium to Ungoogled-chromium, [LibreWolf ](https://librewolf-community.gitlab.io/)is a browser with the goals of privacy and with no telemetry included from Mozilla.

P.S: This is my first scoop, happy to contribute to the project!