### PR TITLE
Add Manifold Release 9 official build + optional third-party libraries

### DIFF
--- a/bucket/manifold-9-official-plus.json
+++ b/bucket/manifold-9-official-plus.json
@@ -1,0 +1,20 @@
+{
+    "version": "9.0.174",
+    "description": "Official build of Manifold Release 9 + optional third-party software",
+    "homepage": "http://manifold.net/",
+    "license": "Unknown",
+    "depends": "extras/vcredist2017" ,
+    "url": "http://www.manifoldgis.com/updates/manifold-9.0.174-x64-fat.zip",
+    "extract_dir": "manifold-9.0.174-x64",
+    "hash": "sha256:1d97957cef87fc99dafb8f9da47d55955e92d8dc342ba9115576ef0a182c5c9c",
+    "shortcuts": [
+        [
+            "bin64\\manifold.exe",
+            "Manifold 9"
+        ],
+        [
+            "bin\\manifold.exe",
+            "Manifold 9 (32-bit)"
+        ]
+    ]
+}


### PR DESCRIPTION
Manifold Release 9 is powerful parallel GIS, ETL, data science and DBMS tool. 
This package includes third-party libraries that provides IronPython scripting and MySQL, PostgreSQL/PostGIS, and SQLite drivers. It also includes 233 MB grids.dat for coordinate transformations.
Manifold official builds are issued about every 4-6 months. Cutting Edge builds are issued monthly or semimonthly.