### PR TITLE
netch@1.8.3: Fix installation

### DIFF
--- a/bucket/netch.json
+++ b/bucket/netch.json
@@ -9,6 +9,7 @@
             "hash": "6e8aa23ed0accad33b11431a5844438938af703a167e6cfc7343d8a8b59ed7f8"
         }
     },
+    "extract_dir": "Netch",
     "pre_install": [
         "ensure \"$dir\\data\" | Out-Null",
         "if (!(Test-Path \"$persist_dir\\data\\settings.json\")) { Set-Content \"$dir\\data\\settings.json\" '{ \"CheckUpdateWhenOpened\": false, \"Server\": [] }' -Encoding Ascii -Force }"

--- a/bucket/netch.json
+++ b/bucket/netch.json
@@ -3,6 +3,9 @@
     "description": "Game accelerator",
     "homepage": "https://github.com/NetchX/Netch",
     "license": "MIT",
+    "suggest": {
+        "dotnet-runtime": "windowsdesktop-runtime"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/NetchX/Netch/releases/download/1.8.3/Netch.7z",


### PR DESCRIPTION
- Closes #6016

In the netch v1.8.3 released archive, the top-level directory exists again.