### PR TITLE
Update winfetch.ps1 to reflect repository transfer

### DIFF
--- a/bucket/winfetch.json
+++ b/bucket/winfetch.json
@@ -1,16 +1,13 @@
 {
     "version": "2.0.0",
     "description": "A command-line system information utility for Windows",
-    "homepage": "https://github.com/lptstr/winfetch",
+    "homepage": "https://github.com/kiedtl/winfetch",
     "license": "MIT",
-    "suggest": {
-        "imagemagick": "imagemagick"
-    },
-    "url": "https://raw.githubusercontent.com/lptstr/winfetch/v2.0.0/winfetch.ps1",
+    "url": "https://raw.githubusercontent.com/kiedtl/winfetch/v2.0.0/winfetch.ps1",
     "hash": "ef7cadab4cec7e1bfe6cfabef3af36e3f0f8abc1f53dcf5e3b6e06ab4fe94179",
     "bin": "winfetch.ps1",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/lptstr/winfetch/v$version/winfetch.ps1"
+        "url": "https://raw.githubusercontent.com/kiedtl/winfetch/v$version/winfetch.ps1"
     }
 }


### PR DESCRIPTION
The winfetch repository was transferred from the `lptstr` pseudo-organization to my personal account.