### PR TITLE
flameshot: Add version 0.9.0

### DIFF
--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -2,7 +2,7 @@
     "version": "0.9.0",
     "description": "Powerful yet simple to use screenshot software",
     "homepage": "https://flameshot.org/",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
             "url": "https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/flameshot_portable-0.9.0-win64.zip",

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.9.0",
+    "description": "Powerful yet simple to use screenshot software.",
+    "homepage": "https://flameshot.org/",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/flameshot_portable-0.9.0-win64.zip",
+            "hash": "4e1844c6198f39a1dfbceefc3eb8f373a6d63f7d4dfd97e9a058549744b79ff5",
+            "extract_dir": "flameshot-0.9.0-win64"
+        }
+    },
+    "bin": "bin/flameshot.exe",
+    "shortcuts": [
+        [
+            "bin/flameshot.exe",
+            "Flameshot"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/flameshot-org/flameshot"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/flameshot-org/flameshot/releases/download/v$version/flameshot_portable-$version-win64.zip",
+                "extract_dir": "flameshot-$version-win64"
+            }
+        }
+    }
+}

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -1,6 +1,6 @@
 {
     "version": "0.9.0",
-    "description": "Powerful yet simple to use screenshot software.",
+    "description": "Powerful yet simple to use screenshot software",
     "homepage": "https://flameshot.org/",
     "license": "GPL-3.0-or-later",
     "architecture": {

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -2,7 +2,7 @@
     "version": "0.9.0",
     "description": "Powerful yet simple to use screenshot software.",
     "homepage": "https://flameshot.org/",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/flameshot_portable-0.9.0-win64.zip",

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -13,6 +13,7 @@
             "extract_dir": "flameshot-0.9.0-win64"
         }
     },
+    "pre_install": "Remove-Item \"$dir\\vc_redist*.exe\"",
     "bin": "bin\\flameshot.exe",
     "shortcuts": [
         [

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -10,10 +10,10 @@
             "extract_dir": "flameshot-0.9.0-win64"
         }
     },
-    "bin": "bin/flameshot.exe",
+    "bin": "bin\\flameshot.exe",
     "shortcuts": [
         [
-            "bin/flameshot.exe",
+            "bin\\flameshot.exe",
             "Flameshot"
         ]
     ],

--- a/bucket/flameshot.json
+++ b/bucket/flameshot.json
@@ -3,6 +3,9 @@
     "description": "Powerful yet simple to use screenshot software",
     "homepage": "https://flameshot.org/",
     "license": "GPL-3.0-only",
+    "suggest": {
+        "vcredist2019": "vcredist2019"
+    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/flameshot-org/flameshot/releases/download/v0.9.0/flameshot_portable-0.9.0-win64.zip",


### PR DESCRIPTION
* Closes #5631

The portable archive name only has the format`flameshot_portable-$version-win64.zip` since `0.9.0`.
It had the format `flameshot-$version-win64.zip` in older versions, so it is uncertain that the format will remain the same in the future.

