### PR TITLE
fork: Update to version 1.64.1

### DIFF
--- a/bucket/fork.json
+++ b/bucket/fork.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.63.0",
+    "version": "1.64.1",
     "description": "A fast and friendly git client for Mac and Windows",
     "homepage": "https://git-fork.com/",
     "license": {
         "identifier": "Shareware",
         "url": "https://git-fork.com/license"
     },
-    "url": "https://fork.dev/update/win/Fork-1.63.0-full.nupkg",
-    "hash": "sha1:e1510200a209393e17590d910d0ab2310b175798",
+    "url": "https://fork.dev/update/win/Fork-1.64.1-full.nupkg",
+    "hash": "sha1:3120a26f5beacd82fb9e4d09363c7402516daa53",
     "extract_dir": "lib\\net45",
     "post_install": "Remove-Item \"$dir\\*\" -Include 'Fork_ExecutionStub.exe', 'PortableGit-*.7z', 'lib', '7z.*' -Recurse",
     "bin": "Fork.exe",


### PR DESCRIPTION
The version check fails because the RELEASE file hasn't been updated to reflect the new versions.  This is a valid version because the download URL works, and the [latest installer version](https://git-fork.com/update/win/ForkInstaller.exe) is 1.64.1 when checking the details of the Fork.exe file inside the installer.