### PR TITLE
amazon-workspaces: remove hash

### DIFF
--- a/bucket/amazon-workspaces.json
+++ b/bucket/amazon-workspaces.json
@@ -7,7 +7,6 @@
         "url": "https://clients.amazonworkspaces.com/app-terms.html"
     },
     "url": "https://d2td7dqidlhjx7.cloudfront.net/prod/global/windows/Amazon+WorkSpaces.msi",
-    "hash": "163fa99b95bf986a101743650c313e5afb895bbd019d12a0c5610c1032511b47",
     "extract_dir": "[ApplicationFolderName]",
     "pre_install": [
         "# Disable the autoupdate of amazon-workspaces client",


### PR DESCRIPTION
Amazon doesn't publish a hash so it doesn't make sense to keep it
in the file.