### PR TITLE
amazon-workspaces: Add version 3.1.6.2064

### DIFF
--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -17,7 +17,7 @@
     ],
     "checkver": {
         "url": "https://docs.aws.amazon.com/workspaces/latest/userguide/amazon-workspaces-windows-client.html",
-        "regex": "\\<td\\>(\\d+\\.\\d+\\.\\d+)\\</td\\>"
+        "regex": "td>([\\d.]+)</"
     },
     "autoupdate": {
         "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -12,7 +12,6 @@
     "pre_install": [
         "# Disable the autoupdate of amazon-workspaces client",
         "$configFile = \"$dir\\workspaces.dll.config\"",
-        "Copy-Item $configFile \"${configFile}Ahoj\"",
         "if (Test-Path -LiteralPath $configFile) {",
         "   [xml]$xml = Get-Content -LiteralPath $configFile",
         "   $key = $xml.SelectSingleNode(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -9,6 +9,16 @@
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
     "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
     "extract_dir": "[ApplicationFolderName]",
+    "pre_install": [
+        "#disable the autoupdate of amazon-workspaces client.",
+        "$configFile = \"$dir\\workspaces.dll.config\"",
+        "If (Test-Path -Path $configFile) {",
+        "   [xml]$xml = Get-Content -path $configFile",
+        "   $key = $xml.SelectNodes(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
+        "   $key[0].Value = ''",
+        "   $xml.Save($configFile)",
+        "}"
+    ],
     "shortcuts": [
         [
             "workspaces.exe",
@@ -21,15 +31,5 @@
     },
     "autoupdate": {
         "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
-    },
-    "post_install": [
-        "#disable the autoupdate of amazon-workspaces client.",
-        "$configFile = \"$dir\\workspaces.dll.config\"",
-        "If (Test-Path -Path $configFile) {",
-        "   [xml]$xml = Get-Content -path $configFile",
-        "   $key = $xml.SelectNodes(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
-        "   $key[0].Value = ''",
-        "   $xml.Save($configFile)",
-        "}"
-    ]
+    }
 }

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -1,10 +1,13 @@
 {
-    "homepage": "https://clients.amazonworkspaces.com/",
-    "description": "Amazon workspaces client.",
-    "license": "Proprietary",
     "version": "3.1.4",
-    "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
+    "description": "Client for Amazon workspaces service",
+    "homepage": "https://clients.amazonworkspaces.com",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://clients.amazonworkspaces.com/app-terms.html"
+    },
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
+    "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
     "extract_dir": "[ApplicationFolderName]",
     "bin": "workspaces.exe",
     "shortcuts": [

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://clients.amazonworkspaces.com/",
+    "description": "Amazon workspaces client.",
+    "license": "Proprietary",
+    "version": "3.1.4",
+    "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
+    "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
+    "extract_dir": "[ApplicationFolderName]",
+    "bin": "workspaces.exe",
+    "shortcuts": [
+        [
+            "workspaces.exe",
+            "Amazon Workspaces"
+        ]
+    ],
+    "checkver": {
+        "url": "https://docs.aws.amazon.com/workspaces/latest/userguide/amazon-workspaces-windows-client.html",
+        "regex": "\\<td\\>(\\d+\\.\\d+\\.\\d+)\\</td\\>"
+    },
+    "autoupdate": {
+        "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
+    }
+}

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -14,8 +14,8 @@
         "$configFile = \"$dir\\workspaces.dll.config\"",
         "If (Test-Path -Path $configFile) {",
         "   [xml]$xml = Get-Content -path $configFile",
-        "   $key = $xml.SelectNodes(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
-        "   $key[0].Value = ''",
+        "   $key = $xml.SelectSingleNode(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
+        "   $key.Value = ''",
         "   $xml.Save($configFile)",
         "}"
     ],

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -9,7 +9,6 @@
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
     "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
     "extract_dir": "[ApplicationFolderName]",
-    "bin": "workspaces.exe",
     "shortcuts": [
         [
             "workspaces.exe",

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.4",
+    "version": "3.1.6.2064",
     "description": "Client for Amazon workspaces service",
     "homepage": "https://clients.amazonworkspaces.com",
     "license": {
@@ -7,13 +7,14 @@
         "url": "https://clients.amazonworkspaces.com/app-terms.html"
     },
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
-    "hash": "604e40ed03883e1d740367fbcc4da9c21fc88fe26f9df7aca4ed0a25c0b1ac2e",
+    "hash": "163fa99b95bf986a101743650c313e5afb895bbd019d12a0c5610c1032511b47",
     "extract_dir": "[ApplicationFolderName]",
     "pre_install": [
-        "#disable the autoupdate of amazon-workspaces client.",
+        "# Disable the autoupdate of amazon-workspaces client",
         "$configFile = \"$dir\\workspaces.dll.config\"",
-        "If (Test-Path -Path $configFile) {",
-        "   [xml]$xml = Get-Content -path $configFile",
+        "Copy-Item $configFile \"${configFile}Ahoj\"",
+        "if (Test-Path -LiteralPath $configFile) {",
+        "   [xml]$xml = Get-Content -LiteralPath $configFile",
         "   $key = $xml.SelectSingleNode(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
         "   $key.Value = ''",
         "   $xml.Save($configFile)",

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -17,18 +17,18 @@
     ],
     "checkver": {
         "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/dub/windows/WorkSpacesAppCast.xml",
-        "regex": "title>Version ([\\d\\.]+)</"
+        "regex": "title>Version ([\\d.]+)</"
     },
     "autoupdate": {
         "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
     },
     "post_install": [
         "#disable the autoupdate of amazon-workspaces client.",
-        "$configFile = \"$dir\\workspaces.dll.config\" ",
-        "If (Test-Path -Path $configFile -ErrorAction SilentlyContinue) { ",
-        "   [xml]$xml = Get-Content -path $configFile ",
-        "   $key = $xml.SelectNodes('//configuration/appSettings/*') | Where-Object {$_.key -eq 'UpdateUrl'}",
-        "   $key.Value = ''",
+        "$configFile = \"$dir\\workspaces.dll.config\"",
+        "If (Test-Path -Path $configFile) {",
+        "   [xml]$xml = Get-Content -path $configFile",
+        "   $key = $xml.SelectNodes(\"(//configuration/appSettings/add[@key='UpdateUrl'])[1]\")",
+        "   $key[0].Value = ''",
         "   $xml.Save($configFile)",
         "}"
     ]

--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -16,10 +16,20 @@
         ]
     ],
     "checkver": {
-        "url": "https://docs.aws.amazon.com/workspaces/latest/userguide/amazon-workspaces-windows-client.html",
-        "regex": "td>([\\d.]+)</"
+        "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/dub/windows/WorkSpacesAppCast.xml",
+        "regex": "title>Version ([\\d\\.]+)</"
     },
     "autoupdate": {
         "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi"
-    }
+    },
+    "post_install": [
+        "#disable the autoupdate of amazon-workspaces client.",
+        "$configFile = \"$dir\\workspaces.dll.config\" ",
+        "If (Test-Path -Path $configFile -ErrorAction SilentlyContinue) { ",
+        "   [xml]$xml = Get-Content -path $configFile ",
+        "   $key = $xml.SelectNodes('//configuration/appSettings/*') | Where-Object {$_.key -eq 'UpdateUrl'}",
+        "   $key.Value = ''",
+        "   $xml.Save($configFile)",
+        "}"
+    ]
 }


### PR DESCRIPTION
This manifest installs amazon workspaces client.

Amazon unfortunately does not publish the full historic list of clients. so I scan for the version number change and then we just install the latest version downloaded from the same url. 