### PR TITLE
altair@4.0.11: Fix URL

### DIFF
--- a/bucket/altair.json
+++ b/bucket/altair.json
@@ -7,12 +7,10 @@
         "64bit": {
             "url": "https://github.com/altair-graphql/altair/releases/download/v4.0.11/altair_4.0.11_x64_win.exe#/dl.7z",
             "hash": "sha512:95cf040ac6b34dd2b3b06e3ab0bf26dd5ce261bcca25f06e74b2f235364643819c97ef14e345e0af400dfce86c9b197bafe73a6c1526736a916b7f62788acb17",
-            "installer": {
-                "script": [
-                    "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
-                    "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*\" -Force -Recurse"
-                ]
-            }
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Uninstall*\" -Force -Recurse"
+            ]
         }
     },
     "shortcuts": [
@@ -30,7 +28,7 @@
                 "url": "https://github.com/altair-graphql/altair/releases/download/v$version/altair_$version_x64_win.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/latest.yml",
-                    "regex": "sha512: $base64"
+                    "regex": "sha512:\\s+$base64"
                 }
             }
         }

--- a/bucket/altair.json
+++ b/bucket/altair.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/imolorhe/altair/releases/download/v4.0.11/altair_4.0.11_win.exe#/dl.7z",
+            "url": "https://github.com/altair-graphql/altair/releases/download/v4.0.11/altair_4.0.11_x64_win.exe#/dl.7z",
             "hash": "sha512:95cf040ac6b34dd2b3b06e3ab0bf26dd5ce261bcca25f06e74b2f235364643819c97ef14e345e0af400dfce86c9b197bafe73a6c1526736a916b7f62788acb17",
             "installer": {
                 "script": [
@@ -22,12 +22,12 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/imolorhe/altair"
+        "github": "https://github.com/altair-graphql/altair"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/imolorhe/altair/releases/download/v$version/altair_$version_win.exe#/dl.7z",
+                "url": "https://github.com/altair-graphql/altair/releases/download/v$version/altair_$version_x64_win.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/latest.yml",
                     "regex": "sha512: $base64"


### PR DESCRIPTION
- Closes #6882

This PR fixes the download URL for the altair windows executable which was renamed to include `_x64` in version `4.0.10`.

| Version| Filename |
| --- | ----------- |
| `<=4.0.9` | altair_4.0.9_win.exe |
| `>=4.0.10` | altair_4.0.10_x64_win.exe |

In addition, the repository has been moved from https://github.com/imolorhe to https://github.com/altair-graphql.
