### PR TITLE
rpg-cli: Add version 1.0.0

### DIFF
--- a/bucket/rpg-cli.json
+++ b/bucket/rpg-cli.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "description": "A minimalist computer RPG written in Rust.",
+    "homepage": "https://github.com/facundoolano/rpg-cli",
+    "license": "MIT",
+    "url": "https://github.com/facundoolano/rpg-cli/releases/download/1.0.0/rpg-cli-1.0.0-windows.exe",
+    "hash": "28020fa64b0f727cc9b321fe2ddc1858cb91074e2f775b9a916c78705cc12f04",
+    "bin": [
+        [
+            "rpg-cli-1.0.0-windows.exe",
+            "rpg-cli"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/facundoolano/rpg-cli/releases/download/$version/rpg-cli-$version-windows.exe"
+    }
+}


### PR DESCRIPTION
rpg-cli is a minimalist computer RPG written in Rust. Its command-line interface can be used as a cd replacement where you randomly encounter enemies as you change directories.