### PR TITLE
clash.net: Add version 1.1.2

### DIFF
--- a/bucket/clash.net.json
+++ b/bucket/clash.net.json
@@ -1,0 +1,28 @@
+{
+    "homepage": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/tree/main",
+    "description": "A Clash GUI Proxy For Windows Using WPF Technology",
+    "version": "1.1.2",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/download/v1.1.2/Clash.NET.1.1.2.x64.7z",
+            "hash": "bafa05c0eff04f8eb7160c15e9bafcafdf84caceaa751b0fea5038c1e8625df5"
+        },
+        "32bit": {
+            "url": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/download/v1.1.2/Clash.NET.1.1.2.x86.7z",
+            "hash": "8906bb8ebca63af23b75eaab07d8637b1b02a53c6a8ca15cbdeca06ed9d499d0"
+        }
+    },
+    "extract_dir": "Clash .NET 1.1.2",
+    "bin": "ClashDotNet.exe",
+    "shortcuts": [
+        [
+            "ClashDotNet.exe",
+            "Clash.NET"
+        ]
+    ],
+    "persist": "data",
+    "checkver": {
+        "github": "https://github.com/ClashDotNetFramework/ClashDotNetFramework/releases/latest"
+    }
+}


### PR DESCRIPTION
Clash .NET is Clash GUI Proxy For Windows Based On WPF Technology
**Test Results**
```
scoop install clash.net
Installing '7zip' (19.00) [64bit]
7z1900-x64.msi (1.7 MB) [=====================================================================================] 100%
Checking hash of 7z1900-x64.msi ... ok.
Extracting 7z1900-x64.msi ... done.
Linking ~\scoop\apps\7zip\current => ~\scoop\apps\7zip\19.00
Creating shim for '7z'.
Creating shortcut for 7-Zip (7zFM.exe)
'7zip' (19.00) was installed successfully!
Installing 'clash.net' (1.1.2) [64bit]
Clash.NET.1.1.2.x64.7z (23.5 MB) [============================================================================] 100%
Checking hash of Clash.NET.1.1.2.x64.7z ... ok.
Extracting Clash.NET.1.1.2.x64.7z ... done.
Linking ~\scoop\apps\clash.net\current => ~\scoop\apps\clash.net\1.1.2
Creating shim for 'ClashDotNet'.
Creating shortcut for Clash.NET (ClashDotNet.exe)
Persisting data
'clash.net' (1.1.2) was installed successfully!
```