### PR TITLE
chatterino: Update to version 2.3.1

### DIFF
--- a/bucket/chatterino.json
+++ b/bucket/chatterino.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "Twitch chat client",
     "homepage": "https://chatterino.com",
     "license": "MIT",
@@ -9,8 +9,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/2.3.0/Chatterino%20Portable.zip",
-            "hash": "7567efdf0f5e62779eaba9a7b34f05613a00eedb98725d84069bde738ec39cc4"
+            "url": "https://chatterino.fra1.digitaloceanspaces.com/bin/2.3.1/Chatterino%20Portable.zip",
+            "hash": "1caf49133dd169b9f57307a10c52d3ec47859a13dcec7f776b6c2c7a2518cb82"
         }
     },
     "extract_dir": "chatterino2",
@@ -28,10 +28,7 @@
         "Misc",
         "ProfileAvatars"
     ],
-    "checkver": {
-        "url": "https://chatterino.com/download/",
-        "regex": "/([\\d.]+)/Chatterino%20Portable"
-    },
+    "checkver": "/([\\d.]+)/Chatterino%20Portable",
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
The website had a redesign, <https://chatterino.com/download/> is now a page that only shows old versions, while the latest version is now visible on <https://chatterino.com/>