### PR TITLE
dbeaver@21.1.1: Fix URL

### DIFF
--- a/bucket/dbeaver.json
+++ b/bucket/dbeaver.json
@@ -12,7 +12,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dbeaver.io/files/21.1.1/dbeaver-ce-21.1.1-win32.win32.x86_64.zip",
+            "url": "https://download.dbeaver.com/community/21.1.1/dbeaver-ce-21.1.1-win32.win32.x86_64.zip",
             "hash": "e2525bd9496b71d10482551e47e4a50d4bb9dabcf32ec87014969fe6e0ce5c9d"
         }
     },
@@ -34,7 +34,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dbeaver.io/files/$version/dbeaver-ce-$version-win32.win32.x86_64.zip"
+                "url": "https://download.dbeaver.com/community/$version/dbeaver-ce-$version-win32.win32.x86_64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
The older download URL targeting at `dbeaver.io/files` seems no longer valid