### PR TITLE
nicotine-plus: Add version 3.1.1

### DIFF
--- a/bucket/nicotine-plus.json
+++ b/bucket/nicotine-plus.json
@@ -1,0 +1,51 @@
+{
+    "version": "3.1.1",
+    "description": "Graphical client for the Soulseek file sharing network",
+    "homepage": "https://nicotine-plus.org/",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/nicotine-plus/nicotine-plus/blob/master/COPYING"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/3.1.1/windows-x86_64-package.zip",
+            "hash": "3400d2273840ac2b1a69d9f2c89df15c0f4830c69b0f658a8a67f5071c22a10c"
+        },
+        "32bit": {
+            "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/3.1.1/windows-i686-package.zip",
+            "hash": "cb6c059cc36ce73b23e093929c0846c262b1d3fd62e3d76849567363d2a4064c"
+        }
+    },
+    "extract_dir": "Nicotine+",
+    "bin": [
+        [
+            "Nicotine+.exe",
+            "nicotine+"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "Nicotine+.exe",
+            "Nicotine+"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/nicotine-plus/nicotine-plus"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-x86_64-package.zip",
+                "hash": {
+                    "url": "$baseurl/windows-x86_64-package.zip.sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-i686-package.zip",
+                "hash": {
+                    "url": "$baseurl/windows-i686-package.zip.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/nicotine-plus.json
+++ b/bucket/nicotine-plus.json
@@ -19,8 +19,7 @@
     "extract_dir": "Nicotine+",
     "bin": [
         [
-            "Nicotine+.exe",
-            "Nicotine+"
+            "Nicotine+.exe"
         ]
     ],
     "shortcuts": [
@@ -35,17 +34,14 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-x86_64-package.zip",
-                "hash": {
-                    "url": "$baseurl/windows-x86_64-package.zip.sha256"
-                }
+                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-x86_64-package.zip"
             },
             "32bit": {
-                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-i686-package.zip",
-                "hash": {
-                    "url": "$baseurl/windows-i686-package.zip.sha256"
-                }
+                "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/$version/windows-i686-package.zip"
             }
+        },
+        "hash": {
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/nicotine-plus.json
+++ b/bucket/nicotine-plus.json
@@ -20,7 +20,7 @@
     "bin": [
         [
             "Nicotine+.exe",
-            "nicotine+"
+            "Nicotine+"
         ]
     ],
     "shortcuts": [

--- a/bucket/nicotine-plus.json
+++ b/bucket/nicotine-plus.json
@@ -1,11 +1,8 @@
 {
     "version": "3.1.1",
     "description": "Graphical client for the Soulseek file sharing network",
-    "homepage": "https://nicotine-plus.org/",
-    "license": {
-        "identifier": "GPL-3.0-or-later",
-        "url": "https://github.com/nicotine-plus/nicotine-plus/blob/master/COPYING"
-    },
+    "homepage": "https://nicotine-plus.github.io/nicotine-plus/",
+    "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/nicotine-plus/nicotine-plus/releases/download/3.1.1/windows-x86_64-package.zip",
@@ -17,11 +14,6 @@
         }
     },
     "extract_dir": "Nicotine+",
-    "bin": [
-        [
-            "Nicotine+.exe"
-        ]
-    ],
     "shortcuts": [
         [
             "Nicotine+.exe",


### PR DESCRIPTION
A "graphical client for the Soulseek file sharing network": https://github.com/nicotine-plus/nicotine-plus