### PR TITLE
universal-gcode-sender: Add version 2.0.7

### DIFF
--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -2,7 +2,7 @@
     "version": "2.0.7",
     "description": "Full featured gcode platform used for interfacing with advanced CNC controllers.",
     "homepage": "https://winder.github.io/ugs_website/",
-    "license": "GPL-3",
+    "license": "GPL-3.0",
     "url": "https://ugs.jfrog.io/ugs/UGS/v2.0.7/ugs-platform-app-win.zip",
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
     "architecture": {

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -7,10 +7,10 @@
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
     "architecture": {
         "32bit": {
-            "bin": "bin/ugsplatform.exe",
+            "bin": "bin\\ugsplatform.exe",
             "shortcuts": [
                 [
-                    "bin/ugsplatform.exe",
+                    "bin\\ugsplatform.exe",
                     "UGS Platform"
                 ]
             ]
@@ -18,13 +18,13 @@
         "64bit": {
             "bin": [
                 [
-                    "bin/ugsplatform64.exe",
+                    "bin\\ugsplatform64.exe",
                     "ugsplatform"
                 ]
             ],
             "shortcuts": [
                 [
-                    "bin/ugsplatform64.exe",
+                    "bin\\ugsplatform64.exe",
                     "UGS Platform"
                 ]
             ]

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -7,15 +7,6 @@
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
     "extract_dir": "ugsplatform-win",
     "architecture": {
-        "32bit": {
-            "bin": "bin\\ugsplatform.exe",
-            "shortcuts": [
-                [
-                    "bin\\ugsplatform.exe",
-                    "UGS Platform"
-                ]
-            ]
-        },
         "64bit": {
             "bin": [
                 [
@@ -26,6 +17,15 @@
             "shortcuts": [
                 [
                     "bin\\ugsplatform64.exe",
+                    "UGS Platform"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "bin\\ugsplatform.exe",
+            "shortcuts": [
+                [
+                    "bin\\ugsplatform.exe",
                     "UGS Platform"
                 ]
             ]

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -2,7 +2,7 @@
     "version": "2.0.7",
     "description": "Full featured gcode platform used for interfacing with advanced CNC controllers.",
     "homepage": "https://winder.github.io/ugs_website/",
-    "license": "GPL-3.0-or-later",
+    "license": "GPL-3.0-only",
     "url": "https://ugs.jfrog.io/ugs/UGS/v2.0.7/ugs-platform-app-win.zip",
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
     "extract_dir": "ugsplatform-win",

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -35,6 +35,9 @@
         "github": "https://github.com/winder/Universal-G-Code-Sender"
     },
     "autoupdate": {
-        "url": "https://ugs.jfrog.io/ugs/UGS/v$version/ugs-platform-app-win.zip"
+        "url": "https://ugs.jfrog.io/ugs/UGS/v$version/ugs-platform-app-win.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
     }
 }

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -5,6 +5,7 @@
     "license": "GPL-3.0",
     "url": "https://ugs.jfrog.io/ugs/UGS/v2.0.7/ugs-platform-app-win.zip",
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
+    "extract_dir": "ugsplatform-win",
     "architecture": {
         "32bit": {
             "bin": "bin\\ugsplatform.exe",
@@ -30,7 +31,6 @@
             ]
         }
     },
-    "extract_dir": "ugsplatform-win",
     "checkver": {
         "github": "https://github.com/winder/Universal-G-Code-Sender"
     },

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0.7",
+    "description": "Full featured gcode platform used for interfacing with advanced CNC controllers.",
+    "homepage": "https://winder.github.io/ugs_website/",
+    "license": "GPL-3",
+    "url": "https://ugs.jfrog.io/ugs/UGS/v2.0.7/ugs-platform-app-win.zip",
+    "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
+    "architecture": {
+        "32bit": {
+            "bin": "bin/ugsplatform.exe",
+            "shortcuts": [
+                [
+                    "bin/ugsplatform.exe",
+                    "UGS Platform"
+                ]
+            ]
+        },
+        "64bit": {
+            "bin": [
+                [
+                    "bin/ugsplatform64.exe",
+                    "ugsplatform"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "bin/ugsplatform64.exe",
+                    "UGS Platform"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "ugsplatform-win",
+    "checkver": {
+        "github": "https://github.com/winder/Universal-G-Code-Sender"
+    },
+    "autoupdate": {
+        "url": "https://ugs.jfrog.io/ugs/UGS/v$version/ugs-platform-app-win.zip"
+    }
+}

--- a/bucket/universal-gcode-sender.json
+++ b/bucket/universal-gcode-sender.json
@@ -2,7 +2,7 @@
     "version": "2.0.7",
     "description": "Full featured gcode platform used for interfacing with advanced CNC controllers.",
     "homepage": "https://winder.github.io/ugs_website/",
-    "license": "GPL-3.0",
+    "license": "GPL-3.0-or-later",
     "url": "https://ugs.jfrog.io/ugs/UGS/v2.0.7/ugs-platform-app-win.zip",
     "hash": "23b0726c0b4b9d29a1a2adaab53f1a16cd4c45c16413bfa67c1900843f46399f",
     "extract_dir": "ugsplatform-win",


### PR DESCRIPTION
* Closes #5849

The archive contains both 32 and 64bit executables and I originally just created shortcuts for both and left both shims available
but I decided to make only the detected architecture available.
Not sure if it is okay or ugly stuff, so let me know if I should just stick to the former option.
