### PR TITLE
wpsoffice: Modify checkver.url

### DIFF
--- a/bucket/wpsoffice.json
+++ b/bucket/wpsoffice.json
@@ -1,13 +1,13 @@
 {
-    "version": "11.2.0.9396",
+    "version": "11.2.0.10017",
     "description": "Complete office suite.",
     "homepage": "https://www.wps.com",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.wps.com/eula"
     },
-    "url": "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/11.2.0.9396/WPSOffice_11.2.0.9396.exe",
-    "hash": "7e31c48c737fed8eee2d9cdece7c3a1f8d5ec8d2dcadce807464ec11bd6db5fb",
+    "url": "https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/11.2.0.10017/WPSOffice_11.2.0.10017.exe",
+    "hash": "f8786a89d97de1edaaf7c1ea84a0d77ae26a7212c38292993e9d4220d37111c1",
     "pre_install": [
         "Expand-7zipArchive \"$dir\\$fname\" -Switches '-t#'",
         "Remove-Item \"$dir\\*\" -Exclude '4.7z' -Recurse",
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://pc.wps.com",
+        "url": "https://params.wps.com/api/map/staticjs/pc_wps_com/download_info.js?outfmt_flat=true",
         "regex": "WPSOffice_([\\d.]+)\\.exe"
     },
     "autoupdate": {


### PR DESCRIPTION
To fetch the newest version. 

As the version on the page `https://pc.wps.com` has lagged behind a lot, a newer solution is needed.