### PR TITLE
interlink: Add version 52.9.7762

### DIFF
--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -5,7 +5,7 @@
     "license": "MPL-2.0",
     "extract_dir": "interlink",
     "bin": "interlink.exe",
-    "note": "Consider disabling Interlink's updater under Edit > Preferences > Advanced > Update.",
+    "notes": "Consider disabling Interlink's updater under Edit > Preferences > Advanced > Update.",
     "checkver": {
         "url": "https://binaryoutcast.com/projects/interlink/download/",
         "regex": "Version:\\<\\/strong\\> (\\d+\\.\\d+\\.\\d+)"

--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -5,11 +5,11 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
+            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
             "hash": "e97fc368798c5e923ac34e9b106e0ff815a232372a3918fc3986a652d5e77138"
         },
         "32bit": {
-            "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
+            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
             "hash": "03764ce8942058ed6f1ade4226774706a50f935f7cbdcd00195f3a60d555a80b"
         }
     },
@@ -28,10 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z"
+                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z"
             },
             "32bit": {
-                "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z"
+                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z"
             }
         },
         "hash": {

--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -14,7 +14,6 @@
         }
     },
     "extract_dir": "interlink",
-    "bin": "interlink.exe",
     "shortcuts": [
         [
             "interlink.exe",

--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -5,11 +5,11 @@
     "license": "MPL-2.0",
     "architecture": {
         "64bit": {
-            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
+            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.7762.win64.7z",
             "hash": "e97fc368798c5e923ac34e9b106e0ff815a232372a3918fc3986a652d5e77138"
         },
         "32bit": {
-            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
+            "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-52.9.7762.win32.7z",
             "hash": "03764ce8942058ed6f1ade4226774706a50f935f7cbdcd00195f3a60d555a80b"
         }
     },
@@ -27,10 +27,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z"
+                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.win64.7z"
             },
             "32bit": {
-                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z"
+                "url": "http://projects.binaryoutcast.com/interlink/releases/latest/interlink-$version.win32.7z"
             }
         },
         "hash": {

--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -1,0 +1,46 @@
+{
+    "version": "52.9.7762",
+    "description": "A free e-mail client based on open source community code built on the Unified XUL Platform.",
+    "homepage": "https://binaryoutcast.com/projects/interlink/",
+    "license": "MPL-2.0",
+    "extract_dir": "interlink",
+    "bin": "interlink.exe",
+    "note": "Consider disabling Interlink's updater under Edit > Preferences > Advanced > Update.",
+    "checkver": {
+        "url": "https://binaryoutcast.com/projects/interlink/download/",
+        "regex": "Version:\\<\\/strong\\> (\\d+\\.\\d+\\.\\d+)"
+    },
+    "shortcuts": [
+        [
+            "interlink.exe",
+            "Interlink"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
+            "hash": "e97fc368798c5e923ac34e9b106e0ff815a232372a3918fc3986a652d5e77138"
+        },
+        "32bit": {
+            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
+            "hash": "03764ce8942058ed6f1ade4226774706a50f935f7cbdcd00195f3a60d555a80b"
+        }
+    },
+    "autoupdate": {
+        "note": "Thanks for using autoupdate, please test your updates!",
+        "architecture": {
+            "64bit": {
+                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z",
+                "hash": {
+                    "regex": "win64\\.7z.*\\n.*\\n.*\\n.*SHA\\-256:\\<\\/strong\\> (\\S{64})"
+                }
+            },
+            "32bit": {
+                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z",
+                "hash": {
+                    "regex": "win32\\.7z.*\\n.*\\n.*\\n.*SHA\\-256:\\<\\/strong\\> (\\S{64})"
+                }
+            }
+        }
+    }
+}

--- a/bucket/interlink.json
+++ b/bucket/interlink.json
@@ -1,46 +1,42 @@
 {
     "version": "52.9.7762",
-    "description": "A free e-mail client based on open source community code built on the Unified XUL Platform.",
+    "description": "E-mail client",
     "homepage": "https://binaryoutcast.com/projects/interlink/",
     "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
+            "hash": "e97fc368798c5e923ac34e9b106e0ff815a232372a3918fc3986a652d5e77138"
+        },
+        "32bit": {
+            "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
+            "hash": "03764ce8942058ed6f1ade4226774706a50f935f7cbdcd00195f3a60d555a80b"
+        }
+    },
     "extract_dir": "interlink",
     "bin": "interlink.exe",
-    "notes": "Consider disabling Interlink's updater under Edit > Preferences > Advanced > Update.",
-    "checkver": {
-        "url": "https://binaryoutcast.com/projects/interlink/download/",
-        "regex": "Version:\\<\\/strong\\> (\\d+\\.\\d+\\.\\d+)"
-    },
     "shortcuts": [
         [
             "interlink.exe",
             "Interlink"
         ]
     ],
-    "architecture": {
-        "64bit": {
-            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win64.7z",
-            "hash": "e97fc368798c5e923ac34e9b106e0ff815a232372a3918fc3986a652d5e77138"
-        },
-        "32bit": {
-            "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-52.9.7762.win32.7z",
-            "hash": "03764ce8942058ed6f1ade4226774706a50f935f7cbdcd00195f3a60d555a80b"
-        }
+    "checkver": {
+        "url": "https://binaryoutcast.com/projects/interlink/release-notes/",
+        "regex": ">Version\\s+([\\d.]+)\\s+<"
     },
     "autoupdate": {
-        "note": "Thanks for using autoupdate, please test your updates!",
         "architecture": {
             "64bit": {
-                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z",
-                "hash": {
-                    "regex": "win64\\.7z.*\\n.*\\n.*\\n.*SHA\\-256:\\<\\/strong\\> (\\S{64})"
-                }
+                "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win64.7z"
             },
             "32bit": {
-                "url": "http://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z",
-                "hash": {
-                    "regex": "win32\\.7z.*\\n.*\\n.*\\n.*SHA\\-256:\\<\\/strong\\> (\\S{64})"
-                }
+                "url": "https://repository.binaryoutcast.com/projects/interlink/releases/latest/interlink-$version.win32.7z"
             }
+        },
+        "hash": {
+            "url": "https://binaryoutcast.com/projects/interlink/download/",
+            "regex": "(?sm)$basename\".*?SHA-256:</strong>\\s+$sha256"
         }
     }
 }


### PR DESCRIPTION
Interlink is an email client based on the mozilla/xul platform.

By default it stores settings/accounts in appdata so don't see reason for persist.