### PR TITLE
waifu2x-ncnn-vulkan: Add version 20210521

### DIFF
--- a/bucket/waifu2x-ncnn-vulkan.json
+++ b/bucket/waifu2x-ncnn-vulkan.json
@@ -1,0 +1,29 @@
+{
+    "version": "20210521",
+    "description": "ncnn implementation of waifu2x converter.",
+    "homepage": "https://github.com/nihui/waifu2x-ncnn-vulkan",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/20210521/waifu2x-ncnn-vulkan-20210521-windows.zip",
+            "hash": "9569800cbe9575f5c1c5e13c491fc645ff0d447ead5a853b5f2efb2005b7417b"
+        }
+    },
+    "extract_dir": "waifu2x-ncnn-vulkan-20210521-windows",
+    "bin": "waifu2x-ncnn-vulkan.exe",
+    "shortcuts": [
+        [
+            "waifu2x-ncnn-vulkan.exe",
+            "waifu2x-ncnn-vulkan"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "extract_dir": "waifu2x-ncnn-vulkan-$version-windows",
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/nihui/waifu2x-ncnn-vulkan/releases/download/$version/waifu2x-ncnn-vulkan-$version-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
A Vulkan API based waifu2x, usable via the command-line.