### PR TITLE
quicklook: Persist UserData folder

### DIFF
--- a/bucket/quicklook.json
+++ b/bucket/quicklook.json
@@ -11,6 +11,7 @@
             "QuickLook"
         ]
     ],
+    "persist": "UserData",
     "checkver": {
         "github": "https://github.com/QL-Win/QuickLook"
     },


### PR DESCRIPTION
The portable version of QuickLook now (actually, already with 3.6.10) stores user data in the `UserData` folder. Hence, it should be persisted.

Source: https://github.com/QL-Win/QuickLook/wiki/Differences-Between-Distributions