### PR TITLE
added 7z in url for sourcetree

### DIFF
--- a/bucket/sourcetree.json
+++ b/bucket/sourcetree.json
@@ -6,7 +6,7 @@
         "identifier": "Proprietary",
         "url": "https://www.atlassian.com/legal/software-license-agreement"
     },
-    "url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTree-3.4.6-full.nupkg",
+    "url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourceTree-3.4.6-full.nupkg#/dl.7z",
     "hash": "sha1:c20b319fb665bb00e0a785c353062b09a6b691fa",
     "extract_dir": "lib\\net45",
     "bin": "SourceTree.exe",


### PR DESCRIPTION
Fixed error - Can't shim 'SourceTree.exe': File doesn't exist.