### PR TITLE
crystaldiskmark: Adjust shortcut name

### DIFF
--- a/bucket/crystaldiskmark.json
+++ b/bucket/crystaldiskmark.json
@@ -21,7 +21,7 @@
             "shortcuts": [
                 [
                     "DiskMark64.exe",
-                    "DiskMark"
+                    "CrystalDiskMark"
                 ]
             ]
         },
@@ -35,7 +35,7 @@
             "shortcuts": [
                 [
                     "DiskMark32.exe",
-                    "DiskMark"
+                    "CrystalDiskMark"
                 ]
             ]
         }


### PR DESCRIPTION
Update the start menu shortcut name to be consistent with [scoop-extras/crystaldiskinfo](https://github.com/lukesampson/scoop-extras/blob/master/bucket/crystaldiskinfo.json)