### PR TITLE
nimbletext@3.1.0.33266: Adopt HTTPS urls

### DIFF
--- a/bucket/nimbletext.json
+++ b/bucket/nimbletext.json
@@ -1,9 +1,9 @@
 {
-    "version": "3.1.0.17465",
+    "version": "3.1.0.33266",
     "description": "Text manipulation and code generation tool.",
     "homepage": "https://nimbletext.com/",
     "license": "Unknown",
-    "url": "http://nimbletext.com/Download/NimbleText.exe",
+    "url": "https://nimbletext.com/Download/NimbleText.exe",
     "hash": "710ee5e8b449aca2b54c45c426f3e8316da31a78463cae373b40f92a161380f6",
     "bin": "NimbleText.exe",
     "shortcuts": [
@@ -11,12 +11,5 @@
             "NimbleText.exe",
             "NimbleText"
         ]
-    ],
-    "checkver": {
-        "url": "http://nimbletext.com/Version/Notes",
-        "regex": "Version ([\\d.]+)"
-    },
-    "autoupdate": {
-        "url": "http://nimbletext.com/Download/NimbleText.exe"
-    }
+    ]
 }

--- a/bucket/nimbletext.json
+++ b/bucket/nimbletext.json
@@ -1,7 +1,7 @@
 {
     "version": "3.1.0.33266",
-    "description": "Text manipulation and code generation tool.",
-    "homepage": "https://nimbletext.com/",
+    "description": "Text manipulation and code generation tool",
+    "homepage": "https://nimbletext.com",
     "license": "Unknown",
     "url": "https://nimbletext.com/Download/NimbleText.exe",
     "hash": "710ee5e8b449aca2b54c45c426f3e8316da31a78463cae373b40f92a161380f6",

--- a/bucket/nimbletext.json
+++ b/bucket/nimbletext.json
@@ -18,6 +18,6 @@
         "reverse": true
     },
     "autoupdate": {
-        "url": "http://nimbletext.com/Download/NimbleText.exe"
+        "url": "https://nimbletext.com/Download/NimbleText.exe"
     }
 }

--- a/bucket/nimbletext.json
+++ b/bucket/nimbletext.json
@@ -11,5 +11,13 @@
             "NimbleText.exe",
             "NimbleText"
         ]
-    ]
+    ],
+    "checkver": {
+        "url": "https://nimbletext.com/Version",
+        "regex": "([\\d.]+),\\d+",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "http://nimbletext.com/Download/NimbleText.exe"
+    }
 }


### PR DESCRIPTION
This app currently fails to install. The manifest is broken in a few ways:

- Download URL no longer supports http. Must use https.
- Current downloadable version is 3.1.0.33266, not 3.1.0.17465 because....
- The version notes page used for checkver/autoupdate is broken (for quite a while), so useless.

This PR fixes the above issues.