### PR TITLE
vnote: add checkver field

### DIFF
--- a/bucket/vnote.json
+++ b/bucket/vnote.json
@@ -21,6 +21,9 @@
             "VNote"
         ]
     ],
+    "checkver": {
+        "github": "https://github.com/vnotex/vnote"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
https://github.com/lukesampson/scoop-extras/issues/6321

Vnote.json is missing checkver field. 
There is a new version of the vnote (2.10 --> 3.5.1)