### PR TITLE
aws-nosql-workbench: Add version 2.2.0

### DIFF
--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -8,8 +8,8 @@
             "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-2.2.0.exe#/dl.7z",
             "hash": "sha512:4003a51ac32e64c9afd06ea6699ace5ff71af40f65ca0d047414bf8891992c13e5b125d29ab48cc209b7aaddedc52bbead0c49e5270129c0de2929e8d1c93c98",
             "pre_install": [
-                "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
-                "Remove-Item -Path \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse"
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Recurse"
             ]
         }
     },

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -29,11 +29,11 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe#/dl.7z",
-                "hash": {
-                    "url": "$url.sha512"
-                }
+                "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe#/dl.7z"
             }
+        },
+        "hash": {
+            "url": "$url.sha512"
         }
     }
 }

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -16,7 +16,6 @@
             ]
         }
     },
-    "bin": "NoSQL Workbench.exe",
     "shortcuts": [
         [
             "NoSQL Workbench.exe",

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -1,8 +1,11 @@
 {
-    "homepage": "https://aws.amazon.com/dynamodb/nosql-workbench/",
-    "description": "NoSQL database designer for Amazon DynamoDB and Amazon Keyspaces",
     "version": "2.2.0",
-    "license": "Proprietary",
+    "description": "NoSQL database designer for Amazon DynamoDB and Amazon Keyspaces",
+    "homepage": "https://aws.amazon.com/dynamodb/nosql-workbench/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://aws.amazon.com/nosql/nosql-workbench-license/"
+    },
     "architecture": {
         "64bit": {
             "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-2.2.0.exe#/dl.7z",

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -29,7 +29,7 @@
             "64bit": {
                 "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe#/dl.7z",
                 "hash": {
-                    "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe.sha512"
+                    "url": "$url.sha512"
                 }
             }
         }

--- a/bucket/aws-nosql-workbench.json
+++ b/bucket/aws-nosql-workbench.json
@@ -1,0 +1,37 @@
+{
+    "homepage": "https://aws.amazon.com/dynamodb/nosql-workbench/",
+    "description": "NoSQL database designer for Amazon DynamoDB and Amazon Keyspaces",
+    "version": "2.2.0",
+    "license": "Proprietary",
+    "architecture": {
+        "64bit": {
+            "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-2.2.0.exe#/dl.7z",
+            "hash": "sha512:4003a51ac32e64c9afd06ea6699ace5ff71af40f65ca0d047414bf8891992c13e5b125d29ab48cc209b7aaddedc52bbead0c49e5270129c0de2929e8d1c93c98",
+            "pre_install": [
+                "Expand-7zipArchive -Path \"$dir\\`$PLUGINSDIR\\app-64.7z\" -DestinationPath \"$dir\"",
+                "Remove-Item -Path \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Recurse"
+            ]
+        }
+    },
+    "bin": "NoSQL Workbench.exe",
+    "shortcuts": [
+        [
+            "NoSQL Workbench.exe",
+            "NoSQL Workbench"
+        ]
+    ],
+    "checkver": {
+        "url": "https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html",
+        "regex": "NoSQL Workbench-win-([\\d.]+)\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe#/dl.7z",
+                "hash": {
+                    "url": "https://s3.amazonaws.com/nosql-workbench/NoSQL%20Workbench-win-$version.exe.sha512"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a manifest for AWS's NoSQL Workbench application.

NoSQL Workbench is a 64-bit Electron-based desktop app (similar to [draw.io Desktop](https://github.com/lukesampson/scoop-extras/blob/master/bucket/draw.io.json)) that aids in designing and modeling NoSQL databases for the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html) and [Amazon Keyspaces](https://docs.aws.amazon.com/keyspaces/latest/devguide/workbench.html) cloud database services.

The manifest has support for version detection, auto-update, and hash file parsing.