### PR TITLE
sysinternals: Fix Autoruns shortcut

### DIFF
--- a/bucket/sysinternals.json
+++ b/bucket/sysinternals.json
@@ -308,8 +308,7 @@
                 ],
                 [
                     "autoruns64.exe",
-                    "SysInternals/Autoruns - View startup programs and processes",
-                    "/accepteula"
+                    "SysInternals/Autoruns - View startup programs and processes"
                 ],
                 [
                     "Bginfo64.exe",
@@ -515,8 +514,7 @@
                 ],
                 [
                     "autoruns.exe",
-                    "SysInternals/Autoruns - View startup programs and processes",
-                    "/accepteula"
+                    "SysInternals/Autoruns - View startup programs and processes"
                 ],
                 [
                     "Bginfo.exe",


### PR DESCRIPTION
to fix error when launch autoruns with shortcut:

![screenshot_20210823184518](https://user-images.githubusercontent.com/4353480/130500937-4512788a-2573-46eb-8340-489031963e96.png)
