### PR TITLE
Update to blender 2.93

### DIFF
--- a/bucket/blender.json
+++ b/bucket/blender.json
@@ -1,13 +1,13 @@
 {
-    "version": "2.92.0",
+    "version": "2.93.0",
     "description": "3D creation suite",
     "homepage": "https://www.blender.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://download.blender.org/release/Blender2.92/blender-2.92.0-windows64.zip",
-            "hash": "5ea980be32819e7cf68ecc53ee117aa1ad7da3cb191c8ff3ff3d776574aa3eb8",
-            "extract_dir": "blender-2.92.0-windows64"
+            "url": "https://download.blender.org/release/Blender2.93/blender-2.93.0-windows-x64.zip",
+            "hash": "39a7cab57289e4f814b23f512a66b9c980a4ce1991fc710908be1d632690795a",
+            "extract_dir": "blender-2.93.0-windows64"
         }
     },
     "bin": "blender.exe",
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.blender.org/release/Blender$majorVersion.$minorVersion/blender-$version-windows64.zip",
+                "url": "https://download.blender.org/release/Blender$majorVersion.$minorVersion/blender-$version-windows-x64.zip",
                 "extract_dir": "blender-$version-windows64"
             }
         },


### PR DESCRIPTION
Hello!
[Blender 2.93] (https://www.blender.org/download/) is out!!
Let's update Scoop.

