### PR TITLE
Create wsl-ssh-agent.json

### DIFF
--- a/bucket/wsl-ssh-agent.json
+++ b/bucket/wsl-ssh-agent.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.5.2",
+    "description": "Helper to interface with Windows ssh-agent.exe service from Windows Subsystem for Linux (WSL)",
+    "homepage": "https://github.com/rupor-github/wsl-ssh-agent",
+    "license": "GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/rupor-github/wsl-ssh-agent/releases/download/v1.5.2/wsl-ssh-agent.zip",
+            "hash": "39e6765a6836484707c26f3372561380b1e619492dc91bf8ebeec37aaee8f3d7",
+            "bin": [
+                [
+                    "wsl-ssh-agent-gui.exe",
+                    "wsl-ssh-agent-gui"
+                ]
+            ]
+        }
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/rupor-github/wsl-ssh-agent/releases/download/v$version/wsl-ssh-agent.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Packaging of `wsl-ssh-agent`. It is probably the most practical way of uniting Windows 10 ssh-agent with WSL.

It is as easy as adding, to `.bashrc`:

```
export SSH_AUTH_SOCK=$HOME/.ssh/agent.sock
ss -a | grep -q $SSH_AUTH_SOCK
if [ $? -ne 0   ]; then
    rm -f $SSH_AUTH_SOCK
    ( setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"/mnt/c/Users/$USER/scoop/apps/wsl-ssh-agent/current/npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork & ) >/dev/null 2>&1
```