### PR TITLE
rtss: Update to version 7.3.1

### DIFF
--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -1,6 +1,6 @@
 {
     "##": "Renaming the downloaded zip to 'sourceforge.net.zip' is a hack for the referer header. See dl()-function in \\lib\\install.ps1",
-    "version": "7.2.3",
+    "version": "7.3.1",
     "description": "Framerate monitoring, On-Screen Display and high-performance video capture service provider for other graphics card utilities.",
     "homepage": "https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html",
     "license": "Freeware",
@@ -8,8 +8,8 @@
         "Visual C++ Redist 2008": "extras/vcredist2008",
         "MSI Afterburner": "extras/msiafterburner"
     },
-    "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup723Build20686.zip#/sourceforge.net.zip",
-    "hash": "f29e2d2b68b4c54d2172739a35e666979287a5966058af7b585e808a6e8b77d3",
+    "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup731Build24485.zip#/sourceforge.net.zip",
+    "hash": "d3d8fb9309723e22ebed67094cdfda63188db4a38426213177507e69e340ee70",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\RTSSSetup*.exe\" -Removal",
         "Remove-Item \"$dir\\`$*\", \"$dir\\Guru3D.com\", \"$dir\\Uninstall*\" -Recurse",
@@ -31,7 +31,10 @@
             "RivaTuner Statistics Server"
         ]
     ],
-    "persist": "Profiles",
+    "persist": [
+        "Profiles",
+        "Plugins\\Client\\Overlays"
+    ],
     "autoupdate": {
         "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup$cleanVersionBuild$matchBuild.zip#/sourceforge.net.zip"
     }

--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -32,8 +32,8 @@
         ]
     ],
     "persist": [
-        "Profiles",
-        "Plugins\\Client\\Overlays"
+        "Plugins\\Client\\Overlays",
+        "Profiles"
     ],
     "autoupdate": {
         "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup$cleanVersionBuild$matchBuild.zip#/sourceforge.net.zip"

--- a/bucket/rtss.json
+++ b/bucket/rtss.json
@@ -35,7 +35,8 @@
         "Plugins\\Client\\Overlays",
         "Profiles"
     ],
-    "autoupdate": {
-        "url": "https://download-eu2.guru3d.com/rtss/%5BGuru3D.com%5D-RTSSSetup$cleanVersionBuild$matchBuild.zip#/sourceforge.net.zip"
+    "checkver": {
+        "url": "https://rtss.guru3d.com/Update.txt",
+        "regex": "ProductVersion\\s+=\\s*([\\d.]+)"
     }
 }


### PR DESCRIPTION
There is an OverlayEditor plugin in version 7.3.0 which saves overlays to `Plugins\Client\Overlays\` (even if you choose another directory). I've added it to persist.
Checkver was disabled in commit https://github.com/lukesampson/scoop-extras/commit/d1fa5192c3268bd9e3d130413de0521d0a532a0c. I didn't touch it.