### PR TITLE
jcpicker: Add version 5.5

### DIFF
--- a/bucket/jcpicker.json
+++ b/bucket/jcpicker.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://annystudio.com/software/colorpicker/",
+    "description": "Free portable offline colour picker and colour editor for web designers and digital artists.",
+    "version": "5.5",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://annystudio.com/jcpicker.exe",
+            "hash": "530047d43a009458d56f326b1e2d53cde19b79fe4c49def0f98ddd8e90190b34"
+        },
+        "32bit": {
+            "url": "https://annystudio.com/jcpicker_32bit.exe#/jcpicker.exe",
+            "hash": "0762c6718020b804a5e7286bdc9a53fc772eb3a5f17e2d1ede2584a964bf8242"
+        }
+    },
+    "bin": "jcpicker.exe",
+    "shortcuts": [
+        [
+            "jcpicker.exe",
+            "Just Color Picker"
+        ]
+    ],
+    "checkver": {
+        "regex": "Latest version:</b> ([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://annystudio.com/jcpicker.exe"
+            },
+            "32bit": {
+                "url": "https://annystudio.com/jcpicker_32bit.exe#/jcpicker.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just Color Picker: a popular color picking tool for designers and web developers

Notably, unlike other pickers, this one can be invoked from the commandline.

Ref: Chocolatey [page](https://community.chocolatey.org/packages/jcpicker) for jcpicker