### PR TITLE
vieb: Add version 4.0.0

### DIFF
--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -1,7 +1,7 @@
 {
     "version": "4.1.0",
     "description": "Vim Inspired Electron Browser",
-    "homepage": "https://vieb.dev/",
+    "homepage": "https://vieb.dev",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {

--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -1,6 +1,6 @@
 {
     "version": "4.0.0",
-    "description": "Vieb is the Vim Inspired Electron Browser",
+    "description": "Vim Inspired Electron Browser",
     "homepage": "https://vieb.dev/",
     "license": "GPL-3.0-only",
     "url": "https://github.com/Jelmerro/Vieb/releases/download/4.0.0/Vieb.4.0.0.exe",
@@ -15,7 +15,6 @@
         "github": "https://github.com/Jelmerro/Vieb"
     },
     "autoupdate": {
-        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb.$version.exe",
-        "extract_dir": "vieb-$version-x64"
+        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb.$version.exe"
     }
 }

--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -1,13 +1,13 @@
 {
-    "version": "4.0.0",
-    "description": "Vim Inspired Electron Browser",
+    "version": "4.1.0",
+    "description": "Vieb is the Vim Inspired Electron Browser",
     "homepage": "https://vieb.dev/",
-    "license": "GPL-3.0-only",
-    "url": "https://github.com/Jelmerro/Vieb/releases/download/4.0.0/Vieb.4.0.0.exe",
-    "hash": "d5f46c3fb5a8a379866f4a97cd2ad5622fc6430465623e291aefb0dd1f8e6e4a",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/Jelmerro/Vieb/releases/download/4.1.0/Vieb-4.1.0-win.zip",
+    "bin": "Vieb.exe",
     "shortcuts": [
         [
-            "Vieb.4.0.0.exe",
+            "Vieb.exe",
             "Vieb"
         ]
     ],
@@ -15,6 +15,6 @@
         "github": "https://github.com/Jelmerro/Vieb"
     },
     "autoupdate": {
-        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb.$version.exe"
+        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb-$version-win.zip"
     }
 }

--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -1,0 +1,21 @@
+{
+    "version": "4.0.0",
+    "description": "Vieb is the Vim Inspired Electron Browser",
+    "homepage": "https://vieb.dev/",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/Jelmerro/Vieb/releases/download/4.0.0/Vieb.4.0.0.exe",
+    "hash": "d5f46c3fb5a8a379866f4a97cd2ad5622fc6430465623e291aefb0dd1f8e6e4a",
+    "shortcuts": [
+        [
+            "Vieb.4.0.0.exe",
+            "Vieb"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Jelmerro/Vieb"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb.$version.exe",
+        "extract_dir": "vieb-$version-x64"
+    }
+}

--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -1,10 +1,14 @@
 {
     "version": "4.1.0",
-    "description": "Vieb is the Vim Inspired Electron Browser",
+    "description": "Vim Inspired Electron Browser",
     "homepage": "https://vieb.dev/",
     "license": "GPL-3.0-or-later",
-    "hash": "1c958e4cba47248213f4b9ede909ea6f57cf24967e953fceb489b5342b1f6f88",
-    "url": "https://github.com/Jelmerro/Vieb/releases/download/4.1.0/Vieb-4.1.0-win.zip",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Jelmerro/Vieb/releases/download/4.1.0/Vieb-4.1.0-win.zip",
+            "hash": "1c958e4cba47248213f4b9ede909ea6f57cf24967e953fceb489b5342b1f6f88"
+        }
+    },
     "bin": "Vieb.exe",
     "shortcuts": [
         [
@@ -16,6 +20,10 @@
         "github": "https://github.com/Jelmerro/Vieb"
     },
     "autoupdate": {
-        "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb-$version-win.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Jelmerro/Vieb/releases/download/$version/Vieb-$version-win.zip"
+            }
+        }
     }
 }

--- a/bucket/vieb.json
+++ b/bucket/vieb.json
@@ -3,6 +3,7 @@
     "description": "Vieb is the Vim Inspired Electron Browser",
     "homepage": "https://vieb.dev/",
     "license": "GPL-3.0-or-later",
+    "hash": "1c958e4cba47248213f4b9ede909ea6f57cf24967e953fceb489b5342b1f6f88",
     "url": "https://github.com/Jelmerro/Vieb/releases/download/4.1.0/Vieb-4.1.0-win.zip",
     "bin": "Vieb.exe",
     "shortcuts": [


### PR DESCRIPTION
I'd like to add very promising browser [Vieb](https://vieb.dev/). I use that day to day and would be great to have Scoop packages for it. 

I have tested installation and update process with my own test bucket under https://github.com/run2cmd/scoop-test-bucket