### PR TITLE
logseq: Update to version 0.4.1

### DIFF
--- a/bucket/logseq.json
+++ b/bucket/logseq.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "A privacy-first platform for knowledge sharing and management",
     "homepage": "https://logseq.com",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/logseq/logseq/releases/download/0.4.0/logseq-win-x64-0.4.0.exe#/dl.7z",
-            "hash": "ab4b6943a6ef6a72912a5ff7bc83e00b962acb8a22faf259f91c696ed534178c"
+            "url": "https://github.com/logseq/logseq/releases/download/0.4.1/logseq-win-x64-0.4.1.exe#/dl.7z",
+            "hash": "302d343f900df34dfff694bb597f5398716a8336dc8caaa0d1b7ce204385e5d8"
         }
     },
     "pre_install": [


### PR DESCRIPTION
Update version, links, and hash for 0.4.1