### PR TITLE
Fixed hash code - openboard.json

### DIFF
--- a/bucket/openboard.json
+++ b/bucket/openboard.json
@@ -4,7 +4,7 @@
     "homepage": "https://www.openboard.ch/index.en.html",
     "license": "GPL-3.0-only",
     "url": "https://github.com/OpenBoard-org/OpenBoard/releases/download/v1.6.1/OpenBoard_Installer_1.6.1.exe",
-    "hash": "f63db1ba4e2790a35b528c72bd046991a85e49373f0ccd9fd385241755756dad",
+    "hash": "5c067fb33e91097260b1e98321ece75de7f89de0457d829f27d0c5467faf40b0",
     "innosetup": true,
     "shortcuts": [
         [


### PR DESCRIPTION
the hash code is incorrect and makes error while installing. I have changed it to the correct sha256 hash code