### PR TITLE
actionlint: Add version 1.5.3

### DIFF
--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -1,0 +1,13 @@
+{
+    "description": ":octocat: Static checker for GitHub Actions workflow files",
+    "homepage": "https://github.com/rhysd/actionlint",
+    "version": "1.5.2",
+    "license": "MIT",
+    "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_amd64.zip",
+    "hash": "f0b2842f0b3712483951a9607f7e3f06f2e4e0cded0fb3f73f5cb7cc61a6fe46",
+    "bin": "actionlint.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_amd64.zip"
+    }
+}

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -1,13 +1,34 @@
 {
-    "description": ":octocat: Static checker for GitHub Actions workflow files",
+    "description": "Static checker for GitHub Actions workflow files",
     "homepage": "https://github.com/rhysd/actionlint",
     "version": "1.5.2",
     "license": "MIT",
-    "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_amd64.zip",
-    "hash": "f0b2842f0b3712483951a9607f7e3f06f2e4e0cded0fb3f73f5cb7cc61a6fe46",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_amd64.zip",
+            "hash": "f0b2842f0b3712483951a9607f7e3f06f2e4e0cded0fb3f73f5cb7cc61a6fe46"
+        },
+        "32bit": {
+            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_386.zip",
+            "hash": "c3d1e8dad47115f096be3b2cf56ed7aff10ebea987efbfbcbb58e816bbcfa778"
+        }
+    },
     "bin": "actionlint.exe",
     "checkver": "github",
     "autoupdate": {
-        "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_amd64.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_amd64.zip",
+                "hash": {
+                    "url": "$baseurl/actionlint_$version_checksums.txt"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_386.zip",
+                "hash": {
+                    "url": "$baseurl/actionlint_$version_checksums.txt"
+                }
+            }
+        }
     }
 }

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -1,7 +1,7 @@
 {
+    "version": "1.5.2",
     "description": "Static checker for GitHub Actions workflow files",
     "homepage": "https://github.com/rhysd/actionlint",
-    "version": "1.5.2",
     "license": "MIT",
     "architecture": {
         "64bit": {

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -24,10 +24,7 @@
                 }
             },
             "32bit": {
-                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_386.zip",
-                "hash": {
-                    "url": "$baseurl/actionlint_$version_checksums.txt"
-                }
+                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_386.zip"
             }
         },
         "hash": {

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -29,6 +29,9 @@
                     "url": "$baseurl/actionlint_$version_checksums.txt"
                 }
             }
+        },
+        "hash": {
+            "url": "$baseurl/actionlint_$version_checksums.txt"
         }
     }
 }

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.5.2",
+    "version": "1.5.3",
     "description": "Static checker for GitHub Actions workflow files",
     "homepage": "https://github.com/rhysd/actionlint",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_amd64.zip",
-            "hash": "f0b2842f0b3712483951a9607f7e3f06f2e4e0cded0fb3f73f5cb7cc61a6fe46"
+            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_windows_amd64.zip",
+            "hash": "581e017565b6fc445b023085099931cbf3e36288c95e215afd3f70b4b59508eb"
         },
         "32bit": {
-            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.2/actionlint_1.5.2_windows_386.zip",
-            "hash": "c3d1e8dad47115f096be3b2cf56ed7aff10ebea987efbfbcbb58e816bbcfa778"
+            "url": "https://github.com/rhysd/actionlint/releases/download/v1.5.3/actionlint_1.5.3_windows_386.zip",
+            "hash": "3e26b97a370a1bc97330be44aacc3711a6c0eb0e53ecee2122f593fce84e2baf"
         }
     },
     "bin": "actionlint.exe",

--- a/bucket/actionlint.json
+++ b/bucket/actionlint.json
@@ -18,10 +18,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_amd64.zip",
-                "hash": {
-                    "url": "$baseurl/actionlint_$version_checksums.txt"
-                }
+                "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_amd64.zip"
             },
             "32bit": {
                 "url": "https://github.com/rhysd/actionlint/releases/download/v$version/actionlint_$version_windows_386.zip"


### PR DESCRIPTION
:octocat: Static checker for GitHub Actions workflow files.

It is useful for every GitHub Actions users and work well on Windows, too.