### PR TITLE
handbrake@1.4.1: Fix installation

### DIFF
--- a/bucket/handbrake.json
+++ b/bucket/handbrake.json
@@ -9,7 +9,7 @@
             "hash": "2e58282e1a6966138b11624eef36c778fb2aeb14a1485e35675d599103598d2d"
         }
     },
-    "extract_dir": "HandBrake 1.4.1",
+    "extract_dir": "HandBrake",
     "shortcuts": [
         [
             "HandBrake.exe",


### PR DESCRIPTION
- Closes #6648

Upstream package changed dir name within zip release.