### PR TITLE
Brave:  Update to Version 1.22.70

### DIFF
--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-x64.zip",
-            "hash": "4a5c84079d760296188da835b0ae3a35e301dd6ff53304d98e52669048e0a9e7"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.70/brave-v1.22.70-win32-x64.zip",
+            "hash": "6578b988363365d82074f6c519725c7d15ceb0fc70fdf0c95052ca43d9479f4e"
         },
         "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-ia32.zip",
-            "hash": "4475f3354653cbd773714589895706bf9a22caba8d0081cc90f85530d8a0dfcd"
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.70/brave-v1.22.70-win32-ia32.zip",
+            "hash": "23d1cd841bb9ba5ef72eec0d9658f4eadc22be8e93612e6c9479a059735a99d2"
         }
     },
     "extract_to": "brave",

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -9,11 +9,11 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-x64.zip",
-            "hash": "d9e7dd4f7597b6cec73dd49a23c52f4da87a8c25ccf837b8c3a8c7a70895606f"
+            "hash": "4a5c84079d760296188da835b0ae3a35e301dd6ff53304d98e52669048e0a9e7"
         },
         "32bit": {
             "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-ia32.zip",
-            "hash": "683a5f4e1295cb26acbff648864939e529243e1f6df4451a857aa8c2ed4794fe"
+            "hash": "4475f3354653cbd773714589895706bf9a22caba8d0081cc90f85530d8a0dfcd"
         }
     },
     "extract_to": "brave",

--- a/bucket/brave.json
+++ b/bucket/brave.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.96",
+    "version": "1.22.67",
     "description": "Secure, Fast & Private Web Browser with Adblocker",
     "homepage": "https://brave.com",
     "license": {
@@ -8,15 +8,15 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-x64.exe#/dl.7z",
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-x64.zip",
             "hash": "d9e7dd4f7597b6cec73dd49a23c52f4da87a8c25ccf837b8c3a8c7a70895606f"
         },
         "32bit": {
-            "url": "https://github.com/brave/brave-browser/releases/download/v1.4.96/brave_installer-ia32.exe#/dl.7z",
+            "url": "https://github.com/brave/brave-browser/releases/download/v1.22.67/brave-v1.22.67-win32-ia32.zip",
             "hash": "683a5f4e1295cb26acbff648864939e529243e1f6df4451a857aa8c2ed4794fe"
         }
     },
-    "pre_install": "Expand-7zipArchive \"$dir\\chrome.7z\" -ExtractDir 'Chrome-bin' -Removal",
+    "extract_to": "brave",
     "bin": "brave.exe",
     "shortcuts": [
         [
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-x64.exe#/dl.7z"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-x64.zip"
             },
             "32bit": {
-                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave_installer-ia32.exe#/dl.7z"
+                "url": "https://github.com/brave/brave-browser/releases/download/v$version/brave-v$version-win32-ia32.zip"
             }
         }
     }


### PR DESCRIPTION
This is my first pull request ever so I might have messed something up.  Brave's release version is now 1.22.70 so I tried to update it.