### PR TITLE
sublime-text: Update to version 4-4107

### DIFF
--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -56,7 +56,7 @@
     "persist": "Data",
     "checkver": {
         "url": "https://www.sublimetext.com/updates/4/stable_update_check",
-        "jsonpath": ".latest_version"
+        "jsonpath": "$.latest_version"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -1,7 +1,7 @@
 {
-    "version": "4-4107",
+    "version": "4107",
     "description": "A sophisticated text editor for code, markup and prose",
-    "homepage": "https://www.sublimetext.com/download",
+    "homepage": "https://www.sublimetext.com",
     "license": {
         "identifier": "Shareware",
         "url": "https://www.sublimetext.com/eula"
@@ -55,16 +55,16 @@
     ],
     "persist": "Data",
     "checkver": {
-        "regex": "(?i)>([\\d.]+)\\s+\\(BUILD\\s+(\\d+)",
-        "replace": "$1-$2"
+        "url": "https://www.sublimetext.com/updates/4/stable_update_check",
+        "jsonpath": ".latest_version"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion_x64.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$version_x64.zip"
             },
             "32bit": {
-                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$version.zip"
             }
         }
     }

--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -1,5 +1,5 @@
 {
-    "version": "4107",
+    "version": "4-4107",
     "description": "A sophisticated text editor for code, markup and prose",
     "homepage": "https://www.sublimetext.com",
     "license": {
@@ -56,15 +56,17 @@
     "persist": "Data",
     "checkver": {
         "url": "https://www.sublimetext.com/updates/4/stable_update_check",
-        "jsonpath": "$.latest_version"
+        "jsonpath": "$.latest_version",
+        "regex": "((\\d)\\d+)",
+        "replace": "$2-$1"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.sublimetext.com/sublime_text_build_$version_x64.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion_x64.zip"
             },
             "32bit": {
-                "url": "https://download.sublimetext.com/sublime_text_build_$version.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion.zip"
             }
         }
     }

--- a/bucket/sublime-text.json
+++ b/bucket/sublime-text.json
@@ -1,7 +1,7 @@
 {
-    "version": "3.2.2-3211",
+    "version": "4-4107",
     "description": "A sophisticated text editor for code, markup and prose",
-    "homepage": "https://www.sublimetext.com/3",
+    "homepage": "https://www.sublimetext.com/download",
     "license": {
         "identifier": "Shareware",
         "url": "https://www.sublimetext.com/eula"
@@ -10,24 +10,24 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://download.sublimetext.com/Sublime%20Text%20Build%203211%20x64.zip",
+                "https://download.sublimetext.com/sublime_text_build_4107_x64.zip",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sublime-text/install-context.reg",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sublime-text/uninstall-context.reg"
             ],
             "hash": [
-                "fb77731fa3eda907620a9e8b85bdccc5b5cb4dcf655dcfdc6c7591b78abd0f31",
+                "5cca7325f109cc321b15f74f277e4909b9664d87687b6c5adaa706e14dc90447",
                 "45914fc3b299e90d9e3c5c84a4c3747c942918462e8b18348ec43383b87ed810",
                 "0253faa4f5e35be203aefa838594965e43aa97129e305d1b8ee1811098e0ae85"
             ]
         },
         "32bit": {
             "url": [
-                "https://download.sublimetext.com/Sublime%20Text%20Build%203211.zip",
+                "https://download.sublimetext.com/sublime_text_build_4107.zip",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sublime-text/install-context.reg",
                 "https://raw.githubusercontent.com/lukesampson/scoop-extras/master/scripts/sublime-text/uninstall-context.reg"
             ],
             "hash": [
-                "e169691d88498fdc8dddc72d336680339707d459d12acf665e830f5ed4a4c98d",
+                "382b2a2034a8cb70fb0d0d91fb986799c3fdd3af0f19a9169618b0199a9a153c",
                 "45914fc3b299e90d9e3c5c84a4c3747c942918462e8b18348ec43383b87ed810",
                 "0253faa4f5e35be203aefa838594965e43aa97129e305d1b8ee1811098e0ae85"
             ]
@@ -50,7 +50,7 @@
     "shortcuts": [
         [
             "sublime_text.exe",
-            "Sublime Text 3"
+            "Sublime Text 4"
         ]
     ],
     "persist": "Data",
@@ -61,10 +61,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.sublimetext.com/Sublime%20Text%20Build%20$preReleaseVersion%20x64.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion_x64.zip"
             },
             "32bit": {
-                "url": "https://download.sublimetext.com/Sublime%20Text%20Build%20$preReleaseVersion.zip"
+                "url": "https://download.sublimetext.com/sublime_text_build_$preReleaseVersion.zip"
             }
         }
     }


### PR DESCRIPTION
Few things going on here:

* `https://www.sublimetext.com/4` does not exist, hence why the `homepage` had to be changed
    * It's not clear if they just haven't set this page up yet (v4 was released yesterday) or they will not create it
* `checkver` now grabs the latest version directly from `https://www.sublimetext.com/updates/4/stable_update_check`.
* The newest build 4107 doesn't have a "semver" compliant version
* The archives are now named differently on their fileserver