### PR TITLE
openclosedriveeject@2.12: hash fix

### DIFF
--- a/bucket/openclosedriveeject.json
+++ b/bucket/openclosedriveeject.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.softwareok.com/Download/OpenCloseDriveEject_x64.zip",
-            "hash": "ec16debb30c5d87c53496328d733ea61be9585d2a7a5774f9726f4085e78fcd3",
+            "hash": "1e336e880e9b0e335858e3e9b3875e90e1b997da658fe551ebfd9f63b5903e0f",
             "bin": [
                 [
                     "OpenCloseDriveEject_x64_p.exe",
@@ -25,7 +25,7 @@
         },
         "32bit": {
             "url": "https://www.softwareok.com/Download/OpenCloseDriveEject.zip",
-            "hash": "4341d4d35fab5f4e93e3eeba32b813471c2603e68df5bbf26e2ade05425f5fe0",
+            "hash": "0ce97b78eb7ef1ae470d9da5299fe2dfc1f05c322d0b0bedcbd7c95773b0dbb2",
             "bin": "OpenCloseDriveEject.exe",
             "shortcuts": [
                 [


### PR DESCRIPTION
Updated latest hash from https://www.softwareok.com/?Download=OpenCloseDriveEject.

ERROR:
Checking hash of OpenCloseDriveEject_x64.zip ... ERROR Hash check failed!
App:         extras/openclosedriveeject
URL:         https://www.softwareok.com/Download/OpenCloseDriveEject_x64.zip
First bytes: 50 4B 03 04 14 00 00 00
Expected:    ec16debb30c5d87c53496328d733ea61be9585d2a7a5774f9726f4085e78fcd3
Actual:      1e336e880e9b0e335858e3e9b3875e90e1b997da658fe551ebfd9f63b5903e0f

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=openclosedriveeject%402.12%3a+hash+check+failed