### PR TITLE
gdu: Add version 5.5.0

### DIFF
--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -23,9 +23,6 @@
             "64bit": {
                 "url": "https://github.com/dundee/gdu/releases/download/v$version/gdu_windows_amd64.exe.zip"
             }
-        },
-        "hash": {
-            "mode": "download"
         }
     }
 }

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.10.1",
+    "version": "4.11.0",
     "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dundee/gdu/releases/download/v4.10.1/gdu_windows_amd64.exe.zip",
-            "hash": "235289e39cc2574c277520a9aef09cbba9474d8847114f61706f1b252b80c770",
+            "url": "https://github.com/dundee/gdu/releases/download/v4.11.0/gdu_windows_amd64.exe.zip",
+            "hash": "764179e2876fb47c36614e20a41f24bcb3ca6b7d76c4558c91d2cc0fe1ae3ee0",
             "bin": [
                 [
                     "gdu_windows_amd64.exe",
@@ -21,6 +21,9 @@
             "64bit": {
                 "url": "https://github.com/dundee/gdu/releases/download/v$version/gdu_windows_amd64.exe.zip"
             }
+        },
+        "hash": {
+            "url": "https://github.com/dundee/gdu/releases/download/v$version/sha256sums.txt"
         }
     }
 }

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -23,7 +23,7 @@
             }
         },
         "hash": {
-            "url": "https://github.com/dundee/gdu/releases/download/v$version/sha256sums.txt"
+            "url": "$baseurl/sha256sums.txt"
         }
     }
 }

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -15,9 +15,16 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/dundee/gdu/releases/download/v4.10.1/gdu_windows_amd64.exe.zip",
-            "hash": "235289e39cc2574c277520a9aef09cbba9474d8847114f61706f1b252b80c770"
+            "hash": "235289e39cc2574c277520a9aef09cbba9474d8847114f61706f1b252b80c770",
+            "bin": [
+                [
+                    "gdu_windows_amd64.exe",
+                    "gdu"
+                ]
+            ]
         }
     },
+    "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.11.0",
+    "version": "4.11.1",
     "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dundee/gdu/releases/download/v4.11.0/gdu_windows_amd64.exe.zip",
-            "hash": "764179e2876fb47c36614e20a41f24bcb3ca6b7d76c4558c91d2cc0fe1ae3ee0",
+            "url": "https://github.com/dundee/gdu/releases/download/v4.11.1/gdu_windows_amd64.exe.zip",
+            "hash": "5dd7e3179c359905b4dba7b0e052bd6aaecd28b0ee843aa7c8ef76bd5bbd1ec7",
             "bin": [
                 [
                     "gdu_windows_amd64.exe",

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,6 +1,6 @@
 {
     "version": "4.10.1",
-    "description": "Disk usage analyzer with console interface written in Go",
+    "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
     "bin": [

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,0 +1,31 @@
+{
+    "version": "4.10.1",
+    "description": "Disk usage analyzer with console interface written in Go",
+    "homepage": "https://github.com/dundee/gdu",
+    "license": "MIT",
+    "bin": [
+		[
+			"gdu_windows_amd64.exe",
+			"gdu"
+		]
+	],
+	"checkver": {
+        "github": "https://github.com/dundee/gdu"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dundee/gdu/releases/download/v4.10.1/gdu_windows_amd64.exe.zip",
+            "hash": "235289e39cc2574c277520a9aef09cbba9474d8847114f61706f1b252b80c770"
+        }
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dundee/gdu/releases/download/v$version/gdu_windows_amd64.exe.zip"
+            }
+        },
+        "hash": {
+            "mode": "download"
+        }
+    }
+}

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -3,15 +3,6 @@
     "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
-    "bin": [
-		[
-			"gdu_windows_amd64.exe",
-			"gdu"
-		]
-	],
-	"checkver": {
-        "github": "https://github.com/dundee/gdu"
-    },
     "architecture": {
         "64bit": {
             "url": "https://github.com/dundee/gdu/releases/download/v4.10.1/gdu_windows_amd64.exe.zip",

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,12 +1,12 @@
 {
-    "version": "5.5.0",
+    "version": "5.8.1",
     "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dundee/gdu/releases/download/v5.5.0/gdu_windows_amd64.exe.zip",
-            "hash": "6f1ef82b13ab92beb4a9d9f32644f724be9b1e7c527182840fa70be191e9b1cd",
+            "url": "https://github.com/dundee/gdu/releases/download/v5.8.1/gdu_windows_amd64.exe.zip",
+            "hash": "33c2e09a2016bfa90c621c11597c684d5a14a65d7eec5c9f275e825c7a9000bf",
             "bin": [
                 [
                     "gdu_windows_amd64.exe",

--- a/bucket/gdu.json
+++ b/bucket/gdu.json
@@ -1,12 +1,12 @@
 {
-    "version": "4.11.1",
+    "version": "5.5.0",
     "description": "Disk usage analyzer with console interface",
     "homepage": "https://github.com/dundee/gdu",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dundee/gdu/releases/download/v4.11.1/gdu_windows_amd64.exe.zip",
-            "hash": "5dd7e3179c359905b4dba7b0e052bd6aaecd28b0ee843aa7c8ef76bd5bbd1ec7",
+            "url": "https://github.com/dundee/gdu/releases/download/v5.5.0/gdu_windows_amd64.exe.zip",
+            "hash": "6f1ef82b13ab92beb4a9d9f32644f724be9b1e7c527182840fa70be191e9b1cd",
             "bin": [
                 [
                     "gdu_windows_amd64.exe",
@@ -23,7 +23,7 @@
             }
         },
         "hash": {
-            "url": "$baseurl/sha256sums.txt"
+            "url": "https://github.com/dundee/gdu/releases/download/v$version/sha256sums.txt"
         }
     }
 }


### PR DESCRIPTION
[gdu](https://github.com/dundee/gdu) is a disk usage analyzer with console interface written in Go.

This of it as a visual `du` or console based [`windirstat`](https://windirstat.net/) ([already in scoop](https://github.com/lukesampson/scoop-extras/blob/master/bucket/windirstat.json))

Regarding [the criteria for inclussion in the main bucket](https://github.com/lukesampson/scoop/wiki/Criteria-for-including-apps-in-the-main-bucket):

- I do not think this is a reasonably well-know and/or widely used developer tool. The project is relatively new.
- the manifest points to the latest version and includes autoupdate
- it is the full version (open source project)
- install is fairly standard (unzip)
- it is not a GUI tool

Hence, because the first criteria is not met, this is proposed for inclusion in extras.

marc