### PR TITLE
wsl-ssh-pageant: Update to version 20201121.2

### DIFF
--- a/bucket/wsl-ssh-pageant.json
+++ b/bucket/wsl-ssh-pageant.json
@@ -1,27 +1,27 @@
 {
-    "version": "20190513.14",
+    "version": "20201121.2",
     "description": "A Pageant -> TCP bridge for use with WSL, allowing for Pageant to be used as an ssh-ageant within the WSL environment.",
     "homepage": "https://github.com/benpye/wsl-ssh-pageant",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20201121.2/wsl-ssh-pageant-amd64.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20201121.2/wsl-ssh-pageant-amd64-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
-                "84b926fd8737cb509bba9ff5c51a01838088dadaa9513addccb5a8ace4a7f7dc",
-                "0bcc64651d420e3b614e591dfba0a741cb8c04d6ec7c90078693a2af37d1b3ef"
+                "d2979bed31d7fe09fbd0186a45ae029e1311eb44cc432cb88d232fd3a4f4c1e0",
+                "8abd3945285cd08a704c9e1112a53b15f8da35d18c51b67385ae05de790af168"
             ]
         },
         "32bit": {
             "url": [
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
-                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20190513.14/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20201121.2/wsl-ssh-pageant-386.exe#/wsl-ssh-pageant.exe",
+                "https://github.com/benpye/wsl-ssh-pageant/releases/download/20201121.2/wsl-ssh-pageant-386-gui.exe#/wsl-ssh-pageant-gui.exe"
             ],
             "hash": [
-                "85d923a911b9604ab457219318264c776969990cf9d49ce60882c83835a8591d",
-                "ba64ecf3c6959ae6a08ee40fe82ef840e8a79b3a4a5eb02d4820db7c5269de58"
+                "92d1aa69f0527b5048009e177bef9f6bd64cf70a2574f4907037d93d7c02060b",
+                "42156c97a60d30dee420efe5b2c353d8ac57ad88a08708abbead73745a7fd1b3"
             ]
         }
     },


### PR DESCRIPTION
- Closes #3885

<https://github.com/benpye/wsl-ssh-pageant/releases/tag/20201121.2>