### PR TITLE
hydrus-network@442: New extract_dir for reverted packaging

### DIFF
--- a/bucket/hydrus-network.json
+++ b/bucket/hydrus-network.json
@@ -9,7 +9,7 @@
             "hash": "068631526d58a774d40c67c2de709b14672af69e9740850ecc615bcfc8942e55"
         }
     },
-    "extract_dir": "windows\\Hydrus Network",
+    "extract_dir": "Hydrus Network",
     "post_install": "if (Test-Path \"$dir\\db.original\\sqlite3.exe\") { Copy-Item \"$dir\\db.original\\sqlite3.exe\" \"$dir\\db\" -Force }",
     "bin": [
         [


### PR DESCRIPTION
New hydrus-network release reverted unintentional change in packaging. (https://github.com/hydrusnetwork/hydrus/releases/tag/v442)
No windows or ubuntu subfolders as before.