### PR TITLE
quicktextpaste@7.01: hash fix

### DIFF
--- a/bucket/quicktextpaste.json
+++ b/bucket/quicktextpaste.json
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://www.softwareok.com/Download/QuickTextPaste_x64_Portable.zip",
-            "hash": "c73e5b827ea64253caf190f1d558f1d65268e5ae4938db3e76c84a5b479e357b",
+            "hash": "c79d6043307cb7fb6903195c70feb473de3751147501d865bb49bb1f5826c966",
             "bin": [
                 [
                     "QuickTextPaste_x64_p.exe",
@@ -25,7 +25,7 @@
         },
         "32bit": {
             "url": "https://www.softwareok.com/Download/QuickTextPaste_Portable.zip",
-            "hash": "2371c3f6cb49ee397c555502a21c360265dc0a169948ed2836141e98ee86ff9d",
+            "hash": "5d3d70831c1e19e9e8ffba438cab85e7111acf51b1b2e047f8fe0b1d56de2aac",
             "bin": [
                 [
                     "QuickTextPaste_p.exe",


### PR DESCRIPTION
Updated latest hash from https://www.softwareok.com/?Download=QuickTextPaste

ERROR:
Checking hash of QuickTextPaste_x64_Portable.zip ... ERROR Hash check failed!
App:         extras/quicktextpaste
URL:         https://www.softwareok.com/Download/QuickTextPaste_x64_Portable.zip
First bytes: 50 4B 03 04 14 00 00 00
Expected:    c73e5b827ea64253caf190f1d558f1d65268e5ae4938db3e76c84a5b479e357b
Actual:      c79d6043307cb7fb6903195c70feb473de3751147501d865bb49bb1f5826c966

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/lukesampson/scoop-extras/issues/new?title=quicktextpaste%407.01%3a+hash+check+failed