### PR TITLE
Update AltDrag to updated and maintained fork

### DIFF
--- a/bucket/altdrag.json
+++ b/bucket/altdrag.json
@@ -1,11 +1,10 @@
 {
-    "version": "1.1",
+    "version": "1.44",
     "description": "Easily drag windows when pressing the Alt key",
-    "homepage": "https://stefansundin.github.io/altdrag/",
-    "license": "GPL-3.0-or-later",
-    "url": "https://github.com/stefansundin/altdrag/releases/download/v1.1/AltDrag-1.1.zip",
-    "hash": "5e1cf4fd8bfbdeca672cd53141019471b344317c81fdefe1ae9cb3f96183bdf9",
-    "extract_dir": "AltDrag",
+    "homepage": "https://github.com/RamonUnch/AltDrag",
+    "license": "GPL-3.0",
+    "url": "https://github.com/RamonUnch/altdrag/releases/download/1.44/AltDrag1.44bin.zip",
+    "hash": "0bbcd9bae6f6f3b3e06cb448e52f4344e3151248d0315de8060c7f78eb29f70c",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\AltDrag.ini\")) {",
         "    (Get-Content \"$dir\\AltDrag.ini\") -replace 'CheckOnStartup=1', 'CheckOnStartup=0' | Set-Content \"$dir\\AltDrag.ini\" -Encoding ASCII",
@@ -19,9 +18,9 @@
     ],
     "persist": "AltDrag.ini",
     "checkver": {
-        "github": "https://github.com/stefansundin/altdrag"
+        "github": "https://github.com/RamonUnch/altdrag"
     },
     "autoupdate": {
-        "url": "https://github.com/stefansundin/altdrag/releases/download/v$version/AltDrag-$version.zip"
+        "url": "https://github.com/RamonUnch/altdrag/releases/download/$version/AltDrag$versionbin.zip"
     }
 }


### PR DESCRIPTION
The original AltDrag project by  [Stefan Sundin](https://github.com/stefansundin/altdrag) hasn't been updated in several years. There is a nicely maintained and update fork by [RamonUnch](https://github.com/RamonUnch/AltDrag) that can easily be installed by scoop, just like the old one. 
I suggest updating the `altdrag` manifest to use the updated fork.