### PR TITLE
Add Clash for Windows

### DIFF
--- a/bucket/clash-for-windows
+++ b/bucket/clash-for-windows
@@ -1,0 +1,30 @@
+{
+    "version": "0.17.1",
+    "description": "A Windows GUI based on Clash",
+    "homepage": "https://github.com/Fndroid/clash_for_windows_pkg",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.17.1/Clash.for.Windows-0.17.1-ia32-win.7z",
+            "hash": "36f526159283dced1b42e08e8fa578859f0f7c71e9b4de1ac51ac53952575f3f"
+        },
+        "64bit": {
+            "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.17.1/Clash.for.Windows-0.17.1-win.7z",
+            "hash": "e7cb8bc26824905376515ede9d4559d2d4accdc939345663f6db8632f848a3c2"
+        }
+    },
+    "shortcuts": [["Clash for Windows.exe", "Clash"]],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows-$version-ia32-win.7z"
+            },
+            "64bit": {
+                "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/$version/Clash.for.Windows-$version-win.7z"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sum"
+        }
+    }
+}

--- a/bucket/clash-for-windows
+++ b/bucket/clash-for-windows
@@ -1,7 +1,7 @@
 {
     "version": "0.17.1",
     "description": "A Windows GUI based on Clash",
-    "homepage": "https://github.com/Fndroid/clash_for_windows_pkg",
+    "homepage": "https://docs.cfw.lbyczf.com",
     "architecture": {
         "32bit": {
             "url": "https://github.com/Fndroid/clash_for_windows_pkg/releases/download/0.17.1/Clash.for.Windows-0.17.1-ia32-win.7z",
@@ -13,7 +13,9 @@
         }
     },
     "shortcuts": [["Clash for Windows.exe", "Clash"]],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/Fndroid/clash_for_windows_pkg"
+    },
     "autoupdate": {
         "architecture": {
             "32bit": {


### PR DESCRIPTION
[Clash for Windows](https://github.com/Fndroid/clash_for_windows_pkg) is a WindowsGUI based on [Clash](https://github.com/Dreamacro/clash).