### PR TITLE
winfetch: Don't suggest imagemagick

### DIFF
--- a/bucket/winfetch.json
+++ b/bucket/winfetch.json
@@ -3,9 +3,6 @@
     "description": "A command-line system information utility for Windows",
     "homepage": "https://github.com/kiedtl/winfetch",
     "license": "MIT",
-    "suggest": {
-        "imagemagick": "imagemagick"
-    },
     "url": "https://raw.githubusercontent.com/kiedtl/winfetch/v2.1.0/winfetch.ps1",
     "hash": "3dfaf59fcf239c87d47e4921da31e520e7769fa5521763e4ce1d38e7c76a73c0",
     "bin": "winfetch.ps1",


### PR DESCRIPTION
Winfetch removed imagemagick as a dependency a few releases ago.