### PR TITLE
go-jsonnet: Add version 0.17.0

### DIFF
--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/google/go-jsonnet",
     "license": "Apache License 2.0",
     "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
-    "hash": "0a310754f7589c5f3aabdcbbbc902b1e521ef987abb2dc1cd8c6ce49494e265f",
+    "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03",
     "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64",
     "bin": [
         "jsonnet.exe",

--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -5,7 +5,7 @@
     "license": "Apache License 2.0",
     "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
     "hash": "0a310754f7589c5f3aabdcbbbc902b1e521ef987abb2dc1cd8c6ce49494e265f",
-    "extract_dir": "go-jsonnet",
+    "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64",
     "bin": [
         "jsonnet.exe",
         "jsonnetfmt.exe"

--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -6,8 +6,7 @@
     "architecture" : {
         "64bit": {
             "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
-            "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03",
-            "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64"
+            "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03"
         }
     },
     "bin": [

--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -17,8 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz",
-                "extract_dir": "go-jsonnet_$version_Windows_x86_64"
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz"
             }
         },
         "hash": {

--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.17.0",
+    "description": "A data templating language for app and tool developers",
+    "homepage": "https://github.com/google/go-jsonnet",
+    "license": "Apache License 2.0",
+    "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
+    "hash": "0a310754f7589c5f3aabdcbbbc902b1e521ef987abb2dc1cd8c6ce49494e265f",
+    "extract_dir": "go-jsonnet",
+    "bin": [
+        "jsonnet.exe",
+        "jsonnetfmt.exe"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz"
+    }
+}

--- a/bucket/go-jsonnet.json
+++ b/bucket/go-jsonnet.json
@@ -2,16 +2,28 @@
     "version": "0.17.0",
     "description": "A data templating language for app and tool developers",
     "homepage": "https://github.com/google/go-jsonnet",
-    "license": "Apache License 2.0",
-    "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
-    "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03",
-    "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64",
+    "license": "Apache-2.0",
+    "architecture" : {
+        "64bit": {
+            "url": "https://github.com/google/go-jsonnet/releases/download/v0.17.0/go-jsonnet_0.17.0_Windows_x86_64.tar.gz",
+            "hash": "d4d56a4e81752b53b301d92066678d036571224383da268896149c087e5a3c03",
+            "extract_dir": "go-jsonnet_0.17.0_Windows_x86_64"
+        }
+    },
     "bin": [
         "jsonnet.exe",
         "jsonnetfmt.exe"
     ],
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/google/go-jsonnet/releases/download/v$version/go-jsonnet_$version_Windows_x86_64.tar.gz",
+                "extract_dir": "go-jsonnet_$version_Windows_x86_64"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
     }
 }


### PR DESCRIPTION
This is a new package for go-jsonnet (https://github.com/google/go-jsonnet). It's a Go implementation of Jsonnet (https://jsonnet.org/) utility , owned by Google. It should not be confused by Json.Net (NewtonSoft.Json) library, it's a different project altogether.

I am not affiliated with Jsonnet project (or Google) in anyway, merely providing Scoop packaging.

The original C++ version is not released on Scoop either - I am packaging the Go version because it consists of self contained .exe files, and seems to be the recommended implementation.